### PR TITLE
test(assets): guard that every url('/…') reference exists in public/

### DIFF
--- a/src/config/__tests__/local-asset-urls-exist.test.ts
+++ b/src/config/__tests__/local-asset-urls-exist.test.ts
@@ -1,0 +1,55 @@
+/**
+ * Guard: every local asset referenced via CSS `url('/…')` must exist in public/.
+ *
+ * ServiceHero shipped `bg-[url('/grid.svg')]` for an asset that was never in
+ * the repo — every service page fired a 404 and the overlay never rendered
+ * (PR #158). Such references are usually boilerplate/template leftovers and are
+ * invisible to tsc/eslint. This scans source for `url('/…')` paths and asserts
+ * the corresponding file exists under public/.
+ *
+ * Scope: only `url(...)` references with a root-relative literal path
+ * (starts with `/`). Dynamic srcs, external URLs and data: URIs are ignored —
+ * this targets exactly the static-asset class that 404'd.
+ */
+
+import { readFileSync, readdirSync, statSync, existsSync } from 'node:fs'
+import { join } from 'node:path'
+
+const ROOT = join(__dirname, '../../..')
+const SRC_DIR = join(ROOT, 'src')
+const PUBLIC_DIR = join(ROOT, 'public')
+
+function walk(dir: string, out: string[]): void {
+  for (const entry of readdirSync(dir)) {
+    if (entry === 'node_modules' || entry === '__tests__') continue
+    const full = join(dir, entry)
+    if (statSync(full).isDirectory()) walk(full, out)
+    else if (/\.(tsx?|css)$/.test(entry)) out.push(full)
+  }
+}
+
+// url('/path'), url("/path"), url(/path) — capture the root-relative path.
+const URL_RE = /url\(\s*['"]?(\/[^'")]+?)['"]?\s*\)/g
+
+describe('local asset urls', () => {
+  it('every url(\'/…\') reference resolves to a file in public/', () => {
+    const files: string[] = []
+    walk(SRC_DIR, files)
+
+    const missing: string[] = []
+    for (const file of files) {
+      const src = readFileSync(file, 'utf8')
+      let m: RegExpExecArray | null
+      URL_RE.lastIndex = 0
+      while ((m = URL_RE.exec(src)) !== null) {
+        const ref = m[1].split(/[?#]/)[0] // strip query/hash
+        if (ref.startsWith('//')) continue // protocol-relative external
+        if (!existsSync(join(PUBLIC_DIR, ref))) {
+          missing.push(`${file.replace(ROOT + '/', '')} → url(${ref}) [not found in public/]`)
+        }
+      }
+    }
+
+    expect(missing).toEqual([])
+  })
+})


### PR DESCRIPTION
## What

Companion guard to #158. `ServiceHero` referenced `bg-[url('/grid.svg')]` for
an asset that was never in the repo — a 404 on every service page, invisible to
tsc/eslint, caught only by live console inspection.

This test scans all `src/**/*.{ts,tsx,css}` for root-relative `url('/…')`
references and asserts each resolves to a file under `public/`. Boilerplate
leftovers can't silently 404 again.

- Scope: only `url(...)` with a root-relative literal path. Dynamic srcs,
  external and `data:` URLs are out of scope.
- Runs in the existing CI test job.

## Proof

Reintroduced `bg-[url('/grid.svg')]` → test **failed** with
`ServiceHero.tsx → url(/grid.svg) [not found in public/]`. Reverted → passes.

## Verification

- `npx jest .../local-asset-urls-exist.test.ts` → passes ✅
- `npm run typecheck` ✅ · `eslint` ✅

🤖 Generated with [Claude Code](https://claude.com/claude-code)