### PR TITLE
fix(seo): stop doubling the brand in page <title> tags

### DIFF
--- a/src/app/[locale]/agb/page.tsx
+++ b/src/app/[locale]/agb/page.tsx
@@ -14,7 +14,7 @@ export async function generateMetadata({ params }: AGBPageProps): Promise<Metada
   const title = `${t('meta.title')} | ${ORG.name}`
   const description = t('meta.description')
   return {
-    title,
+    title: { absolute: title },
     description,
     openGraph: { title, description, type: 'website' },
   }

--- a/src/app/[locale]/contact/page.tsx
+++ b/src/app/[locale]/contact/page.tsx
@@ -18,7 +18,7 @@ export async function generateMetadata({ params }: { params: Promise<{ locale: s
   const title = `${t('meta.title')} | ${ORG.name}`
   const description = t('meta.description')
   return {
-    title,
+    title: { absolute: title },
     description,
     openGraph: { title, description, type: 'website' },
   }

--- a/src/app/[locale]/datenschutz/page.tsx
+++ b/src/app/[locale]/datenschutz/page.tsx
@@ -14,7 +14,7 @@ export async function generateMetadata({ params }: DatenschutzPageProps): Promis
   const title = `${t('meta.title')} | ${ORG.name}`
   const description = t('meta.description', { orgName: ORG.name })
   return {
-    title,
+    title: { absolute: title },
     description,
     openGraph: { title, description, type: 'website' },
   }

--- a/src/app/[locale]/faq/page.tsx
+++ b/src/app/[locale]/faq/page.tsx
@@ -21,7 +21,7 @@ export async function generateMetadata({ params }: FAQPageProps): Promise<Metada
   const title = `${t('meta.title')} | ${ORG.name}`
   const description = t('meta.description')
   return {
-    title,
+    title: { absolute: title },
     description,
     openGraph: { title, description, type: 'website' },
   }

--- a/src/app/[locale]/get-involved/donate/page.tsx
+++ b/src/app/[locale]/get-involved/donate/page.tsx
@@ -24,7 +24,7 @@ export async function generateMetadata({ params }: DonatePageProps): Promise<Met
   const title = `${t('meta.title')} | ${ORG.name}`
   const description = t('meta.description')
   return {
-    title,
+    title: { absolute: title },
     description,
     openGraph: { title, description, type: 'website' },
   }

--- a/src/app/[locale]/get-involved/internships/page.tsx
+++ b/src/app/[locale]/get-involved/internships/page.tsx
@@ -25,7 +25,7 @@ export async function generateMetadata({ params }: InternshipsPageProps): Promis
   const title = `${t('internships.meta.title')} | ${ORG.name}`
   const description = t('internships.meta.description')
   return {
-    title,
+    title: { absolute: title },
     description,
     openGraph: { title, description, type: 'website' },
   }

--- a/src/app/[locale]/get-involved/it-hilfe-techniker/page.tsx
+++ b/src/app/[locale]/get-involved/it-hilfe-techniker/page.tsx
@@ -25,7 +25,7 @@ export async function generateMetadata({ params }: ITHilfeTechnikerPageProps): P
   const title = `${t('itHilfeTechniker.meta.title')} | ${ORG.name}`
   const description = t('itHilfeTechniker.meta.description')
   return {
-    title,
+    title: { absolute: title },
     description,
     openGraph: { title, description, type: 'website' },
   }

--- a/src/app/[locale]/get-involved/kontakt/page.tsx
+++ b/src/app/[locale]/get-involved/kontakt/page.tsx
@@ -20,7 +20,7 @@ export async function generateMetadata({ params }: KontaktPageProps): Promise<Me
   const title = `${t('meta.title')} | ${ORG.name}`
   const description = t('meta.description')
   return {
-    title,
+    title: { absolute: title },
     description,
     openGraph: { title, description, type: 'website' },
   }

--- a/src/app/[locale]/get-involved/page.tsx
+++ b/src/app/[locale]/get-involved/page.tsx
@@ -41,7 +41,7 @@ export async function generateMetadata({ params }: GetInvolvedPageProps): Promis
   const title = `${t('meta.title')} | ${ORG.name}`
   const description = t('meta.description')
   return {
-    title,
+    title: { absolute: title },
     description,
     openGraph: { title, description, type: 'website' },
   }

--- a/src/app/[locale]/get-involved/partnerships/page.tsx
+++ b/src/app/[locale]/get-involved/partnerships/page.tsx
@@ -25,7 +25,7 @@ export async function generateMetadata({ params }: PartnershipsPageProps): Promi
   const title = `${t('partnerships.meta.title')} | ${ORG.name}`
   const description = t('partnerships.meta.description')
   return {
-    title,
+    title: { absolute: title },
     description,
     openGraph: { title, description, type: 'website' },
   }

--- a/src/app/[locale]/get-involved/technical-experts/page.tsx
+++ b/src/app/[locale]/get-involved/technical-experts/page.tsx
@@ -25,7 +25,7 @@ export async function generateMetadata({ params }: TechnicalExpertsPageProps): P
   const title = `${t('technicalExperts.meta.title')} | ${ORG.name}`
   const description = t('technicalExperts.meta.description')
   return {
-    title,
+    title: { absolute: title },
     description,
     openGraph: { title, description, type: 'website' },
   }

--- a/src/app/[locale]/get-involved/volunteer/page.tsx
+++ b/src/app/[locale]/get-involved/volunteer/page.tsx
@@ -25,7 +25,7 @@ export async function generateMetadata({ params }: VolunteerPageProps): Promise<
   const title = `${t('volunteer.meta.title')} | ${ORG.name}`
   const description = t('volunteer.meta.description')
   return {
-    title,
+    title: { absolute: title },
     description,
     openGraph: { title, description, type: 'website' },
   }

--- a/src/app/[locale]/get-involved/work-reintegration/page.tsx
+++ b/src/app/[locale]/get-involved/work-reintegration/page.tsx
@@ -25,7 +25,7 @@ export async function generateMetadata({ params }: WorkReintegrationPageProps): 
   const title = `${t('workReintegration.meta.title')} | ${ORG.name}`
   const description = t('workReintegration.meta.description')
   return {
-    title,
+    title: { absolute: title },
     description,
     openGraph: { title, description, type: 'website' },
   }

--- a/src/app/[locale]/impressum/page.tsx
+++ b/src/app/[locale]/impressum/page.tsx
@@ -14,7 +14,7 @@ export async function generateMetadata({ params }: ImpressumPageProps): Promise<
   const title = `${t('meta.title')} | ${ORG.name}`
   const description = t('meta.description')
   return {
-    title,
+    title: { absolute: title },
     description,
     openGraph: { title, description, type: 'website' },
   }

--- a/src/app/[locale]/it-hilfe/techniker/[id]/page.tsx
+++ b/src/app/[locale]/it-hilfe/techniker/[id]/page.tsx
@@ -23,23 +23,23 @@ export async function generateMetadata({ params }: Props): Promise<Metadata> {
   const { id, locale } = await params
   const t = await getTranslations({ locale, namespace: 'techniker' })
 
-  if (!UUID_RE.test(id)) return { title: `${t('meta.title')} | ${ORG.name}` }
+  if (!UUID_RE.test(id)) return { title: { absolute: `${t('meta.title')} | ${ORG.name}` } }
 
   try {
     const tech = await getTechnicianById(id)
-    if (!tech) return { title: `${t('meta.title')} | ${ORG.name}` }
+    if (!tech) return { title: { absolute: `${t('meta.title')} | ${ORG.name}` } }
     const tierLabel = tech.profileTier === 'professional' ? t('detail.professional') : t('detail.community')
     const displayName = tech.name ?? t('meta.title')
     const title = `${displayName} – ${tierLabel} | ${ORG.name}`
     const description = tech.bio ?? `${displayName} · ${tierLabel} · ${ORG.name}`
     return {
-      title,
+      title: { absolute: title },
       description,
       openGraph: { title, description, type: 'website' },
     }
   } catch (err) {
     logger.warn('Failed to generate technician metadata', { error: err })
-    return { title: `${t('meta.title')} | ${ORG.name}` }
+    return { title: { absolute: `${t('meta.title')} | ${ORG.name}` } }
   }
 }
 

--- a/src/app/[locale]/it-hilfe/techniker/page.tsx
+++ b/src/app/[locale]/it-hilfe/techniker/page.tsx
@@ -17,7 +17,7 @@ export async function generateMetadata({ params }: TechnikerPageProps): Promise<
   const title = `${t('meta.title')} | ${ORG.name}`
   const description = t('meta.description')
   return {
-    title,
+    title: { absolute: title },
     description,
     openGraph: { title, description, type: 'website' },
   }

--- a/src/app/[locale]/mitglied-werden/page.tsx
+++ b/src/app/[locale]/mitglied-werden/page.tsx
@@ -21,7 +21,7 @@ export async function generateMetadata({ params }: MitgliedWerdenPageProps): Pro
   const { locale } = await params
   const t = await getTranslations({ locale, namespace: 'mitgliedWerden' })
   return {
-    title: `${t('meta.title')} | ${ORG.name}`,
+    title: { absolute: `${t('meta.title')} | ${ORG.name}` },
     description: t('meta.description', { orgName: ORG.name, fee: MEMBERSHIP.fees.regular }),
     openGraph: {
       title: `${t('meta.title')} | ${ORG.name}`,

--- a/src/app/[locale]/revamped/page.tsx
+++ b/src/app/[locale]/revamped/page.tsx
@@ -29,7 +29,7 @@ export async function generateMetadata({ params }: RevampedPageProps): Promise<M
   const { locale } = await params
   const t = await getTranslations({ locale, namespace: 'revamped' })
   return {
-    title: `${t('meta.title')} | ${ORG.name}`,
+    title: { absolute: `${t('meta.title')} | ${ORG.name}` },
     description: t('meta.description'),
     openGraph: {
       title: `${t('meta.title')} | ${ORG.name}`,

--- a/src/app/[locale]/sellers/[id]/layout.tsx
+++ b/src/app/[locale]/sellers/[id]/layout.tsx
@@ -51,12 +51,12 @@ export async function generateMetadata({
   const t = await getTranslations({ locale, namespace: 'techniker.seller' })
 
   if (!UUID_RE.test(id)) {
-    return { title: `${t('meta.titleFallback')} | ${ORG.name}` }
+    return { title: { absolute: `${t('meta.titleFallback')} | ${ORG.name}` } }
   }
 
   const seller = await getSellerMeta(id)
   if (!seller) {
-    return { title: `${t('meta.titleFallback')} | ${ORG.name}` }
+    return { title: { absolute: `${t('meta.titleFallback')} | ${ORG.name}` } }
   }
 
   const name = seller.display_name || seller.user_name || ORG.name
@@ -68,7 +68,7 @@ export async function generateMetadata({
     : null
 
   return {
-    title,
+    title: { absolute: title },
     description,
     openGraph: {
       title,

--- a/src/app/[locale]/services/[service]/layout.tsx
+++ b/src/app/[locale]/services/[service]/layout.tsx
@@ -10,7 +10,7 @@ export async function generateMetadata({
   const { locale } = await params
   const t = await getTranslations({ locale, namespace: 'services.meta' })
   return {
-    title: `${t('serviceDetailTitle')} | ${ORG.name}`,
+    title: { absolute: `${t('serviceDetailTitle')} | ${ORG.name}` },
     description: t('serviceDetailDesc'),
   }
 }

--- a/src/app/[locale]/services/[service]/page.tsx
+++ b/src/app/[locale]/services/[service]/page.tsx
@@ -28,7 +28,7 @@ export async function generateMetadata({ params }: { params: Promise<{ service: 
 
   if (!service) {
     return {
-      title: `Service Not Found | ${ORG.name}`,
+      title: { absolute: `Service Not Found | ${ORG.name}` },
       description: 'The requested service could not be found.',
     }
   }
@@ -36,7 +36,7 @@ export async function generateMetadata({ params }: { params: Promise<{ service: 
   // Special SEO metadata for data recovery
   if (slug === 'data-recovery-transfer') {
     return {
-      title: `Data Recovery & Transfer Services Zurich | ${ORG.name}`,
+      title: { absolute: `Data Recovery & Transfer Services Zurich | ${ORG.name}` },
       description: 'Professional data recovery and transfer services in Zurich. Recover data from old computers, transfer files between devices, access legacy media (floppy disks, ZIP drives, MO drives). Base fee CHF 30.',
       keywords: [
         'data recovery zurich',
@@ -60,7 +60,7 @@ export async function generateMetadata({ params }: { params: Promise<{ service: 
   }
 
   return {
-    title: `${service.name} | ${ORG.name}`,
+    title: { absolute: `${service.name} | ${ORG.name}` },
     description: service.description,
     openGraph: {
       title: `${service.name} | ${ORG.name}`,

--- a/src/app/[locale]/services/[service]/repair/page.tsx
+++ b/src/app/[locale]/services/[service]/repair/page.tsx
@@ -23,7 +23,7 @@ export async function generateMetadata({ params }: Props): Promise<Metadata> {
   const title = `${t('meta.title')} | ${ORG.name}`
   const description = t('meta.description')
   return {
-    title,
+    title: { absolute: title },
     description,
     openGraph: { title, description, type: 'website' },
   }

--- a/src/app/[locale]/services/build-your-computer/layout.tsx
+++ b/src/app/[locale]/services/build-your-computer/layout.tsx
@@ -2,7 +2,7 @@ import { Metadata } from 'next'
 import { ORG } from '@/config/org'
 
 export const metadata: Metadata = {
-  title: `AI-Powered Sustainable Computer Builds | ${ORG.name}`,
+  title: { absolute: `AI-Powered Sustainable Computer Builds | ${ORG.name}` },
   description: 'Revolutionary AI system that scans global inventory networks to build custom computers using primarily used and refurbished components. 100% sustainable builds with global parts sourcing.',
   keywords: [
     'sustainable computer build',

--- a/src/app/[locale]/services/hardware-recycling/page.tsx
+++ b/src/app/[locale]/services/hardware-recycling/page.tsx
@@ -34,7 +34,7 @@ export async function generateMetadata({ params }: HardwareRecyclingPageProps): 
   const { locale } = await params
   const t = await getTranslations({ locale, namespace: 'services.hardwareRecycling' })
   return {
-    title: `${t('meta.title')} | ${ORG.name}`,
+    title: { absolute: `${t('meta.title')} | ${ORG.name}` },
     description: t('meta.description'),
     openGraph: {
       title: `${t('meta.ogTitle')} | ${ORG.name}`,

--- a/src/app/[locale]/services/linux-open-source/page.tsx
+++ b/src/app/[locale]/services/linux-open-source/page.tsx
@@ -47,7 +47,7 @@ export async function generateMetadata({ params }: LinuxPageProps): Promise<Meta
   const title = `${t('meta.title')} | ${ORG.name}`
   const description = t('meta.description')
   return {
-    title,
+    title: { absolute: title },
     description,
     openGraph: { title, description, type: 'website' },
   }

--- a/src/app/[locale]/services/open-source-solutions/[slug]/page.tsx
+++ b/src/app/[locale]/services/open-source-solutions/[slug]/page.tsx
@@ -23,13 +23,13 @@ export async function generateMetadata({
   const alternative = getAlternativeById(slug)
 
   if (!alternative) {
-    return { title: `${t('detail.notFound')} | ${ORG.name}` }
+    return { title: { absolute: `${t('detail.notFound')} | ${ORG.name}` } }
   }
 
   const category = getCategoryById(alternative.categoryId)
 
   return {
-    title: `${alternative.name} — ${alternative.tagline} | ${ORG.name}`,
+    title: { absolute: `${alternative.name} — ${alternative.tagline} | ${ORG.name}` },
     description: alternative.description.slice(0, 160),
     openGraph: {
       title: `${alternative.name} — ${t('detail.openSourceAlternative')} | ${ORG.name}`,

--- a/src/app/[locale]/services/open-source-solutions/page.tsx
+++ b/src/app/[locale]/services/open-source-solutions/page.tsx
@@ -24,7 +24,7 @@ export async function generateMetadata({
   const title = `${t('meta.title')} | ${ORG.name}`
   const description = t('meta.description')
   return {
-    title,
+    title: { absolute: title },
     description,
     keywords: t.raw('meta.keywords') as string[],
     openGraph: { title, description, type: 'website' },

--- a/src/app/[locale]/services/web-design-development/layout.tsx
+++ b/src/app/[locale]/services/web-design-development/layout.tsx
@@ -2,7 +2,7 @@ import { Metadata } from 'next'
 import { ORG } from '@/config/org'
 
 export const metadata: Metadata = {
-  title: `Web Design & Development | ${ORG.name}`,
+  title: { absolute: `Web Design & Development | ${ORG.name}` },
   description: 'Professional web design and development services using open source technologies. Modern, responsive websites built with sustainability and performance in mind.',
   openGraph: {
     title: `Web Design & Development | ${ORG.name}`,

--- a/src/app/[locale]/services/web-design-development/page.tsx
+++ b/src/app/[locale]/services/web-design-development/page.tsx
@@ -20,7 +20,7 @@ export async function generateMetadata({ params }: { params: Promise<{ locale: s
   const { locale } = await params
   const t = await getTranslations({ locale, namespace: 'services.webDesign.meta' })
   return {
-    title: `${t('title')} | ${ORG.name}`,
+    title: { absolute: `${t('title')} | ${ORG.name}` },
     description: t('description'),
     openGraph: {
       title: `${t('title')} | ${ORG.name}`,

--- a/src/app/[locale]/space/page.tsx
+++ b/src/app/[locale]/space/page.tsx
@@ -22,7 +22,7 @@ export async function generateMetadata({ params }: SpacePageProps): Promise<Meta
   const title = `${t('meta.title')} | ${ORG.name}`
   const description = t('meta.description')
   return {
-    title,
+    title: { absolute: title },
     description,
     openGraph: { title, description, type: 'website' },
   }

--- a/src/app/[locale]/support/page.tsx
+++ b/src/app/[locale]/support/page.tsx
@@ -19,7 +19,7 @@ export async function generateMetadata({ params }: SupportPageProps): Promise<Me
   const title = `${t('meta.title')} | ${ORG.name}`
   const description = t('meta.description')
   return {
-    title,
+    title: { absolute: title },
     description,
     openGraph: { title, description, type: 'website' },
   }

--- a/src/app/[locale]/transparenz/page.tsx
+++ b/src/app/[locale]/transparenz/page.tsx
@@ -20,7 +20,7 @@ export async function generateMetadata({ params }: TransparenzPageProps): Promis
   const { locale } = await params
   const t = await getTranslations({ locale, namespace: 'transparenz' })
   return {
-    title: `${t('meta.title')} | ${ORG.name}`,
+    title: { absolute: `${t('meta.title')} | ${ORG.name}` },
     description: t('meta.description', { orgName: ORG.name }),
     openGraph: {
       title: `${t('meta.title')} | ${ORG.name}`,

--- a/src/app/[locale]/workshops/[slug]/page.tsx
+++ b/src/app/[locale]/workshops/[slug]/page.tsx
@@ -31,14 +31,14 @@ export async function generateMetadata({ params }: Props): Promise<Metadata> {
 
   if (!workshop) {
     return {
-      title: `${t('detail.notFound')} | ${ORG.name}`,
+      title: { absolute: `${t('detail.notFound')} | ${ORG.name}` },
     }
   }
 
   const description = workshop.short_description || workshop.description || undefined
 
   return {
-    title: `${workshop.title} | ${ORG.name} ${t('meta.title')}`,
+    title: { absolute: `${workshop.title} | ${ORG.name} ${t('meta.title')}` },
     description,
     openGraph: {
       title: `${workshop.title} | ${ORG.name} ${t('meta.title')}`,

--- a/src/app/[locale]/workshops/page.tsx
+++ b/src/app/[locale]/workshops/page.tsx
@@ -20,7 +20,7 @@ export async function generateMetadata({ params }: { params: Promise<{ locale: s
   const { locale } = await params
   const t = await getTranslations({ locale, namespace: 'workshops.meta' })
   return {
-    title: `${t('title')} | ${ORG.name}`,
+    title: { absolute: `${t('title')} | ${ORG.name}` },
     description: t('description'),
     openGraph: {
       title: `${t('title')} | ${ORG.name}`,

--- a/src/app/dashboard/blog-submissions/page.tsx
+++ b/src/app/dashboard/blog-submissions/page.tsx
@@ -9,7 +9,7 @@ export async function generateMetadata(): Promise<Metadata> {
   const locale = await getLocale()
   const t = await getTranslations({ locale, namespace: 'dashboard.meta' })
   return {
-    title: `${t('blogSubmissionsTitle')} | ${ORG.name}`,
+    title: { absolute: `${t('blogSubmissionsTitle')} | ${ORG.name}` },
     description: t('blogSubmissionsDesc'),
   }
 }

--- a/src/app/dashboard/techniker/page.tsx
+++ b/src/app/dashboard/techniker/page.tsx
@@ -20,7 +20,7 @@ export async function generateMetadata(): Promise<Metadata> {
   const locale = await getLocale()
   const t = await getTranslations({ locale, namespace: 'dashboard.meta' })
   return {
-    title: `${t('technikerTitle')} | ${ORG.name}`,
+    title: { absolute: `${t('technikerTitle')} | ${ORG.name}` },
     description: t('technikerDesc'),
   }
 }

--- a/src/app/services/[service]/page.tsx
+++ b/src/app/services/[service]/page.tsx
@@ -32,7 +32,7 @@ export async function generateMetadata({ params }: { params: Promise<{ service: 
   if (slug === 'data-recovery-transfer') {
     const city = LOCATIONS.store.city
     return {
-      title: `Data Recovery & Transfer Services ${city} | ${ORG.name}`,
+      title: { absolute: `Data Recovery & Transfer Services ${city} | ${ORG.name}` },
       description: `Professional data recovery and transfer services in ${city}. Recover data from old computers, transfer files between devices, access legacy media (floppy disks, ZIP drives, MO drives). Base fee CHF 30.`,
       keywords: [
         'data recovery zurich',


### PR DESCRIPTION
## Bug 🐛 (verified live)

Page titles render the brand twice: **"Mitmachen | Revamp-IT | Revamp-IT"**,
**"Marktplatz … | Revamp-IT | Revamp-IT"**, etc.

Cause: page metadata builds a fully-branded title (`${t('meta.title')} |
Revamp-IT`) **and** the parent `[locale]/layout.tsx` defines
`title.template: '%s | Revamp-IT'`, so Next.js appends the brand a second time.
`og:title` was already correct (the template never applies to OpenGraph).

## Fix

Wrap each **top-level** metadata `title` in `{ absolute: … }` so it opts out of
the parent template and renders the branded string exactly once. This is the
minimal, per-page-faithful fix — the exact intended title is preserved.

- `openGraph` / `twitter` titles: **untouched** (already correct)
- `title.template` / `title.default`: **untouched**
- 37 page/layout files, 1:1 line changes
- `auth/register` intentionally skipped — it sets `document.title` imperatively
  in a client component (no template applies)

## Verification (local)

- `npm run typecheck` ✅
- `eslint` on all 37 changed files ✅
- Diff audited: no `openGraph`/`twitter` title was wrapped; only top-level
  metadata titles changed ✅
- Will confirm a few live titles post-deploy.

🤖 Generated with [Claude Code](https://claude.com/claude-code)