### PR TITLE
a11y(overlays): focus-trap HirnSlideOver & MobileMenu via shared hook

### DIFF
--- a/src/components/admin/HirnSlideOver.tsx
+++ b/src/components/admin/HirnSlideOver.tsx
@@ -6,6 +6,7 @@ import Heading from '@/components/admin/AdminHeading'
 import { Button } from '@/components/ui/button'
 import { Link } from '@/i18n/navigation'
 import { useTranslations } from 'next-intl'
+import { useFocusTrap } from '@/hooks/useFocusTrap'
 import { HirnChat } from './HirnChat'
 import { ORG } from '@/config/org'
 import { ROUTES } from '@/config/routes'
@@ -26,26 +27,21 @@ function generateSessionId(): string {
 export function HirnSlideOver({ isOpen, onClose }: HirnSlideOverProps) {
   const [sessionId, setSessionId] = useState<string>(() => generateSessionId())
   const t = useTranslations('admin.hirn')
+  const tCommon = useTranslations('common')
 
-  // Handle escape key
+  // Escape-to-close, initial focus, focus restore and the Tab trap all live in
+  // the shared hook; attach its ref to the panel below.
+  const panelRef = useFocusTrap<HTMLDivElement>(isOpen, onClose)
+
+  // Lock body scroll while the panel is open.
   useEffect(() => {
-    const handleEscape = (e: KeyboardEvent) => {
-      if (e.key === 'Escape') {
-        onClose()
-      }
-    }
-
-    if (isOpen) {
-      document.addEventListener('keydown', handleEscape)
-      // Prevent body scroll when panel is open
-      document.body.style.overflow = 'hidden'
-    }
-
+    if (!isOpen) return
+    const prevOverflow = document.body.style.overflow
+    document.body.style.overflow = 'hidden'
     return () => {
-      document.removeEventListener('keydown', handleEscape)
-      document.body.style.overflow = ''
+      document.body.style.overflow = prevOverflow
     }
-  }, [isOpen, onClose])
+  }, [isOpen])
 
   const handleNewSession = useCallback(() => {
     setSessionId(generateSessionId())
@@ -61,10 +57,18 @@ export function HirnSlideOver({ isOpen, onClose }: HirnSlideOverProps) {
       <div
         className="fixed inset-0 z-50 bg-black/30 backdrop-blur-xs transition-opacity"
         onClick={onClose}
+        aria-hidden="true"
       />
 
-      {/* Panel */}
-      <div className="fixed inset-y-0 right-0 z-50 w-full max-w-md bg-surface-base shadow-xs flex flex-col animate-slide-in-right">
+      {/* Panel — tabIndex=-1 so the trap can focus it before any child. */}
+      <div
+        ref={panelRef}
+        role="dialog"
+        aria-modal="true"
+        aria-label="Hirn AI"
+        tabIndex={-1}
+        className="fixed inset-y-0 right-0 z-50 w-full max-w-md bg-surface-base shadow-xs flex flex-col animate-slide-in-right focus:outline-none"
+      >
         {/* Header */}
         <div className="flex items-center justify-between px-4 py-3 border-b border bg-action">
           <div className="flex items-center gap-3">
@@ -93,6 +97,7 @@ export function HirnSlideOver({ isOpen, onClose }: HirnSlideOverProps) {
               variant="ghost"
               size="icon"
               onClick={onClose}
+              aria-label={tCommon('close')}
               className="text-white/80 hover:text-white hover:bg-surface-base/10 rounded-lg"
             >
               <X className="w-5 h-5" />

--- a/src/components/layout/MobileMenu.tsx
+++ b/src/components/layout/MobileMenu.tsx
@@ -1,7 +1,8 @@
 'use client'
 
-import { useEffect, useRef, useState } from 'react'
+import { useEffect, useState } from 'react'
 import { Link } from '@/i18n/navigation'
+import { useFocusTrap } from '@/hooks/useFocusTrap'
 import { useRouter } from 'next/navigation'
 import { X, ChevronDown, ExternalLink, ArrowRight } from 'lucide-react'
 import { createPortal } from 'react-dom'
@@ -22,7 +23,6 @@ interface MobileMenuProps {
   isOpen: boolean
   onClose: () => void
   navigationItems: NavigationItem[]
-  triggerRef?: React.RefObject<HTMLButtonElement | null>
 }
 
 /**
@@ -33,7 +33,6 @@ export function MobileMenu({
   isOpen,
   onClose,
   navigationItems,
-  triggerRef,
 }: MobileMenuProps) {
   const router = useRouter()
   const { data: session } = useSession()
@@ -47,7 +46,9 @@ export function MobileMenu({
     if (!key) return null
     try { return tBadge(key as never) } catch { return key }
   }
-  const menuPanelRef = useRef<HTMLDivElement>(null)
+  // Escape-to-close, initial focus, focus restore (to the hamburger trigger)
+  // and the Tab trap all live in the shared hook; attach its ref to the panel.
+  const menuPanelRef = useFocusTrap<HTMLDivElement>(isOpen, onClose)
   const [openDropdown, setOpenDropdown] = useState<string | null>(null)
   const [mounted, setMounted] = useState(false)
 
@@ -57,30 +58,15 @@ export function MobileMenu({
     return () => cancelAnimationFrame(frame)
   }, [])
 
-  // Handle escape key
+  // Lock body scroll while the menu is open.
   useEffect(() => {
-    const handleEscape = (e: KeyboardEvent) => {
-      if (e.key === 'Escape' && isOpen) {
-        onClose()
-      }
-    }
-    document.addEventListener('keydown', handleEscape)
-    return () => document.removeEventListener('keydown', handleEscape)
-  }, [isOpen, onClose])
-
-  // Handle body scroll lock and focus
-  useEffect(() => {
-    if (isOpen) {
-      menuPanelRef.current?.focus()
-      document.body.style.overflow = 'hidden'
-    } else {
-      document.body.style.overflow = ''
-      triggerRef?.current?.focus()
-    }
+    if (!isOpen) return
+    const prevOverflow = document.body.style.overflow
+    document.body.style.overflow = 'hidden'
     return () => {
-      document.body.style.overflow = ''
+      document.body.style.overflow = prevOverflow
     }
-  }, [isOpen, triggerRef])
+  }, [isOpen])
 
   const handleNavigation = (href: string) => {
     if (href === '#') return

--- a/src/components/layout/header/Header.tsx
+++ b/src/components/layout/header/Header.tsx
@@ -205,7 +205,6 @@ export function Header() {
         isOpen={mobileMenuOpen}
         onClose={() => setMobileMenuOpen(false)}
         navigationItems={mainNavigation}
-        triggerRef={mobileMenuTriggerRef}
       />
     </>
   )


### PR DESCRIPTION
## What

Extends the `useFocusTrap` hook (#149) to the two remaining hand-rolled dialog overlays.

### HirnSlideOver — was the worst offender
A right-hand AI-chat slide-over with **no dialog semantics at all**:
- no `role="dialog"` / `aria-modal`
- no focus management (no focus-in, trap, or restore)
- icon-only close button with **no accessible name**

Added: `role="dialog"`, `aria-modal`, `aria-label`, `aria-hidden` on the backdrop,
`aria-label="Schliessen"` on the close button, and the shared focus trap.

### MobileMenu — missing the trap
Already moved focus in and restored it, but had **no Tab trap** — focus could walk
into the page behind the menu. Replaced its bespoke Esc listener + manual
focus/restore with the shared hook (which captures the hamburger trigger as the
restore target). The now-redundant `triggerRef` prop is removed and Header no
longer passes it.

Both now share one focus-management SSOT with `Modal` and `CartDrawer`.

## Verification (local — CI billing-blocked)

- `npm run typecheck` ✅
- `eslint` on all 3 changed files ✅
- `useFocusTrap` unit tests still green (7/7) ✅

🤖 Generated with [Claude Code](https://claude.com/claude-code)