### PR TITLE
test(seo): guard message *.meta.title against brand suffixes (+ fix shop)

### DIFF
--- a/messages/de.json
+++ b/messages/de.json
@@ -452,7 +452,7 @@
   },
   "shop": {
     "meta": {
-      "title": "Refurbished IT kaufen | Revamp-IT",
+      "title": "Refurbished IT kaufen",
       "description": "Tested refurbished computers, laptops, monitors, and accessories directly from the Revamp-IT shop in Zurich.",
       "productNotFound": "Produkt nicht gefunden",
       "productFallbackDesc": "{brand} {model} — geprüft und aufbereitet von {orgName}"

--- a/messages/en.json
+++ b/messages/en.json
@@ -460,7 +460,7 @@
   },
   "shop": {
     "meta": {
-      "title": "Buy refurbished IT | Revamp-IT",
+      "title": "Buy refurbished IT",
       "description": "Tested refurbished computers, laptops, monitors, and accessories directly from the Revamp-IT shop in Zurich.",
       "productNotFound": "Product not found",
       "productFallbackDesc": "{brand} {model} — inspected and refurbished by {orgName}"

--- a/messages/es.json
+++ b/messages/es.json
@@ -6883,7 +6883,7 @@
   },
   "shop": {
     "meta": {
-      "title": "Buy refurbished IT | Revamp-IT",
+      "title": "Buy refurbished IT",
       "description": "Tested refurbished computers, laptops, monitors, and accessories directly from the Revamp-IT shop in Zurich.",
       "productNotFound": "Producto no encontrado",
       "productFallbackDesc": "{brand} {model} — inspeccionado y reacondicionado por {orgName}"

--- a/messages/fr.json
+++ b/messages/fr.json
@@ -460,7 +460,7 @@
   },
   "shop": {
     "meta": {
-      "title": "Buy refurbished IT | Revamp-IT",
+      "title": "Buy refurbished IT",
       "description": "Tested refurbished computers, laptops, monitors, and accessories directly from the Revamp-IT shop in Zurich.",
       "productNotFound": "Produit introuvable",
       "productFallbackDesc": "{brand} {model} — inspecté et remis à neuf par {orgName}"

--- a/messages/it.json
+++ b/messages/it.json
@@ -6883,7 +6883,7 @@
   },
   "shop": {
     "meta": {
-      "title": "Buy refurbished IT | Revamp-IT",
+      "title": "Buy refurbished IT",
       "description": "Tested refurbished computers, laptops, monitors, and accessories directly from the Revamp-IT shop in Zurich.",
       "productNotFound": "Prodotto non trovato",
       "productFallbackDesc": "{brand} {model} — ispezionato e ricondizionato da {orgName}"

--- a/messages/ja.json
+++ b/messages/ja.json
@@ -6853,7 +6853,7 @@
   },
   "shop": {
     "meta": {
-      "title": "Buy refurbished IT | Revamp-IT",
+      "title": "Buy refurbished IT",
       "description": "Tested refurbished computers, laptops, monitors, and accessories directly from the Revamp-IT shop in Zurich.",
       "productNotFound": "商品が見つかりません",
       "productFallbackDesc": "{brand} {model} — {orgName}により検査・整備済み"

--- a/messages/ko.json
+++ b/messages/ko.json
@@ -6853,7 +6853,7 @@
   },
   "shop": {
     "meta": {
-      "title": "Buy refurbished IT | Revamp-IT",
+      "title": "Buy refurbished IT",
       "description": "Tested refurbished computers, laptops, monitors, and accessories directly from the Revamp-IT shop in Zurich.",
       "productNotFound": "제품을 찾을 수 없습니다",
       "productFallbackDesc": "{brand} {model} — {orgName}가 검사 및 재건한 제품"

--- a/messages/ru.json
+++ b/messages/ru.json
@@ -447,7 +447,7 @@
   },
   "shop": {
     "meta": {
-      "title": "Buy refurbished IT | Revamp-IT",
+      "title": "Buy refurbished IT",
       "description": "Tested refurbished computers, laptops, monitors, and accessories directly from the Revamp-IT shop in Zurich.",
       "productNotFound": "Товар не найден",
       "productFallbackDesc": "{brand} {model} — проверено и восстановлено {orgName}"

--- a/src/config/__tests__/no-brand-suffix-in-message-titles.test.ts
+++ b/src/config/__tests__/no-brand-suffix-in-message-titles.test.ts
@@ -1,0 +1,48 @@
+/**
+ * Guard: no i18n `*.meta.title` value may end with a brand suffix.
+ *
+ * Page metadata titles built from messages (`title: t.raw('…').meta.title`)
+ * are wrapped by a layout `title.template` ('%s | Revamp-IT[ Projekte]'),
+ * which appends the brand. A message value that ALSO ends with `| Revamp-IT`
+ * (or the no-hyphen `| RevampIT`) renders the brand twice — e.g. the upcycling
+ * minisite shipped "Monitor-Upcycling | RevampIT | Revamp-IT Projekte"
+ * (PR #160). The source-side guard (no-doubled-title-brand) can't see this —
+ * the title originates in message JSON, not a .tsx file.
+ *
+ * Rule: a `meta.title` must carry only the page-specific part; the template
+ * adds the brand. A trailing `| <brand>` is therefore always wrong. The brand
+ * appearing mid-sentence ("Support RevampIT") is fine and not flagged.
+ */
+
+import { readdirSync, readFileSync } from 'node:fs'
+import { join } from 'node:path'
+
+const MESSAGES_DIR = join(__dirname, '../../../messages')
+const BRAND_SUFFIX = /\| (?:RevampIT|Revamp-IT)\s*$/
+
+function collectMetaTitles(obj: unknown, path: string, out: Array<{ path: string; value: string }>): void {
+  if (obj === null || typeof obj !== 'object') return
+  for (const [key, val] of Object.entries(obj as Record<string, unknown>)) {
+    const next = path ? `${path}.${key}` : key
+    if (key === 'title' && typeof val === 'string' && path.endsWith('.meta')) {
+      out.push({ path: next, value: val })
+    }
+    collectMetaTitles(val, next, out)
+  }
+}
+
+describe('no brand suffix in message titles', () => {
+  const localeFiles = readdirSync(MESSAGES_DIR).filter((f) => /^[a-z]{2}\.json$/.test(f))
+
+  it.each(localeFiles)('%s: no *.meta.title ends with a brand suffix', (file) => {
+    const messages = JSON.parse(readFileSync(join(MESSAGES_DIR, file), 'utf8'))
+    const titles: Array<{ path: string; value: string }> = []
+    collectMetaTitles(messages, '', titles)
+
+    const offenders = titles
+      .filter((t) => BRAND_SUFFIX.test(t.value))
+      .map((t) => `${t.path} = ${JSON.stringify(t.value)}`)
+
+    expect(offenders).toEqual([])
+  })
+})


### PR DESCRIPTION
## What

Closes the gap that let the upcycling doubled-brand titles (#160) ship. A title
that lives in i18n **message JSON** and flows into `metadata.title` via
`t.raw(...).meta.title` is invisible to the source-side guard (#157).

New guard scans all locale files: **no `*.meta.title` may end with a brand
suffix** (`| Revamp-IT` or the no-hyphen `| RevampIT`) — the layout template
appends the brand, so a trailing brand always doubles. Mid-sentence brand
mentions ("Support RevampIT", "seller on the RevampIT Marketplace") are fine
and not flagged.

It found one remaining offender — `shop.meta.title` (`… | Revamp-IT`) — so that
suffix is stripped across all 8 locales. `/shop` redirects to `/marketplace`
and the key is only loaded by loading/error skeletons, so this is harmless
cleanup that keeps the guard exemption-free.

## Proof

Reintroduced `| RevampIT` on a shop title → guard **failed** naming
`shop.meta.title`. Reverted/stripped → 8/8 locales pass.

## Verification

- `npx jest .../no-brand-suffix-in-message-titles.test.ts` → 8/8 ✅
- `npm run typecheck` ✅ · `eslint` ✅

🤖 Generated with [Claude Code](https://claude.com/claude-code)