### PR TITLE
feat(protocols): in-browser recording + three-modality picker + bulk-create banner

### DIFF
--- a/src/app/admin/protocols/[id]/__tests__/ProtocolDetailClient.test.tsx
+++ b/src/app/admin/protocols/[id]/__tests__/ProtocolDetailClient.test.tsx
@@ -117,7 +117,7 @@ describe('ProtocolDetailClient', () => {
       />
     )
 
-    fireEvent.click(screen.getByRole('button', { name: /1 Aufgaben erstellen/i }))
+    fireEvent.click(screen.getByRole('button', { name: /Alle 1 Aufgabe erstellen/i }))
 
     await waitFor(() => {
       expect(global.fetch).toHaveBeenCalledWith(

--- a/src/app/admin/protocols/new/ProtocolFormClient.tsx
+++ b/src/app/admin/protocols/new/ProtocolFormClient.tsx
@@ -1,5 +1,6 @@
 'use client'
 
+import { useState } from 'react'
 import { Loader2, Upload, Mic, FileText, Users, ChevronDown, ChevronUp, Check } from 'lucide-react'
 import { MEETING_TYPE_LABELS, PROTOCOL_VISIBILITY_LABELS } from '@/config/protocols'
 import type { MeetingType, ProtocolVisibility } from '@/config/protocols'
@@ -13,6 +14,8 @@ import { Textarea } from '@/components/ui/textarea'
 import { Select } from '@/components/ui/select'
 import { FormField } from '@/components/ui/form-field'
 import { Button } from '@/components/ui/button'
+
+type InputMode = 'record' | 'upload' | 'paste' | null
 
 interface ProtocolFormClientProps {
   teamMembers: Array<{ id: string; name: string }>
@@ -41,6 +44,14 @@ export default function ProtocolFormClient({ teamMembers }: ProtocolFormClientPr
     handleFileUpload,
     handleSubmit,
   } = useProtocolForm(teamMembers)
+
+  const [mode, setMode] = useState<InputMode>(null)
+
+  const resetInput = () => {
+    setMode(null)
+    setAudioFile(null)
+    handleContentChange('')
+  }
 
   return (
     <div className="max-w-3xl space-y-6">
@@ -169,37 +180,51 @@ export default function ProtocolFormClient({ teamMembers }: ProtocolFormClientPr
         <div className="bg-white rounded-lg border p-6 space-y-4">
           <Heading level={2} className="text-lg font-semibold text-neutral-900">Inhalt</Heading>
           <p className="text-sm text-neutral-600">
-            Transkript, Notizen einfügen oder Audio-Datei hochladen. Die KI strukturiert den Inhalt automatisch.
+            Wie möchtest du den Sitzungsinhalt bereitstellen? Wähle eine der drei Möglichkeiten — die KI strukturiert den Inhalt anschliessend automatisch.
           </p>
 
-          <FormField label="Transkript oder Notizen" htmlFor="content">
-            <Textarea
-              id="content"
-              value={content}
-              onChange={(e) => handleContentChange(e.target.value)}
-              placeholder="Sitzungsnotizen hier einfügen..."
-              rows={10}
-              disabled={!!audioFile}
-              className="font-mono text-sm disabled:!opacity-100 disabled:bg-neutral-100 disabled:text-neutral-500"
-            />
-            <div className="flex items-center justify-between mt-1">
-              <div className="flex items-center gap-2">
-                {contentFormat && (
-                  <span className={`text-xs px-2 py-0.5 rounded-full ${contentFormat === 'json' ? 'bg-primary-100 dark:bg-primary-900/30 text-primary-700 dark:text-primary-300' : 'bg-neutral-100 text-neutral-600'}`}>
-                    {contentFormat === 'json' ? 'JSON erkannt' : 'Freitext'}
-                  </span>
-                )}
-              </div>
-              <span className="text-xs text-neutral-500">{content.length} Zeichen</span>
+          {/* Mode picker — visible while no mode chosen */}
+          {mode === null && (
+            <div className="grid grid-cols-1 sm:grid-cols-3 gap-3">
+              <ModeTile
+                icon={Mic}
+                title="Aufnehmen"
+                description="Sitzung direkt im Browser aufnehmen — Mikrofon erforderlich."
+                onClick={() => setMode('record')}
+              />
+              <ModeTile
+                icon={Upload}
+                title="Hochladen"
+                description="Audioaufnahme oder Textdatei (.txt, .json, .mp3, .wav, .m4a)."
+                onClick={() => setMode('upload')}
+              />
+              <ModeTile
+                icon={FileText}
+                title="Einfügen"
+                description="Transkript oder Notizen aus der Zwischenablage einfügen."
+                onClick={() => setMode('paste')}
+              />
             </div>
-          </FormField>
+          )}
 
-          {/* File Upload */}
-          <div className="border-t pt-4 space-y-4">
-            <div>
-              <label className="block text-sm font-medium text-neutral-700 mb-2">
-                Oder Datei hochladen
-              </label>
+          {/* Record mode */}
+          {mode === 'record' && !audioFile && (
+            <div className="space-y-3">
+              <AudioRecorderInline
+                onRecorded={(file) => setAudioFile(file)}
+                disabled={loading || processing}
+              />
+              <SwitchModeLink onClick={resetInput} />
+            </div>
+          )}
+
+          {/* Upload mode */}
+          {mode === 'upload' && !audioFile && !content.trim() && (
+            <div className="rounded-lg border border-neutral-200 p-4 space-y-3 dark:border-white/[0.08]">
+              <div className="flex items-center gap-2 text-sm font-medium text-neutral-800 dark:text-neutral-200">
+                <Upload className="w-4 h-4" aria-hidden />
+                Datei hochladen
+              </div>
               <div className="flex items-center gap-3">
                 <label className="flex items-center gap-2 px-4 py-2 bg-neutral-100 text-neutral-700 rounded-lg hover:bg-neutral-200 cursor-pointer transition-colors text-sm">
                   <Upload className="w-4 h-4" />
@@ -213,50 +238,72 @@ export default function ProtocolFormClient({ teamMembers }: ProtocolFormClientPr
                 </label>
                 <span className="text-xs text-neutral-500">.txt, .json, .mp3, .wav, .m4a, .webm</span>
               </div>
+              <SwitchModeLink onClick={resetInput} />
             </div>
+          )}
 
-            {!audioFile && !content.trim() && (
-              <AudioRecorderInline
-                onRecorded={(file) => setAudioFile(file)}
-                disabled={loading || processing}
-              />
-            )}
-
-            {audioFile && (
-              <div className="mt-3 p-3 bg-neutral-50 border border-neutral-200 rounded-lg">
-                <div className="flex items-center justify-between">
+          {/* Paste mode */}
+          {mode === 'paste' && !audioFile && (
+            <div className="space-y-2">
+              <FormField label="Transkript oder Notizen" htmlFor="content">
+                <Textarea
+                  id="content"
+                  value={content}
+                  onChange={(e) => handleContentChange(e.target.value)}
+                  placeholder="Sitzungsnotizen hier einfügen..."
+                  rows={10}
+                  className="font-mono text-sm"
+                />
+                <div className="flex items-center justify-between mt-1">
                   <div className="flex items-center gap-2">
-                    <Mic className="w-4 h-4 text-primary-600" />
-                    <span className="text-sm font-medium text-neutral-800">{audioFile.name}</span>
-                    <span className="text-xs text-primary-600">({(audioFile.size / 1024 / 1024).toFixed(1)} MB)</span>
+                    {contentFormat && (
+                      <span className={`text-xs px-2 py-0.5 rounded-full ${contentFormat === 'json' ? 'bg-primary-100 dark:bg-primary-900/30 text-primary-700 dark:text-primary-300' : 'bg-neutral-100 text-neutral-600'}`}>
+                        {contentFormat === 'json' ? 'JSON erkannt' : 'Freitext'}
+                      </span>
+                    )}
                   </div>
-                  <button
-                    onClick={() => setAudioFile(null)}
-                    className="text-xs text-primary-600 hover:text-primary-800"
-                  >
-                    Entfernen
-                  </button>
+                  <span className="text-xs text-neutral-500">{content.length} Zeichen</span>
                 </div>
+              </FormField>
+              <SwitchModeLink onClick={resetInput} />
+            </div>
+          )}
 
-                {/* Whisper model selector — compact inline styling inside audio panel */}
-                <div className="mt-2">
-                  <label htmlFor="whisper_model" className="block text-xs font-medium text-neutral-700 mb-1">
-                    Whisper-Modell
-                  </label>
-                  <Select
-                    id="whisper_model"
-                    value={whisperModel}
-                    onChange={(e) => setWhisperModel(e.target.value)}
-                    className="py-1 text-xs"
-                  >
-                    {WHISPER_MODELS.map((model) => (
-                      <option key={model.id} value={model.id}>{model.label}</option>
-                    ))}
-                  </Select>
+          {/* Attached audio file — shown for both record + upload completions */}
+          {audioFile && (
+            <div className="rounded-lg border border-neutral-200 bg-neutral-50 p-4 space-y-3 dark:bg-white/[0.04] dark:border-white/[0.08]">
+              <div className="flex items-center justify-between">
+                <div className="flex items-center gap-2">
+                  <Mic className="w-4 h-4 text-primary-600" />
+                  <span className="text-sm font-medium text-neutral-800 dark:text-neutral-200">{audioFile.name}</span>
+                  <span className="text-xs text-primary-600">({(audioFile.size / 1024 / 1024).toFixed(1)} MB)</span>
                 </div>
+                <button
+                  type="button"
+                  onClick={resetInput}
+                  className="text-xs text-primary-600 hover:text-primary-800"
+                >
+                  Entfernen
+                </button>
               </div>
-            )}
-          </div>
+
+              <div>
+                <label htmlFor="whisper_model" className="block text-xs font-medium text-neutral-700 dark:text-neutral-300 mb-1">
+                  Whisper-Modell
+                </label>
+                <Select
+                  id="whisper_model"
+                  value={whisperModel}
+                  onChange={(e) => setWhisperModel(e.target.value)}
+                  className="py-1 text-xs"
+                >
+                  {WHISPER_MODELS.map((model) => (
+                    <option key={model.id} value={model.id}>{model.label}</option>
+                  ))}
+                </Select>
+              </div>
+            </div>
+          )}
 
           {/* Submit */}
           <div className="flex items-center justify-between pt-4 border-t">
@@ -294,3 +341,40 @@ export default function ProtocolFormClient({ teamMembers }: ProtocolFormClientPr
     </div>
   )
 }
+
+function ModeTile({
+  icon: Icon,
+  title,
+  description,
+  onClick,
+}: {
+  icon: typeof Mic
+  title: string
+  description: string
+  onClick: () => void
+}) {
+  return (
+    <button
+      type="button"
+      onClick={onClick}
+      className="text-left rounded-lg border border-neutral-200 p-4 hover:border-primary-400 hover:bg-primary-50 transition-colors space-y-2 dark:border-white/[0.08] dark:hover:border-primary-500 dark:hover:bg-primary-900/10"
+    >
+      <Icon className="w-5 h-5 text-primary-600 dark:text-primary-400" aria-hidden />
+      <div className="text-sm font-medium text-neutral-900 dark:text-neutral-100">{title}</div>
+      <div className="text-xs text-neutral-600 dark:text-neutral-400">{description}</div>
+    </button>
+  )
+}
+
+function SwitchModeLink({ onClick }: { onClick: () => void }) {
+  return (
+    <button
+      type="button"
+      onClick={onClick}
+      className="text-xs text-primary-600 hover:text-primary-800 dark:text-primary-400 dark:hover:text-primary-300"
+    >
+      Andere Eingabe wählen
+    </button>
+  )
+}
+

--- a/src/app/admin/protocols/new/ProtocolFormClient.tsx
+++ b/src/app/admin/protocols/new/ProtocolFormClient.tsx
@@ -6,6 +6,7 @@ import type { MeetingType, ProtocolVisibility } from '@/config/protocols'
 import { WHISPER_MODELS } from '@/config/transcription'
 import Heading from '@/components/admin/AdminHeading'
 import { AIFormAssist } from '@/components/ai/AIFormAssist'
+import { AudioRecorderInline } from '@/components/admin/protocols/AudioRecorderInline'
 import { useProtocolForm } from '@/hooks/useProtocolForm'
 import { Input } from '@/components/ui/input'
 import { Textarea } from '@/components/ui/textarea'
@@ -194,23 +195,32 @@ export default function ProtocolFormClient({ teamMembers }: ProtocolFormClientPr
           </FormField>
 
           {/* File Upload */}
-          <div className="border-t pt-4">
-            <label className="block text-sm font-medium text-neutral-700 mb-2">
-              Oder Datei hochladen
-            </label>
-            <div className="flex items-center gap-3">
-              <label className="flex items-center gap-2 px-4 py-2 bg-neutral-100 text-neutral-700 rounded-lg hover:bg-neutral-200 cursor-pointer transition-colors text-sm">
-                <Upload className="w-4 h-4" />
-                Datei wählen
-                <input
-                  type="file"
-                  accept=".txt,.md,.json,.mp3,.wav,.m4a,.webm,.ogg,.flac"
-                  onChange={handleFileUpload}
-                  className="hidden"
-                />
+          <div className="border-t pt-4 space-y-4">
+            <div>
+              <label className="block text-sm font-medium text-neutral-700 mb-2">
+                Oder Datei hochladen
               </label>
-              <span className="text-xs text-neutral-500">.txt, .json, .mp3, .wav, .m4a, .webm</span>
+              <div className="flex items-center gap-3">
+                <label className="flex items-center gap-2 px-4 py-2 bg-neutral-100 text-neutral-700 rounded-lg hover:bg-neutral-200 cursor-pointer transition-colors text-sm">
+                  <Upload className="w-4 h-4" />
+                  Datei wählen
+                  <input
+                    type="file"
+                    accept=".txt,.md,.json,.mp3,.wav,.m4a,.webm,.ogg,.flac"
+                    onChange={handleFileUpload}
+                    className="hidden"
+                  />
+                </label>
+                <span className="text-xs text-neutral-500">.txt, .json, .mp3, .wav, .m4a, .webm</span>
+              </div>
             </div>
+
+            {!audioFile && !content.trim() && (
+              <AudioRecorderInline
+                onRecorded={(file) => setAudioFile(file)}
+                disabled={loading || processing}
+              />
+            )}
 
             {audioFile && (
               <div className="mt-3 p-3 bg-neutral-50 border border-neutral-200 rounded-lg">

--- a/src/app/admin/protocols/new/__tests__/ProtocolFormClient.test.tsx
+++ b/src/app/admin/protocols/new/__tests__/ProtocolFormClient.test.tsx
@@ -43,7 +43,8 @@ describe('ProtocolFormClient', () => {
       target: { value: 'team_weekly' },
     })
 
-    // Step 2: Content — enter transcript
+    // Step 2: Content — pick "Einfügen" tile to reveal the textarea, then enter transcript
+    fireEvent.click(await screen.findByRole('button', { name: /Einfügen/i }))
     const textarea = await screen.findByLabelText(/Transkript oder Notizen/i)
     fireEvent.change(textarea, {
       target: { value: 'Dies ist ein genügend langes Transkript für die Verarbeitung mit mehr als fünfzig Zeichen.' },

--- a/src/components/admin/protocols/AudioRecorderInline.tsx
+++ b/src/components/admin/protocols/AudioRecorderInline.tsx
@@ -1,0 +1,173 @@
+'use client'
+
+import { useEffect } from 'react'
+import { Mic, Pause, Play, Square, Check, X } from 'lucide-react'
+import { Button } from '@/components/ui/button'
+import { useVoiceRecording } from '@/hooks/useVoiceRecording'
+
+interface AudioRecorderInlineProps {
+  /** Called when the user clicks "use this recording" with a finished File ready for upload. */
+  onRecorded: (file: File) => void
+  /** Max recording duration in seconds. Default 1h. */
+  maxDuration?: number
+  /** Disable the recorder when the surrounding form is busy. */
+  disabled?: boolean
+}
+
+function formatTime(seconds: number): string {
+  const total = Math.floor(seconds)
+  const mm = String(Math.floor(total / 60)).padStart(2, '0')
+  const ss = String(total % 60).padStart(2, '0')
+  return `${mm}:${ss}`
+}
+
+export function AudioRecorderInline({
+  onRecorded,
+  maxDuration = 3600,
+  disabled = false,
+}: AudioRecorderInlineProps) {
+  const {
+    state,
+    recordingTime,
+    errorMessage,
+    audioUrl,
+    audioBlobRef,
+    startRecording,
+    stopRecording,
+    pauseRecording,
+    resumeRecording,
+    discardRecording,
+  } = useVoiceRecording({ maxDuration })
+
+  useEffect(() => {
+    if (state === 'error' && errorMessage) {
+      // The hook surfaces an inline error message; nothing more to do here.
+    }
+  }, [state, errorMessage])
+
+  const handleUseRecording = () => {
+    const blob = audioBlobRef.current
+    if (!blob) return
+    const ext = blob.type.includes('mp4') ? 'mp4' : 'webm'
+    const ts = new Date().toISOString().replace(/[:.]/g, '-')
+    const file = new File([blob], `recording-${ts}.${ext}`, { type: blob.type })
+    onRecorded(file)
+    discardRecording()
+  }
+
+  return (
+    <div className="rounded-lg border border-neutral-200 p-4 space-y-3 dark:border-white/[0.08]">
+      <div className="flex items-center justify-between gap-3">
+        <div className="flex items-center gap-2 text-sm font-medium text-neutral-800 dark:text-neutral-200">
+          <Mic className="w-4 h-4" aria-hidden />
+          Aufnahme im Browser
+        </div>
+        {(state === 'recording' || state === 'paused') && (
+          <div className="flex items-center gap-2" aria-live="polite">
+            <span
+              className={`inline-block w-2 h-2 rounded-full ${
+                state === 'recording' ? 'bg-error-500 animate-pulse' : 'bg-warning-500'
+              }`}
+              aria-hidden
+            />
+            <span className="font-mono text-sm tabular-nums">{formatTime(recordingTime)}</span>
+            <span className="text-xs text-neutral-500">
+              / {formatTime(maxDuration)} max
+            </span>
+          </div>
+        )}
+      </div>
+
+      {state === 'idle' && (
+        <div className="flex items-center justify-between gap-3">
+          <p className="text-xs text-neutral-600 dark:text-neutral-400">
+            Klick auf «Aufnahme starten» und sprich — die Aufnahme wird nach «Verwenden» genauso transkribiert wie eine hochgeladene Datei.
+          </p>
+          <Button
+            type="button"
+            variant="primary"
+            size="sm"
+            onClick={startRecording}
+            disabled={disabled}
+            className="gap-1.5"
+          >
+            <Mic className="w-4 h-4" />
+            Aufnahme starten
+          </Button>
+        </div>
+      )}
+
+      {state === 'recording' && (
+        <div className="flex items-center justify-end gap-2">
+          <Button type="button" variant="outline" size="sm" onClick={pauseRecording} className="gap-1.5">
+            <Pause className="w-4 h-4" />
+            Pause
+          </Button>
+          <Button type="button" variant="destructive" size="sm" onClick={stopRecording} className="gap-1.5">
+            <Square className="w-4 h-4" />
+            Stopp
+          </Button>
+        </div>
+      )}
+
+      {state === 'paused' && (
+        <div className="flex items-center justify-end gap-2">
+          <Button type="button" variant="primary" size="sm" onClick={resumeRecording} className="gap-1.5">
+            <Play className="w-4 h-4" />
+            Fortsetzen
+          </Button>
+          <Button type="button" variant="destructive" size="sm" onClick={stopRecording} className="gap-1.5">
+            <Square className="w-4 h-4" />
+            Stopp
+          </Button>
+        </div>
+      )}
+
+      {state === 'stopped' && (
+        <div className="space-y-3">
+          <div className="flex items-center gap-3">
+            <span className="text-sm text-neutral-700 dark:text-neutral-300">
+              Aufnahme — {formatTime(recordingTime)}
+            </span>
+            {audioUrl && (
+              <audio
+                src={audioUrl}
+                controls
+                className="flex-1 h-8 max-w-md"
+                aria-label="Vorschau der Aufnahme"
+              />
+            )}
+          </div>
+          <div className="flex items-center justify-end gap-2">
+            <Button
+              type="button"
+              variant="outline"
+              size="sm"
+              onClick={discardRecording}
+              disabled={disabled}
+              className="gap-1.5"
+            >
+              <X className="w-4 h-4" />
+              Verwerfen
+            </Button>
+            <Button
+              type="button"
+              variant="primary"
+              size="sm"
+              onClick={handleUseRecording}
+              disabled={disabled || !audioBlobRef.current}
+              className="gap-1.5"
+            >
+              <Check className="w-4 h-4" />
+              Aufnahme verwenden
+            </Button>
+          </div>
+        </div>
+      )}
+
+      {state === 'error' && errorMessage && (
+        <p className="text-sm text-error-600 dark:text-error-400">{errorMessage}</p>
+      )}
+    </div>
+  )
+}

--- a/src/components/admin/protocols/ProtocolActionItemsList.tsx
+++ b/src/components/admin/protocols/ProtocolActionItemsList.tsx
@@ -6,6 +6,7 @@ import {
   ExternalLink,
   Vote,
   HelpCircle,
+  Sparkles,
 } from 'lucide-react'
 import Heading from '@/components/admin/AdminHeading'
 import {
@@ -88,11 +89,70 @@ export function ProtocolActionItemsList({
   const tasks = notes.action_items.filter(i => i.item_type === 'task')
   const decisions = notes.action_items.filter(i => i.item_type === 'decision')
   const openQuestions = notes.action_items.filter(i => i.item_type === 'info')
+  const openDecisionCount = decisions.filter(d => {
+    const outcome = decisionOutcomes.find(o => o.action_item_id === d.id)
+    return !outcome?.is_closed
+  }).length
 
   const canAct = isReview || isFinalized
+  const showSummaryBanner = canAct && notes.action_items.length > 0
 
   return (
     <div id="protocol-step-tasks" className="bg-white dark:bg-neutral-900 rounded-lg border border-neutral-200 dark:border-white/[0.08] overflow-hidden">
+
+      {/* Summary banner — surfaces total counts + the single bulk-create CTA. */}
+      {showSummaryBanner && (
+        <div className="px-4 py-4 border-b border-neutral-100 dark:border-white/[0.06] bg-primary-50/50 dark:bg-primary-900/10 space-y-3">
+          <div className="flex items-start gap-3">
+            <Sparkles className="w-5 h-5 text-primary-600 dark:text-primary-400 mt-0.5 flex-shrink-0" aria-hidden />
+            <div className="flex-1 min-w-0 space-y-1">
+              <p className="text-sm font-medium text-neutral-900 dark:text-white">
+                KI hat erkannt:{' '}
+                {tasks.length > 0 && (
+                  <span className="text-primary-700 dark:text-primary-300">
+                    {tasks.length} {tasks.length === 1 ? 'Aufgabe' : 'Aufgaben'}
+                  </span>
+                )}
+                {tasks.length > 0 && (decisions.length > 0 || openQuestions.length > 0) && ' · '}
+                {decisions.length > 0 && (
+                  <span className="text-violet-700 dark:text-violet-300">
+                    {decisions.length} {decisions.length === 1 ? 'Entscheidung' : 'Entscheidungen'}
+                  </span>
+                )}
+                {decisions.length > 0 && openQuestions.length > 0 && ' · '}
+                {openQuestions.length > 0 && (
+                  <span className="text-neutral-700 dark:text-neutral-300">
+                    {openQuestions.length} Info
+                  </span>
+                )}
+              </p>
+              <p className="text-xs text-neutral-600 dark:text-neutral-400">
+                {unlinkedTaskItems.length > 0 && (
+                  <>Erstelle alle Aufgaben mit einem Klick. </>
+                )}
+                {openDecisionCount > 0 && (
+                  <>Entscheidungen sind offen — Teilnehmer können unten direkt abstimmen.</>
+                )}
+                {unlinkedTaskItems.length === 0 && openDecisionCount === 0 && (
+                  <>Alle Aufgaben verknüpft, alle Entscheidungen geschlossen.</>
+                )}
+              </p>
+            </div>
+            {unlinkedTaskItems.length > 0 && (
+              <button
+                onClick={onCreateAllTasks}
+                disabled={bulkCreatingTasks}
+                className="flex-shrink-0 text-sm px-4 py-2 rounded-lg bg-primary-600 text-white hover:bg-primary-700 disabled:opacity-50 transition-colors font-medium gap-2 inline-flex items-center"
+              >
+                {bulkCreatingTasks
+                  ? <><Loader2 className="w-4 h-4 animate-spin" />Erstellt…</>
+                  : <><ListChecks className="w-4 h-4" />Alle {unlinkedTaskItems.length} {unlinkedTaskItems.length === 1 ? 'Aufgabe' : 'Aufgaben'} erstellen</>
+                }
+              </button>
+            )}
+          </div>
+        </div>
+      )}
 
       {/* Header */}
       <div className="px-4 py-3 border-b border-neutral-100 dark:border-white/[0.06] flex items-center justify-between gap-3">
@@ -105,18 +165,6 @@ export function ProtocolActionItemsList({
             {notes.action_items.length}
           </span>
         </div>
-        {unlinkedTaskItems.length > 0 && canAct && (
-          <button
-            onClick={onCreateAllTasks}
-            disabled={bulkCreatingTasks}
-            className="text-xs px-3 py-1.5 rounded-lg border border-primary-300 dark:border-primary-700 text-primary-700 dark:text-primary-400 hover:bg-primary-50 dark:hover:bg-primary-900/20 disabled:opacity-50 transition-colors"
-          >
-            {bulkCreatingTasks
-              ? <><Loader2 className="w-3 h-3 animate-spin inline mr-1" />Erstellt…</>
-              : `${unlinkedTaskItems.length} Aufgaben erstellen`
-            }
-          </button>
-        )}
       </div>
 
       {bulkTaskErrors.length > 0 && (


### PR DESCRIPTION
## Summary

The protocols feature was hard and not intuitive — users couldn't record directly, the three input modalities were jumbled into one mixed content area, and the bulk task-creation action was buried in a small header button.

Three commits restructure the entry experience from "figure out what goes where" to "pick one of three modes, then one click."

- **Commit 1 — `feat(protocols): in-browser recording`**: New `AudioRecorderInline` wraps the already-existing `useVoiceRecording` hook (mono 16k webm, pause/resume/auto-stop). Users get Start / Pause / Resume / Stop / Discard / "Use this recording" with a live mm:ss timer and an inline audio preview. The recorded Blob is converted to a `File` and handed to the existing `setAudioFile` — same downstream transcription + AI pipeline, no API changes.

- **Commit 2 — `feat(protocols): three-modality picker`**: Replaced the mixed content area with an explicit three-tile picker — Aufnehmen (Record) · Hochladen (Upload) · Einfügen (Paste). Each tile is a peer; clicking reveals only that mode's UI. "Andere Eingabe wählen" lets the user undo without losing the surrounding form state.

- **Commit 3 — `feat(protocols): bulk-create summary banner`**: After AI processing, a Sparkles-iconed banner at the top of the action items list shows extracted counts ("KI hat erkannt: 5 Aufgaben · 2 Entscheidungen · 3 Info") with a prominent primary-styled "Alle N Aufgaben erstellen" button. Removed the old tiny in-header button.

## Why base = `claude/loop-bugfixes-2026-05` (PR #140)

This branch is stacked on top of PR #140 (137 base commits + 4 follow-up fixes for the Vercel build). GitHub will auto-update the base to `main` once #140 merges.

## Out of scope (separate follow-ups)

- Attendee-name → user-ID mapping UI (AI fuzzy-matches today but never shows the mapping decision)
- Quorum / progress visual on decision voting
- Decision-task-proposal auto-create on approval (currently two clicks)
- Mobile workflow stepper
- State preservation on re-process (re-running AI overwrites manual edits)

## Test plan

- [x] Local jest: `ProtocolFormClient` flow with paste mode (updated to click "Einfügen" tile first)
- [x] Local jest: `ProtocolDetailClient` bulk-create (updated to match new button label)
- [ ] Browser: record audio in /admin/protocols/new, confirm transcription kicks off
- [ ] Browser: switch modes via "Andere Eingabe wählen" — confirms state is cleared
- [ ] Browser: REVIEW status protocol shows summary banner with correct counts
- [ ] Browser: clicking "Alle X Aufgaben erstellen" creates them in parallel

🤖 Generated with [Claude Code](https://claude.com/claude-code)