### PR TITLE
test: realign 10 drifted unit-test suites + fix timecards notification href bug

### DIFF
--- a/src/app/api/admin/intake/[id]/publish/__tests__/route.test.ts
+++ b/src/app/api/admin/intake/[id]/publish/__tests__/route.test.ts
@@ -111,6 +111,16 @@ jest.mock('@/lib/intake/timeline', () => ({
   appendIntakeEvent: (...args: unknown[]) => mockAppendIntakeEvent.apply(null, args),
 }))
 
+// The route delegates the actual listing create/refresh to publishRevampitListing
+// (it replaced the old inline marketplace_listings insert). That helper runs its
+// own DB chains inside the tx and is covered by its own tests; here we mock it so
+// the route test exercises only the route's orchestration + gating.
+const mockPublishRevampitListing = jest.fn()
+
+jest.mock('@/lib/marketplace/publish-revampit-listing', () => ({
+  publishRevampitListing: (...args: unknown[]) => mockPublishRevampitListing.apply(null, args),
+}))
+
 jest.mock('@/lib/api/helpers', () => {
   const { NextResponse } = jest.requireActual('next/server')
   return {
@@ -184,6 +194,7 @@ beforeEach(() => {
     return cb(tx)
   })
   mockAppendIntakeEvent.mockResolvedValue(undefined)
+  mockPublishRevampitListing.mockResolvedValue('listing-1')
 
   mockValidateBody.mockReturnValue({ success: true, data: { price_chf: 299 } })
 

--- a/src/app/api/admin/marketplace/stats/__tests__/route.test.ts
+++ b/src/app/api/admin/marketplace/stats/__tests__/route.test.ts
@@ -36,7 +36,10 @@ jest.mock('@/lib/api/middleware', () => ({
 
 const mockSelect = jest.fn()
 const mockFrom = jest.fn()
+const mockInnerJoin = jest.fn()
 
+// Route chain: db.select({...}).from(listings).innerJoin(users, eq(...))
+// innerJoin is the terminal awaited step and resolves to the row array.
 jest.mock('@/db', () => ({
   db: {
     select: (...args: unknown[]) => { mockSelect(...args); return { from: mockFrom } },
@@ -45,10 +48,11 @@ jest.mock('@/db', () => ({
 
 jest.mock('@/db/schema', () => ({
   listings: {
-    id: 'l_id', status: 'l_status', verifiedAt: 'l_verifiedAt', isRevampit: 'l_isRevampit',
+    id: 'l_id', status: 'l_status', verifiedAt: 'l_verifiedAt', isRevampit: 'l_isRevampit', sellerId: 'l_sellerId',
   },
   listingReports: { status: 'lr_status' },
   marketplaceOrders: { status: 'mo_status', amountChf: 'mo_amountChf' },
+  users: { id: 'u_id', email: 'u_email' },
 }))
 
 jest.mock('drizzle-orm', () => ({
@@ -56,6 +60,7 @@ jest.mock('drizzle-orm', () => ({
     (_strings: TemplateStringsArray, ..._values: unknown[]) => ({ __sql: true }),
     { raw: (s: string) => ({ __raw: s }) }
   ),
+  eq: (...args: unknown[]) => ({ __eq: args }),
 }))
 
 jest.mock('@/config/database', () => ({
@@ -113,8 +118,9 @@ function makeRequest() {
 beforeEach(() => {
   jest.resetAllMocks()
   mockAuth.mockResolvedValue(MOCK_SESSION)
-  // select().from() — terminal; from resolves directly
-  mockFrom.mockResolvedValue([MOCK_ROW])
+  // select().from().innerJoin() — innerJoin is terminal and resolves the rows
+  mockFrom.mockReturnValue({ innerJoin: mockInnerJoin })
+  mockInnerJoin.mockResolvedValue([MOCK_ROW])
 })
 
 // ============================================================================
@@ -142,7 +148,7 @@ describe('GET /api/admin/marketplace/stats — authenticated', () => {
   })
 
   it('returns 500 when DB throws', async () => {
-    mockFrom.mockRejectedValueOnce(new Error('DB error'))
+    mockInnerJoin.mockRejectedValueOnce(new Error('DB error'))
     const response = await GET(makeRequest())
     expect(response.status).toBe(500)
   })

--- a/src/app/api/ai/vote-advisor/__tests__/route.test.ts
+++ b/src/app/api/ai/vote-advisor/__tests__/route.test.ts
@@ -36,8 +36,26 @@ jest.mock('@/lib/api/helpers', () => {
     apiSuccess: (data: unknown, status = 200) => NextResponse.json({ success: true, data }, { status }),
     apiError: (_err: unknown, msg: string, status = 500) => NextResponse.json({ success: false, error: msg }, { status }),
     apiBadRequest: (msg: string, details?: unknown) => NextResponse.json({ success: false, error: msg, details }, { status: 400 }),
+    apiRateLimited: (msg = 'Rate limited') => NextResponse.json({ success: false, error: msg }, { status: 429 }),
   }
 })
+
+// Rate limiters use real module-level LRU state that persists across tests in
+// the suite — without mocking, the per-IP limit (5/hour) trips after a handful
+// of cases and short-circuits the route. Mock them to always allow.
+const mockVoteAdvisorIp = jest.fn((..._args: unknown[]) => true)
+const mockVoteAdvisorGlobal = jest.fn((..._args: unknown[]) => true)
+jest.mock('@/lib/security/rate-limit', () => ({
+  rateLimiters: {
+    voteAdvisorIp: (...args: unknown[]) => mockVoteAdvisorIp(...args),
+    voteAdvisorGlobal: (...args: unknown[]) => mockVoteAdvisorGlobal(...args),
+  },
+  getClientIdentifier: () => 'test-client',
+}))
+
+jest.mock('@/config/error-messages', () => ({
+  ERROR_MESSAGES: { INVALID_REQUEST: 'Ungültige Anfrage' },
+}))
 
 jest.mock('@/lib/logger', () => ({
   logger: { info: jest.fn(), warn: jest.fn(), error: jest.fn(), debug: jest.fn() },
@@ -69,6 +87,8 @@ function makeRequest(body: unknown) {
 beforeEach(() => {
   jest.resetAllMocks()
   mockCallWithFallback.mockResolvedValue(MOCK_AI_RESULT)
+  mockVoteAdvisorIp.mockReturnValue(true)
+  mockVoteAdvisorGlobal.mockReturnValue(true)
 })
 
 // ============================================================================

--- a/src/app/api/newsletter/subscribe/__tests__/route.test.ts
+++ b/src/app/api/newsletter/subscribe/__tests__/route.test.ts
@@ -221,7 +221,12 @@ describe('POST /api/newsletter/subscribe — new subscriber', () => {
 })
 
 describe('POST /api/newsletter/subscribe — email failure', () => {
-  it('returns 502 when sendEmail resolves with success=false (does not swallow silent failure)', async () => {
+  it('degrades gracefully (200, confirmed:false, "Bestätigung folgt") and logs a warning when sendEmail fails', async () => {
+    // Contract: the DB row was already inserted as pending before the email
+    // send, so a failed confirmation email must NOT surface as a scary 502 the
+    // user can't act on. The route returns 200 and records the failure via
+    // logger.warn so the silent-failure-is-logged guarantee stays locked.
+    const { logger } = jest.requireMock('@/lib/logger')
     mockSendEmail.mockResolvedValueOnce({ success: false, error: 'SMTP rejected' })
 
     const req = new NextRequest('http://localhost/api/newsletter/subscribe', {
@@ -230,10 +235,12 @@ describe('POST /api/newsletter/subscribe — email failure', () => {
       headers: { 'Content-Type': 'application/json' },
     })
     const response = await POST(req)
-    expect(response.status).toBe(502)
+    expect(response.status).toBe(200)
     const body = await response.json()
-    expect(body.success).toBe(false)
-    expect(body.error).toMatch(/Bestätigungs-E-Mail/i)
+    expect(body.success).toBe(true)
+    expect(body.data.confirmed).toBe(false)
+    expect(body.data.message).toMatch(/Bestätigung folgt/i)
+    expect(logger.warn).toHaveBeenCalled()
   })
 })
 

--- a/src/config/notifications.ts
+++ b/src/config/notifications.ts
@@ -89,6 +89,9 @@ export const RELATED_TYPE_HREFS: Record<string, string> = {
   [RELATED_TYPES.WORKSHOP_PROPOSAL]: '/admin/workshops/proposals/',
   [RELATED_TYPES.MEMBERSHIP]: '/admin/membership/',
   [RELATED_TYPES.LISTING]: '/admin/marketplace/',
-  [RELATED_TYPES.TIME_OFF]: '/dashboard/timecards', // requester → their tool
-  [RELATED_TYPES.TIME_OFF_REVIEW]: '/admin/timecards', // approver → the queue
+  // timecards has no [id] detail page — land on the flat queue and pass the
+  // request id as a harmless query param (same append pattern as CONVERSATION),
+  // so relatedHref() can't produce a broken "/dashboard/timecards<id>" path.
+  [RELATED_TYPES.TIME_OFF]: '/dashboard/timecards?id=', // requester → their tool
+  [RELATED_TYPES.TIME_OFF_REVIEW]: '/admin/timecards?id=', // approver → the queue
 }

--- a/src/lib/__tests__/logger.test.ts
+++ b/src/lib/__tests__/logger.test.ts
@@ -7,7 +7,8 @@
  *
  * Behaviors locked:
  *   debug
- *   - does NOT call console.log in non-development env (NODE_ENV=test)
+ *   - calls console.log ONLY in development (NODE_ENV=development)
+ *   - is a no-op in non-development env (jest forces NODE_ENV=test)
  *
  *   info
  *   - calls console.log with [INFO] prefix
@@ -46,14 +47,35 @@ afterEach(() => {
 // ============================================================================
 
 describe('logger.debug', () => {
+  // jest forces NODE_ENV=test, where debug() is a no-op. shouldLog() reads
+  // NODE_ENV lazily, so flipping it to 'development' here exercises the active
+  // branch; we restore it afterwards so other suites see the original value.
+  let originalNodeEnv: string | undefined
+
+  beforeEach(() => {
+    originalNodeEnv = process.env.NODE_ENV
+  })
+
+  afterEach(() => {
+    (process.env as Record<string, string | undefined>).NODE_ENV = originalNodeEnv
+  })
+
+  it('is a no-op in non-development env (NODE_ENV=test)', () => {
+    (process.env as Record<string, string | undefined>).NODE_ENV = 'test'
+    logger.debug('debug message')
+
+    expect(consoleLog).not.toHaveBeenCalled()
+  })
+
   it('calls console.log in development environment', () => {
-    // .env sets NODE_ENV=development, loaded by next/jest — debug is active in tests
+    (process.env as Record<string, string | undefined>).NODE_ENV = 'development'
     logger.debug('debug message')
 
     expect(consoleLog).toHaveBeenCalledTimes(1)
   })
 
-  it('includes [DEBUG] prefix in output', () => {
+  it('includes [DEBUG] prefix in output (development)', () => {
+    (process.env as Record<string, string | undefined>).NODE_ENV = 'development'
     logger.debug('trace message')
 
     const firstArg = consoleLog.mock.calls[0][0] as string
@@ -182,7 +204,18 @@ describe('logError convenience function', () => {
 })
 
 describe('logDebug convenience function', () => {
+  let originalNodeEnv: string | undefined
+
+  beforeEach(() => {
+    originalNodeEnv = process.env.NODE_ENV
+  })
+
+  afterEach(() => {
+    (process.env as Record<string, string | undefined>).NODE_ENV = originalNodeEnv
+  })
+
   it('calls console.log in development environment', () => {
+    (process.env as Record<string, string | undefined>).NODE_ENV = 'development'
     logDebug('via convenience')
 
     expect(consoleLog).toHaveBeenCalledTimes(1)

--- a/src/lib/admin/__tests__/inventory-actions.test.ts
+++ b/src/lib/admin/__tests__/inventory-actions.test.ts
@@ -109,6 +109,18 @@ jest.mock('@/lib/logger', () => ({
   logger: { info: jest.fn(), warn: jest.fn(), error: jest.fn(), debug: jest.fn() },
 }))
 
+// publishProduct/unpublishProduct now delegate the actual listing create/refresh/
+// remove to the unified-marketplace helpers (the old inline marketplace_listings
+// insert/update is gone). Those helpers have their own tests; here we only assert
+// the orchestration: inventory lookup → delegate (or skip when not found).
+const mockPublishRevampitListing = jest.fn().mockResolvedValue('listing-1')
+const mockUnpublishRevampitListing = jest.fn().mockResolvedValue(undefined)
+
+jest.mock('@/lib/marketplace/publish-revampit-listing', () => ({
+  publishRevampitListing: (...args: unknown[]) => mockPublishRevampitListing.apply(null, args),
+  unpublishRevampitListing: (...args: unknown[]) => mockUnpublishRevampitListing.apply(null, args),
+}))
+
 // ---------------------------------------------------------------------------
 // Imports (after mocks)
 // ---------------------------------------------------------------------------
@@ -133,49 +145,25 @@ beforeEach(() => {
 // ============================================================================
 
 describe('publishProduct', () => {
-  it('returns early (no insert/update on listing) when productInfo not found', async () => {
-    // update (status change) → then productInfo select returns []
-    mockDbSelect
-      .mockReturnValueOnce(makeChain([]))  // productInfo → not found
+  it('approves the product but skips publishing when inventoryItem not found', async () => {
+    // First (and only) select is the inventory-item lookup → not found.
+    mockDbSelect.mockReturnValueOnce(makeChain([]))
 
     await publishProduct('product-1', 'user-1')
 
-    expect(mockDbInsert).not.toHaveBeenCalled()
-    // only 1 update (status change), no listing update
-    expect(mockDbUpdate).toHaveBeenCalledTimes(1) // status update still runs
+    // Status approval still runs, but no listing is created.
+    expect(mockDbUpdate).toHaveBeenCalledTimes(1) // status approval
+    expect(mockPublishRevampitListing).not.toHaveBeenCalled()
   })
 
-  it('returns early when inventoryItem not found', async () => {
-    mockDbSelect
-      .mockReturnValueOnce(makeChain([{ brand: 'Dell', productName: 'Latitude', shortDescription: 'Laptop', estimatedPriceChf: '299' }]))
-      .mockReturnValueOnce(makeChain([]))  // inventoryItem → not found
+  it('delegates to publishRevampitListing when inventoryItem found', async () => {
+    mockDbSelect.mockReturnValueOnce(makeChain([{ id: 'inv-1' }])) // inventory item
 
     await publishProduct('product-1', 'user-1')
 
-    expect(mockDbInsert).not.toHaveBeenCalled()
-  })
-
-  it('updates existing listing when one exists', async () => {
-    mockDbSelect
-      .mockReturnValueOnce(makeChain([{ brand: 'Dell', productName: 'Latitude', shortDescription: '', estimatedPriceChf: '299' }]))
-      .mockReturnValueOnce(makeChain([{ id: 'inv-1' }]))          // inventory item
-      .mockReturnValueOnce(makeChain([{ id: 'listing-existing' }]))  // existing listing
-
-    await publishProduct('product-1', 'user-1')
-
-    expect(mockDbUpdate).toHaveBeenCalledTimes(2) // status + listing
-    expect(mockDbInsert).not.toHaveBeenCalled()
-  })
-
-  it('creates new listing when none exists', async () => {
-    mockDbSelect
-      .mockReturnValueOnce(makeChain([{ brand: 'HP', productName: 'EliteBook', shortDescription: '', estimatedPriceChf: '250' }]))
-      .mockReturnValueOnce(makeChain([{ id: 'inv-1' }]))  // inventory item
-      .mockReturnValueOnce(makeChain([]))                  // no existing listing
-
-    await publishProduct('product-1', 'user-1')
-
-    expect(mockDbInsert).toHaveBeenCalledTimes(1)
+    expect(mockDbUpdate).toHaveBeenCalledTimes(1) // status approval
+    expect(mockPublishRevampitListing).toHaveBeenCalledTimes(1)
+    expect(mockPublishRevampitListing).toHaveBeenCalledWith(expect.anything(), 'inv-1')
   })
 })
 
@@ -184,20 +172,21 @@ describe('publishProduct', () => {
 // ============================================================================
 
 describe('unpublishProduct', () => {
-  it('updates listing to DRAFT when inventory item found', async () => {
+  it('delegates to unpublishRevampitListing when inventory item found', async () => {
     mockDbSelect.mockReturnValueOnce(makeChain([{ id: 'inv-1' }]))
 
     await unpublishProduct('product-1', 'user-1')
 
-    expect(mockDbUpdate).toHaveBeenCalledTimes(1)
+    expect(mockUnpublishRevampitListing).toHaveBeenCalledTimes(1)
+    expect(mockUnpublishRevampitListing).toHaveBeenCalledWith(expect.anything(), 'inv-1')
   })
 
-  it('skips DB update when inventory item not found', async () => {
+  it('skips unpublish when inventory item not found', async () => {
     mockDbSelect.mockReturnValueOnce(makeChain([]))
 
     await unpublishProduct('product-1', 'user-1')
 
-    expect(mockDbUpdate).not.toHaveBeenCalled()
+    expect(mockUnpublishRevampitListing).not.toHaveBeenCalled()
   })
 })
 
@@ -243,8 +232,9 @@ describe('updateProductImage', () => {
     expect(mockDbInsert).not.toHaveBeenCalled()
   })
 
-  it('deletes old Vercel blob when replacing an existing image', async () => {
-    const oldUrl = 'https://abc.blob.vercel-storage.com/old.jpg'
+  it('deletes the old object when the new upload lands at a different URL', async () => {
+    // Upload resolves to cdn.example.com/product.jpg (beforeEach default); old key differs.
+    const oldUrl = 'https://other-cdn.com/old.jpg'
     mockDbSelect
       .mockReturnValueOnce(makeChain([{ id: 'img-1', filePath: oldUrl }]))
       .mockReturnValueOnce(makeChain([{ itemUuid: 'I-240101-0001' }]))
@@ -254,9 +244,12 @@ describe('updateProductImage', () => {
     expect(mockDeleteImage).toHaveBeenCalledWith(oldUrl)
   })
 
-  it('does NOT call deleteImage for non-Vercel URLs', async () => {
+  it('does NOT call deleteImage when the re-upload overwrites the same URL', async () => {
+    // Deterministic <itemUuid>.jpg keys mean a re-upload usually returns the same
+    // URL — no stale object to clean up.
+    const sameUrl = 'https://cdn.example.com/product.jpg'
     mockDbSelect
-      .mockReturnValueOnce(makeChain([{ id: 'img-1', filePath: 'https://other-cdn.com/old.jpg' }]))
+      .mockReturnValueOnce(makeChain([{ id: 'img-1', filePath: sameUrl }]))
       .mockReturnValueOnce(makeChain([{ itemUuid: 'I-240101-0001' }]))
 
     await updateProductImage('prod-1', 'base64data', 'user-1')

--- a/src/lib/erfassung/__tests__/create-product.test.ts
+++ b/src/lib/erfassung/__tests__/create-product.test.ts
@@ -129,6 +129,17 @@ jest.mock('@/lib/logger', () => ({
   logger: { info: jest.fn(), warn: jest.fn(), error: jest.fn(), debug: jest.fn() },
 }))
 
+// publishRevampitListing is the unified-marketplace publish helper. create-product
+// delegates to it on `action='publish'` (it replaced the old inline
+// marketplace_listings insert). Its own DB chains are covered by its own tests;
+// here we only assert that create-product calls it for publish and skips it when
+// checklist-gated, so a no-op spy is the correct seam.
+const mockPublishRevampitListing = jest.fn().mockResolvedValue('listing-1')
+
+jest.mock('@/lib/marketplace/publish-revampit-listing', () => ({
+  publishRevampitListing: (...args: unknown[]) => mockPublishRevampitListing.apply(null, args),
+}))
+
 // ---------------------------------------------------------------------------
 // Imports (after mocks)
 // ---------------------------------------------------------------------------
@@ -246,20 +257,20 @@ describe('createErfassungProduct — action/status', () => {
     expect(result.inventoryId).toBe('inventory-1')
   })
 
-  it('publish action → inserts marketplace listing (3 inserts total)', async () => {
-    mockTxExecute.mockResolvedValueOnce({ rows: [{ count: '0' }] }) // UUID
-    mockTxInsert
-      .mockReturnValueOnce(makeInsertChain([{ id: 'product-1' }]))   // product
-      .mockReturnValueOnce(makeInsertChain([{ id: 'inventory-1' }])) // inventory
-      .mockReturnValueOnce(makeInsertChain([]))                       // marketplace listing
+  it('publish action → delegates to publishRevampitListing (2 own inserts)', async () => {
+    setupMinimalDraft()
 
     const result = await createErfassungProduct(makePayload({ action: 'publish' }), 'user-1', mockTx as never)
 
-    expect(mockTxInsert).toHaveBeenCalledTimes(3)
+    // create-product itself inserts only product + inventory; the marketplace
+    // listing is created by publishRevampitListing (mocked here).
+    expect(mockTxInsert).toHaveBeenCalledTimes(2)
+    expect(mockPublishRevampitListing).toHaveBeenCalledTimes(1)
+    expect(mockPublishRevampitListing).toHaveBeenCalledWith(mockTx, 'inventory-1')
     expect(result.productId).toBe('product-1')
   })
 
-  it('checklistGated + publish → skips marketplace listing (2 inserts only)', async () => {
+  it('checklistGated + publish → skips publishRevampitListing (2 inserts only)', async () => {
     setupMinimalDraft()
 
     await createErfassungProduct(
@@ -269,8 +280,9 @@ describe('createErfassungProduct — action/status', () => {
       { checklistGated: true },
     )
 
-    // checklistGated overrides publish → no marketplace listing insert
+    // checklistGated overrides publish → no marketplace listing
     expect(mockTxInsert).toHaveBeenCalledTimes(2)
+    expect(mockPublishRevampitListing).not.toHaveBeenCalled()
   })
 })
 

--- a/src/lib/erfassung/__tests__/file-parser.test.ts
+++ b/src/lib/erfassung/__tests__/file-parser.test.ts
@@ -5,6 +5,11 @@
  * and product validation from file input.
  */
 
+// exceljs is only used by parseExcel; these tests exercise parseCSV only.
+// Stub it so Jest never loads exceljs' ESM-only `uuid` dependency (which isn't
+// transformed and otherwise crashes the whole suite at import time).
+jest.mock('exceljs', () => ({ Workbook: class {} }))
+
 // Mock next/server
 jest.mock('next/server', () => ({
   NextRequest: class {},

--- a/src/lib/hirn/__tests__/providers.test.ts
+++ b/src/lib/hirn/__tests__/providers.test.ts
@@ -278,8 +278,10 @@ describe('getDefaultChatProvider', () => {
     )
     mockGroqIsAvailable.mockResolvedValue(false) // override beforeEach default (true)
 
+    // User-facing message is intentionally German (Swiss app). Assert on the
+    // stable lead-in, not the volatile "Geprüft: <provider list>" tail.
     await expect(getDefaultChatProvider()).rejects.toThrow(
-      'No available AI providers configured'
+      'Kein KI-Anbieter verfügbar'
     )
   })
 

--- a/src/lib/logger.ts
+++ b/src/lib/logger.ts
@@ -20,8 +20,6 @@ interface LogEntry {
 }
 
 class Logger {
-  private isDevelopment = process.env.NODE_ENV === 'development'
-
   private formatLog(level: LogLevel, message: string, data?: unknown): LogEntry {
     return {
       level,
@@ -32,8 +30,13 @@ class Logger {
   }
 
   private shouldLog(level: LogLevel): boolean {
+    // Read NODE_ENV lazily at call-time rather than caching it at construction.
+    // NODE_ENV never changes mid-process, so runtime behaviour is identical to a
+    // captured field — but reading it here keeps both branches testable instead
+    // of freezing whatever NODE_ENV happened to be at import time.
+    const isDevelopment = process.env.NODE_ENV === 'development'
     // In production, only log warnings and errors
-    if (!this.isDevelopment && level === LogLevel.DEBUG) {
+    if (!isDevelopment && level === LogLevel.DEBUG) {
       return false
     }
     return true


### PR DESCRIPTION
## Summary

The unit suite had **29 failures across 10 suites**. The CI test job is
non-blocking ("still maturing"), so these accumulated silently. This PR brings
the **entire suite green (522 suites / 7676 tests)** and fixes one real
production bug found during triage.

## Real bug fixed 🐛

`RELATED_TYPE_HREFS` `TIME_OFF` / `TIME_OFF_REVIEW` entries had no trailing
separator. `NotificationBell.relatedHref()` builds links as
`` `${base}${related_id}` ``, so a time-off notification produced the broken URL
`/dashboard/timecards<id>`. Changed to `/dashboard/timecards?id=` so the id
becomes a harmless query param and the link resolves to the tool.

## Design improvement (runtime-identical)

`logger` now reads `NODE_ENV` lazily inside `shouldLog()` instead of caching it
at construction. Runtime behavior is unchanged (NODE_ENV never changes
mid-process) but both `debug()` branches are now testable.

## Test-only realignments (code was already correct)

| Suite | Drift |
|-------|-------|
| newsletter/subscribe | Route deliberately degrades gracefully (200 + "Bestätigung folgt") instead of a 502 the user can't act on — test now asserts the new contract **and** that `logger.warn` still fires |
| hirn/providers | Error message is intentionally German — assert stable lead-in "Kein KI-Anbieter verfügbar" |
| ai/vote-advisor | Unmocked rate-limiter LRU state tripped the per-IP limit → 500; mock it + error-messages |
| marketplace/stats | Mock the `.innerJoin()` terminal of the query chain |
| erfassung/create-product, admin/inventory-actions, intake/publish | Now delegate to `publishRevampitListing` / `unpublishRevampitListing`; mock the helpers, assert delegation |
| erfassung/file-parser | Mock `exceljs` (ESM-only `uuid` dep) so CSV-only tests don't crash at import |

## Verification (local — CI billing-blocked)

- `npx jest` (full): **522 suites / 7676 tests passed, 0 failures** ✅
- `npm run typecheck` ✅
- `eslint` on all changed files ✅

🤖 Generated with [Claude Code](https://claude.com/claude-code)