### PR TITLE
a11y(cart): trap & restore focus in CartDrawer via shared useFocusTrap hook

### DIFF
--- a/src/components/marketplace/cart/CartDrawer.tsx
+++ b/src/components/marketplace/cart/CartDrawer.tsx
@@ -7,6 +7,7 @@ import { useTranslations } from 'next-intl'
 import { Button } from '@/components/ui/button'
 import { Link } from '@/i18n/navigation'
 import { formatCHF } from '@/config/marketplace'
+import { useFocusTrap } from '@/hooks/useFocusTrap'
 import { useCart } from './CartProvider'
 
 /**
@@ -18,18 +19,19 @@ export function CartDrawer() {
   const t = useTranslations('marketplace.cart')
   const { items, total, count, drawerOpen, closeDrawer, remove } = useCart()
 
-  // Esc closes; lock body scroll while open.
+  // Escape-to-close, initial focus, focus restore and the Tab trap all live in
+  // the shared hook; attach its ref to the panel below.
+  const panelRef = useFocusTrap<HTMLDivElement>(drawerOpen, closeDrawer)
+
+  // Lock body scroll while the drawer is open.
   useEffect(() => {
     if (!drawerOpen) return
-    const onKey = (e: KeyboardEvent) => { if (e.key === 'Escape') closeDrawer() }
-    window.addEventListener('keydown', onKey)
     const prevOverflow = document.body.style.overflow
     document.body.style.overflow = 'hidden'
     return () => {
-      window.removeEventListener('keydown', onKey)
       document.body.style.overflow = prevOverflow
     }
-  }, [drawerOpen, closeDrawer])
+  }, [drawerOpen])
 
   if (!drawerOpen) return null
 
@@ -38,8 +40,8 @@ export function CartDrawer() {
       {/* Scrim */}
       <div className="absolute inset-0 bg-black/50" onClick={closeDrawer} aria-hidden="true" />
 
-      {/* Panel */}
-      <div className="relative flex h-full w-full max-w-sm flex-col border-l border-strong bg-surface-base">
+      {/* Panel — tabIndex=-1 so the trap can focus it when no child is focusable. */}
+      <div ref={panelRef} tabIndex={-1} className="relative flex h-full w-full max-w-sm flex-col border-l border-strong bg-surface-base focus:outline-none">
         <header className="flex items-center justify-between border-b border-subtle px-5 py-4">
           <h2 className="flex items-center gap-2 text-base font-semibold text-text-primary">
             <ShoppingCart className="h-5 w-5" aria-hidden="true" />

--- a/src/components/ui/Modal.tsx
+++ b/src/components/ui/Modal.tsx
@@ -4,20 +4,16 @@
  * Shared Modal wrapper component
  *
  * Provides consistent backdrop, header with title/close button,
- * escape-to-close, click-outside-to-close, initial-focus, focus
- * restoration on close, and a focus trap that cycles Tab inside
- * the dialog.
- *
- * The trap is intentionally minimal (no `focus-trap-react` dep);
- * it covers the common case — modals contain a few interactive
- * elements, not a treeview. If a future modal needs more complex
- * focus management, swap to a tested library here only.
+ * click-outside-to-close, and accessible focus management
+ * (escape-to-close, initial focus, focus restoration on close, and a
+ * Tab trap) via the shared `useFocusTrap` hook.
  */
 
-import { useEffect, useCallback, useRef, type ReactNode } from 'react'
+import { type ReactNode } from 'react'
 import { X } from 'lucide-react'
 import { useTranslations } from 'next-intl'
 import Heading from '@/components/ui/Heading'
