### PR TITLE
fix(nav): repair 12 broken navigation i18n keys across all locales

### DIFF
--- a/messages/de.json
+++ b/messages/de.json
@@ -107,6 +107,7 @@
       "becomeMemberDesc": "Teil des Vereins werden und mitbestimmen",
       "contact": "Kontakt",
       "contactDesc": "Wir freuen uns auf dich",
+      "aboPools": "Abo-Pools",
       "aboPoolsDesc": "Digitale Abos teilen und Kosten aufteilen",
       "projectMonitorUpcycling": "Monitor-Upcycling",
       "projectMonitorUpcyclingDesc": "Aktiv · Wand- und Deckenleuchten aus ausgemusterten Bildschirmen, mit ZHAW-Ökobilanz und Swico-Förderung.",

--- a/messages/en.json
+++ b/messages/en.json
@@ -80,6 +80,7 @@
       "findHelpDesc": "Community technicians near you",
       "findTechnicianDesc": "Browse technician profiles and get in touch",
       "becomeTechnicianDesc": "Share IT knowledge and help others",
+      "aboPools": "Subscription Pools",
       "aboPoolsDesc": "Share digital subscriptions and split costs",
       "learnDesc": "Workshops, guides and resources",
       "workshopsDesc": "Book in-person courses",

--- a/messages/es.json
+++ b/messages/es.json
@@ -107,6 +107,7 @@
       "becomeMemberDesc": "Ser parte de la asociación y participar",
       "contact": "Contacto",
       "contactDesc": "Estamos deseando conocerte",
+      "aboPools": "Grupos de suscripción",
       "aboPoolsDesc": "Comparte suscripciones digitales y divide los costos",
       "projectMonitorUpcycling": "Monitor-Upcycling",
       "projectMonitorUpcyclingDesc": "Activo · luminarias de pared y techo a partir de monitores retirados, con ACV de la ZHAW y financiación Swico.",

--- a/messages/fr.json
+++ b/messages/fr.json
@@ -86,6 +86,7 @@
       "findHelpDesc": "Techniciens communautaires près de chez vous",
       "findTechnicianDesc": "Techniciens communautaires et professionnels",
       "becomeTechnicianDesc": "Partager des connaissances informatiques et aider les autres",
+      "aboPools": "Pools d'abonnements",
       "aboPoolsDesc": "Partager des abonnements numériques et diviser les coûts",
       "learnDesc": "Ateliers, guides et ressources",
       "workshopsDesc": "Réserver des cours en personne",

--- a/messages/it.json
+++ b/messages/it.json
@@ -107,6 +107,7 @@
       "becomeMemberDesc": "Entra nell'associazione e partecipa alle decisioni",
       "contact": "Contatto",
       "contactDesc": "Siamo felici di sentirti",
+      "aboPools": "Pool di abbonamenti",
       "aboPoolsDesc": "Condividi abbonamenti digitali e dividi i costi",
       "projectMonitorUpcycling": "Monitor-Upcycling",
       "projectMonitorUpcyclingDesc": "Attivo · plafoniere e applique da monitor dismessi, con LCA ZHAW e sostegno Swico.",

--- a/messages/ja.json
+++ b/messages/ja.json
@@ -107,6 +107,7 @@
       "becomeMemberDesc": "団体の一員として意思決定に参加する",
       "contact": "お問い合わせ",
       "contactDesc": "お待ちしています",
+      "aboPools": "サブスクリプションプール",
       "aboPoolsDesc": "デジタルサブスクリプションを共有してコストを分担",
       "projectMonitorUpcycling": "Monitor-Upcycling",
       "projectMonitorUpcyclingDesc": "進行中 · 廃棄モニターから壁面・天井照明へ。ZHAW によるライフサイクル評価と Swico の助成付き。",

--- a/messages/ko.json
+++ b/messages/ko.json
@@ -107,6 +107,7 @@
       "becomeMemberDesc": "단체의 일원이 되어 의사 결정에 참여",
       "contact": "문의",
       "contactDesc": "언제든지 연락해 주세요",
+      "aboPools": "구독 풀",
       "aboPoolsDesc": "디지털 구독을 공유하고 비용을 분담하세요",
       "projectMonitorUpcycling": "Monitor-Upcycling",
       "projectMonitorUpcyclingDesc": "진행 중 · 폐기된 모니터로 만드는 벽면·천장 조명. ZHAW LCA와 Swico 지원 포함.",

--- a/messages/ru.json
+++ b/messages/ru.json
@@ -107,6 +107,7 @@
       "becomeMemberDesc": "Стать частью организации и участвовать в решениях",
       "contact": "Контакты",
       "contactDesc": "Будем рады вашему обращению",
+      "aboPools": "Пулы подписок",
       "aboPoolsDesc": "Делитесь цифровыми подписками и расходами",
       "projectMonitorUpcycling": "Monitor-Upcycling",
       "projectMonitorUpcyclingDesc": "Активный · настенные и потолочные светильники из списанных мониторов, с LCA от ZHAW и поддержкой Swico.",

