### PR TITLE
fix(services): remove dead /grid.svg reference from ServiceHero (404)

### DIFF
--- a/src/components/services/ServiceHero.tsx
+++ b/src/components/services/ServiceHero.tsx
@@ -15,7 +15,6 @@ interface ServiceHeroProps {
 export default function ServiceHero({ hero }: ServiceHeroProps) {
   return (
     <section className="relative bg-action text-white py-12 sm:py-16 md:py-20 lg:py-24 overflow-hidden">
-      <div className="absolute inset-0 bg-[url('/grid.svg')] opacity-10"></div>
       <div className="container mx-auto px-4 sm:px-6 relative">
         <div className="max-w-3xl">
           <Heading level={1} className="text-3xl sm:text-4xl md:text-5xl lg:text-6xl font-bold mb-4 sm:mb-6 leading-tight">{hero.title}</Heading>


### PR DESCRIPTION
## Bug 🐛 (found via live console inspection)

`/services/computer-repair-upgrades` (and every service detail page) logged a
console **404 for `/grid.svg`**. `ServiceHero` had a decorative overlay
`<div className="… bg-[url('/grid.svg')] opacity-10">`, but **grid.svg was
never in the repo** (no git history) — so the asset always 404'd and the
overlay never rendered.

## Fix

Removed the dead overlay div. The hero is visually identical (it has been live
without the asset all along), the per-page 404 is gone, and an arbitrary-value
`bg-[url(...)]` className is removed (design-system cleanliness).

## Verification

- `npm run typecheck` ✅ · `eslint` ✅
- Confirmed no other `bg-[url('/…')]` local-asset references exist.

🤖 Generated with [Claude Code](https://claude.com/claude-code)