+import { useFocusTrap } from '@/hooks/useFocusTrap'
 
 const SIZE_CLASSES = {
   sm: 'max-w-sm',
@@ -35,9 +31,6 @@ interface ModalProps {
   size?: keyof typeof SIZE_CLASSES
 }
 
-const FOCUSABLE_SELECTOR =
-  'a[href], button:not([disabled]), textarea:not([disabled]), input:not([disabled]), select:not([disabled]), [tabindex]:not([tabindex="-1"])'
-
 export function Modal({
   isOpen,
   onClose,
@@ -47,61 +40,7 @@ export function Modal({
   size = 'md',
 }: ModalProps) {
   const t = useTranslations('common')
-  const dialogRef = useRef<HTMLDivElement>(null)
-  // Track the element that was focused when the modal opened so we can
-  // restore focus on close. Without this, keyboard users land back at the
-  // top of the page every time.
-  const previousFocusRef = useRef<HTMLElement | null>(null)
-
-  const handleKeyDown = useCallback(
-    (e: KeyboardEvent) => {
-      if (e.key === 'Escape') {
-        onClose()
-        return
-      }
-      if (e.key === 'Tab' && dialogRef.current) {
-        const focusables = dialogRef.current.querySelectorAll<HTMLElement>(FOCUSABLE_SELECTOR)
-        if (focusables.length === 0) return
-        const first = focusables[0]
-        const last = focusables[focusables.length - 1]
-        if (e.shiftKey && document.activeElement === first) {
-          e.preventDefault()
-          last.focus()
-        } else if (!e.shiftKey && document.activeElement === last) {
-          e.preventDefault()
-          first.focus()
-        }
-      }
-    },
-    [onClose],
-  )
-
-  useEffect(() => {
-    if (!isOpen) return
-
-    // Remember whoever opened the modal so we can return focus on close.
-    previousFocusRef.current = document.activeElement as HTMLElement | null
-
-    document.addEventListener('keydown', handleKeyDown)
-
-    // Move focus into the dialog. Prefer the first focusable element
-    // (typically a form input or close button) so screen readers
-    // announce the modal contents immediately.
-    const focusables = dialogRef.current?.querySelectorAll<HTMLElement>(FOCUSABLE_SELECTOR)
-    const target = focusables?.[0] ?? dialogRef.current
-    target?.focus()
-
-    return () => {
-      document.removeEventListener('keydown', handleKeyDown)
-      // Restore focus to whatever opened the modal — only if that
-      // element is still in the document (e.g. the trigger wasn't
-      // unmounted while the modal was open).
-      const prev = previousFocusRef.current
-      if (prev && document.body.contains(prev)) {
-        prev.focus()
-      }
-    }
-  }, [isOpen, handleKeyDown])
+  const dialogRef = useFocusTrap<HTMLDivElement>(isOpen, onClose)
 
   if (!isOpen) return null
 

--- a/src/hooks/__tests__/useFocusTrap.test.tsx
+++ b/src/hooks/__tests__/useFocusTrap.test.tsx
@@ -1,0 +1,110 @@
+/**
+ * Tests for useFocusTrap — accessible focus management for overlays.
+ *
+ * Used by Modal and the marketplace CartDrawer. A broken trap is a real
+ * keyboard/screen-reader accessibility defect (WCAG 2.4.3), so the
+ * behaviors are locked here:
+ *
+ *   - moves focus into the container when activated (first focusable)
+ *   - falls back to the container itself when it has no focusable child
+ *   - calls onEscape when Escape is pressed (only while active)
+ *   - Tab from the last focusable wraps to the first; Shift+Tab from the
+ *     first wraps to the last
+ *   - restores focus to the previously-focused element on deactivation
+ */
+
+import { renderHook } from '@testing-library/react'
+import { useRef, type RefObject } from 'react'
+import { useFocusTrap } from '../useFocusTrap'
+
+/**
+ * Render the hook with its returned ref attached to a real DOM container so
+ * focus/keyboard behavior can be exercised. The container is appended to
+ * document.body (jsdom) and torn down after each test.
+ */
+function setup(active: boolean, onEscape?: () => void, html = '') {
+  const container = document.createElement('div')
+  container.tabIndex = -1
+  container.innerHTML = html
+  document.body.appendChild(container)
+
+  const view = renderHook(
+    ({ active }: { active: boolean }) => {
+      const ref = useFocusTrap<HTMLDivElement>(active, onEscape) as RefObject<HTMLDivElement | null>
+      // Attach the hook's ref to our pre-built container.
+      ;(ref as { current: HTMLDivElement | null }).current = container
+      return ref
+    },
+    { initialProps: { active } },
+  )
+  return { container, view }
+}
+
+afterEach(() => {
+  document.body.innerHTML = ''
+})
+
+describe('useFocusTrap', () => {
+  it('moves focus to the first focusable element when activated', () => {
+    const { container } = setup(true, undefined, '<button id="a">A</button><button id="b">B</button>')
+    const first = container.querySelector<HTMLButtonElement>('#a')!
+    expect(document.activeElement).toBe(first)
+  })
+
+  it('focuses the container itself when there is no focusable child', () => {
+    const { container } = setup(true, undefined, '<p>no focusables here</p>')
+    expect(document.activeElement).toBe(container)
+  })
+
+  it('calls onEscape when Escape is pressed while active', () => {
+    const onEscape = jest.fn()
+    setup(true, onEscape, '<button>A</button>')
+    document.dispatchEvent(new KeyboardEvent('keydown', { key: 'Escape' }))
+    expect(onEscape).toHaveBeenCalledTimes(1)
+  })
+
+  it('does NOT call onEscape when inactive', () => {
+    const onEscape = jest.fn()
+    setup(false, onEscape, '<button>A</button>')
+    document.dispatchEvent(new KeyboardEvent('keydown', { key: 'Escape' }))
+    expect(onEscape).not.toHaveBeenCalled()
+  })
+
+  it('wraps Tab from the last focusable back to the first', () => {
+    const { container } = setup(true, undefined, '<button id="a">A</button><button id="b">B</button>')
+    const first = container.querySelector<HTMLButtonElement>('#a')!
+    const last = container.querySelector<HTMLButtonElement>('#b')!
+    last.focus()
+    const e = new KeyboardEvent('keydown', { key: 'Tab', bubbles: true, cancelable: true })
+    document.dispatchEvent(e)
+    expect(e.defaultPrevented).toBe(true)
+    expect(document.activeElement).toBe(first)
+  })
+
+  it('wraps Shift+Tab from the first focusable back to the last', () => {
+    const { container } = setup(true, undefined, '<button id="a">A</button><button id="b">B</button>')
+    const first = container.querySelector<HTMLButtonElement>('#a')!
+    const last = container.querySelector<HTMLButtonElement>('#b')!
+    first.focus()
+    const e = new KeyboardEvent('keydown', { key: 'Tab', shiftKey: true, bubbles: true, cancelable: true })
+    document.dispatchEvent(e)
+    expect(e.defaultPrevented).toBe(true)
+    expect(document.activeElement).toBe(last)
+  })
+
+  it('restores focus to the previously-focused element on deactivation', () => {
+    // A trigger button outside the trap that "opened" the overlay.
+    const trigger = document.createElement('button')
+    trigger.id = 'trigger'
+    document.body.appendChild(trigger)
+    trigger.focus()
+    expect(document.activeElement).toBe(trigger)
+
+    const { view } = setup(true, undefined, '<button id="a">A</button>')
+    // Focus moved into the trap.
+    expect(document.activeElement).not.toBe(trigger)
+
+    view.rerender({ active: false })
+    expect(document.activeElement).toBe(trigger)
+  })
+})

--- a/src/hooks/useFocusTrap.ts
+++ b/src/hooks/useFocusTrap.ts
@@ -1,0 +1,87 @@
+'use client'
+
+/**
+ * useFocusTrap — accessible focus management for dialogs, drawers and any
+ * modal overlay.
+ *
+ * When `active` becomes true it:
+ *   - remembers the element that had focus (so it can be restored on close),
+ *   - moves focus to the first focusable element inside the container
+ *     (or the container itself if it has none),
+ *   - traps Tab / Shift+Tab so focus cycles within the container,
+ *   - calls `onEscape` when Escape is pressed.
+ *
+ * When `active` becomes false (or the component unmounts) it restores focus
+ * to whatever was focused before — but only if that element is still in the
+ * document, so keyboard users don't get dumped back at the top of the page.
+ *
+ * Attach the returned ref to the dialog container (give it `tabIndex={-1}`
+ * so it can receive focus programmatically without joining the tab order).
+ *
+ * The trap is intentionally minimal (no `focus-trap-react` dependency); it
+ * covers the common case — overlays contain a handful of interactive
+ * elements, not a treeview. Swap to a tested library here only if a future
+ * overlay needs richer focus management.
+ */
+
+import { useEffect, useRef, type RefObject } from 'react'
+
+const FOCUSABLE_SELECTOR =
+  'a[href], button:not([disabled]), textarea:not([disabled]), input:not([disabled]), select:not([disabled]), [tabindex]:not([tabindex="-1"])'
+
+export function useFocusTrap<T extends HTMLElement = HTMLDivElement>(
+  active: boolean,
+  onEscape?: () => void,
+): RefObject<T> {
+  const containerRef = useRef<T>(null)
+  // Track the element focused when the trap activated, to restore on close.
+  const previousFocusRef = useRef<HTMLElement | null>(null)
+  // Keep the latest onEscape without re-running the trap effect (which would
+  // re-steal focus) whenever the callback's identity changes.
+  const onEscapeRef = useRef(onEscape)
+  useEffect(() => {
+    onEscapeRef.current = onEscape
+  })
+
+  useEffect(() => {
+    if (!active) return
+
+    const container = containerRef.current
+    previousFocusRef.current = document.activeElement as HTMLElement | null
+
+    const handleKeyDown = (e: KeyboardEvent) => {
+      if (e.key === 'Escape') {
+        onEscapeRef.current?.()
+        return
+      }
+      if (e.key !== 'Tab' || !container) return
+      const focusables = container.querySelectorAll<HTMLElement>(FOCUSABLE_SELECTOR)
+      if (focusables.length === 0) return
+      const first = focusables[0]
+      const last = focusables[focusables.length - 1]
+      if (e.shiftKey && document.activeElement === first) {
+        e.preventDefault()
+        last.focus()
+      } else if (!e.shiftKey && document.activeElement === last) {
+        e.preventDefault()
+        first.focus()
+      }
+    }
+
+    document.addEventListener('keydown', handleKeyDown)
+
+    // Move focus into the container so screen readers announce its contents.
+    const focusables = container?.querySelectorAll<HTMLElement>(FOCUSABLE_SELECTOR)
+    ;(focusables?.[0] ?? container)?.focus()
+
+    return () => {
+      document.removeEventListener('keydown', handleKeyDown)
+      const prev = previousFocusRef.current
+      if (prev && document.body.contains(prev)) {
+        prev.focus()
+      }
+    }
+  }, [active])
+
+  return containerRef
+}


### PR DESCRIPTION
## Problem

The marketplace `CartDrawer` is a `role="dialog" aria-modal="true"` overlay but
had **no focus management**:
- opening it left keyboard focus on the trigger *behind* the scrim,
- Tab could walk into the page content behind the drawer (no trap),
- closing it didn't restore focus to the trigger.

That's a WCAG 2.4.3 / dialog-pattern defect for keyboard and screen-reader users.

## Fix (DRY)

`Modal.tsx` already had a correct, minimal focus trap — but it was locked inside
the component. Extracted it into a reusable **`useFocusTrap(active, onEscape)`**
hook (single source of truth for overlay focus management):

- **CartDrawer** now uses it → initial focus into the panel, Tab/Shift+Tab wrap,
  focus restored to the trigger on close, Esc-to-close. Its hand-rolled Esc
  listener is removed; only the drawer-specific body-scroll lock remains.
- **Modal** refactored to consume the hook — behavior-identical, ~50 fewer lines.

## Tests

7 new unit tests lock the hook contract: initial focus, container fallback when
no focusable child, Esc fires only while active, Tab and Shift+Tab wrap, and
focus restoration on deactivation.

## Verification (local — CI billing-blocked)

- `npx jest src/hooks/__tests__/useFocusTrap.test.tsx` → 7/7 ✅
- `npm run typecheck` ✅
- `eslint` on all 4 changed files ✅

🤖 Generated with [Claude Code](https://claude.com/claude-code)