### PR TITLE
fix(seo): de-double <title> in marketplace/services/projects layouts

### DIFF
--- a/src/app/[locale]/marketplace/layout.tsx
+++ b/src/app/[locale]/marketplace/layout.tsx
@@ -12,7 +12,7 @@ export async function generateMetadata({
   const title = `${t('layoutTitle')} | ${ORG.name}`
   const description = t('description')
   return {
-    title,
+    title: { absolute: title },
     description,
     openGraph: {
       title,

--- a/src/app/[locale]/projects/layout.tsx
+++ b/src/app/[locale]/projects/layout.tsx
@@ -12,7 +12,9 @@ export async function generateMetadata({
   return {
     title: {
       template: `%s | ${ORG.name} ${t('templateSuffix')}`,
-      default: `${t('layoutTitle')} | ${ORG.name}`,
+      // Bare — the parent [locale] template (`%s | ORG`) appends the brand.
+      // Including it here too rendered "… | Revamp-IT | Revamp-IT".
+      default: t('layoutTitle'),
     },
     description: t('description'),
   }

--- a/src/app/[locale]/services/layout.tsx
+++ b/src/app/[locale]/services/layout.tsx
@@ -12,7 +12,7 @@ export async function generateMetadata({
   const title = `${t('layoutTitle')} | ${ORG.name}`
   const description = t('description')
   return {
-    title,
+    title: { absolute: title },
     description,
     openGraph: {
       title,


### PR DESCRIPTION
## What

Follow-up to #155. That sweep fixed page-level metadata but **excluded
layouts**, so three high-traffic routes were still doubling the brand
(confirmed live):

| Route | Before |
|-------|--------|
| `/marketplace` | Marktplatz … \| Revamp-IT \| Revamp-IT |
| `/services` | Computer Reparatur … \| Revamp-IT \| Revamp-IT |
| `/projects` | Unsere Projekte \| Revamp-IT \| Revamp-IT |

## Fix

- **marketplace/layout**, **services/layout**: wrap the top-level metadata
  `title` in `{ absolute }` (same fix as the pages).
- **projects/layout**: its `title.default` carried the brand *and* the parent
  `[locale]` template re-added it → made the default bare (`t('layoutTitle')`)
  so the brand lands exactly once.

`auth/layout` has the same `default` shape but is `robots: noindex` (no SEO
impact) and its pages set their own titles — left untouched.

## Verification

- `npm run typecheck` ✅
- `eslint` ✅
- Will confirm the three routes live post-deploy.

🤖 Generated with [Claude Code](https://claude.com/claude-code)