--- a/src/config/customer-journeys.ts
+++ b/src/config/customer-journeys.ts
@@ -24,12 +24,12 @@ export const CUSTOMER_JOURNEYS = {
         descriptionKey: 'communityListingsDesc',
       },
       {
-        nameKey: 'shopRevampIT',
+        nameKey: 'orgShop',
         href: `${ROUTES.public.marketplace}?seller_type=revampit`,
         descriptionKey: 'orgShopDesc',
       },
       {
-        nameKey: 'storeZurich',
+        nameKey: 'store',
         href: '/contact',
         descriptionKey: 'storeDesc',
       },

--- a/src/config/navigation.tsx
+++ b/src/config/navigation.tsx
@@ -74,7 +74,7 @@ export const mainNavigation: NavigationItem[] = [
       },
       {
         name: 'Unsere Wirkung',
-        nameKey: 'ourImpact',
+        nameKey: 'impact',
         href: '/about/impact',
         descriptionKey: 'impactDesc',
       },
@@ -158,7 +158,7 @@ export const mainNavigation: NavigationItem[] = [
       // Section: Hardware
       {
         name: 'Hardware',
-        nameKey: 'sectionHardware',
+        nameKey: 'hardware',
         href: '/services',
         isSection: true,
       },
@@ -183,7 +183,7 @@ export const mainNavigation: NavigationItem[] = [
       // Section: Software
       {
         name: 'Software',
-        nameKey: 'sectionSoftware',
+        nameKey: 'software',
         href: '/services',
         isSection: true,
       },
@@ -195,7 +195,7 @@ export const mainNavigation: NavigationItem[] = [
       },
       {
         name: 'Webentwicklung',
-        nameKey: 'webDevelopment',
+        nameKey: 'webDev',
         href: '/services/web-design-development',
         descriptionKey: 'webDevDesc',
       },
@@ -259,13 +259,13 @@ export const mainNavigation: NavigationItem[] = [
       // Section: Engagement
       {
         name: 'Engagement',
-        nameKey: 'sectionEngagement',
+        nameKey: 'engagement',
         href: '/get-involved',
         isSection: true,
       },
       {
         name: 'Freiwilligenarbeit',
-        nameKey: 'volunteering',
+        nameKey: 'volunteer',
         href: '/get-involved/volunteer',
         descriptionKey: 'volunteerDesc',
       },
@@ -277,14 +277,14 @@ export const mainNavigation: NavigationItem[] = [
       },
       {
         name: 'Wiedereinstieg',
-        nameKey: 'workReintegration',
+        nameKey: 'reintegration',
         href: '/get-involved/work-reintegration',
         descriptionKey: 'reintegrationDesc',
       },
       // Section: Unterstützen
       {
         name: 'Unterstützen',
-        nameKey: 'sectionSupport',
+        nameKey: 'support',
         href: '/get-involved',
         isSection: true,
       },
@@ -312,7 +312,7 @@ export const mainNavigation: NavigationItem[] = [
       // "Mitmachen" (volunteer time, donate, share resources).
       {
         name: 'Mitgliedschaft',
-        nameKey: 'sectionMembership',
+        nameKey: 'membership',
         href: '/mitglied-werden',
         isSection: true,
       },


### PR DESCRIPTION
## Bug 🐛 (found via live console inspection)

Opening the navigation menu logged **12 `MISSING_MESSAGE` errors**, and because
each nav item's German `name` field is the fallback, **every non-German visitor
saw German nav labels** (Webentwicklung, Freiwilligenarbeit, Mitgliedschaft, …)
— a real international-reach defect, not just console noise.

## Root cause

11 nav `nameKey`s were renamed in the config (`ourImpact`, `sectionHardware`,
`webDevelopment`, `volunteering`, `workReintegration`, `shopRevampIT`,
`storeZurich`, `sectionSoftware`, `sectionEngagement`, `sectionSupport`,
`sectionMembership`) but the message files never got the new names. Tell-tale:
each item's *own* `descriptionKey` still used the original stem
(`impactDesc`, `webDevDesc`, `volunteerDesc`, …) — the config was internally
inconsistent.

## Fix (SSOT + DRY)

Repoint the 11 renamed `nameKey`s back to their existing stems
(`impact`, `hardware`, `software`, `webDev`, `engagement`, `volunteer`,
`reintegration`, `support`, `membership`, `orgShop`, `store`) — these are
**already translated in all 7 locales**, so the nav localises correctly
everywhere with **zero duplicate keys**. Verified the stem values are the
intended labels (e.g. `impact`="Unsere Wirkung", `store`="Ladenlokal Zürich").

The 12th key, `aboPools`, was genuinely missing (only `aboPoolsDesc` existed) —
added the label to all 7 locales.

## Verification (local)

- Nav key reconciliation passes in **de/en/fr/it/es/ja/ko/ru** (0 missing) ✅
- `npm run typecheck` ✅
- `eslint` on both config files ✅
- `npm run lint:umlauts` ✅

🤖 Generated with [Claude Code](https://claude.com/claude-code)