### PR TITLE
refactor(lifecycle): race-safe transition guard across IT-Hilfe, orders, appointments

### DIFF
--- a/docs/ARCHITECTURE_DEBT.md
+++ b/docs/ARCHITECTURE_DEBT.md
@@ -1,8 +1,8 @@
 # Architecture Debt — Parallel Implementations + Spaghetti Patterns
 
 **Created:** 2026-06-04  
-**Last Modified:** 2026-06-19  
-**Last Modified Summary:** Phase 3 — admin dashboard 404 links, workshop notification hrefs, IT-Hilfe single-email notifications
+**Last Modified:** 2026-06-29  
+**Last Modified Summary:** #4 — race-safe lifecycle transition guard (`src/lib/lifecycle`) adopted by IT-Hilfe + orders + appointments (Phase 1)
 
 **Last updated:** 2026-06-15 (auth/onboarding cleanup + notification pipeline closed)
 
@@ -158,6 +158,38 @@ approval flow in repair bookings) keeps its specific enum.
 
 **Estimated effort:** 2-3 hours. Risk: minimal — additive layer, doesn't
 change existing enums.
+
+---
+
+## #4 — Lifecycle transition engine (request→accept→complete→review)
+
+**Status:** Phase 1 ✓ DONE (2026-06-29). Phase 2 deferred.
+
+The three flows — IT-Hilfe peer-repair, service appointments, marketplace
+orders — are each "a row with a `status` column moving through role-gated
+actions". They independently re-implemented the read-validate-write step, and
+only IT-Hilfe did it race-safely (and duplicated that 3×). Decided model:
+**"shared core, separate flows"** — share the engine, keep the three
+transition tables + side-effects distinct.
+
+**Phase 1 — race-safe transition guard (`src/lib/lifecycle/guardedTransition`):**
+`SELECT … FOR UPDATE` → re-check the precondition under the lock → run the
+flow's writes in the same transaction. `check(row, tx)` can read a second
+entity in the same tx (IT-Hilfe re-reads offer status — without `FOR UPDATE`,
+serializing on the request row). All three flows route through it:
+- IT-Hilfe (`accept-offer.ts`, `complete`, `confirm-review`) — collapsed the 3×
+  hand-rolled lock blocks; behavior-preserving (`createReview` stays post-commit).
+- Marketplace orders (`PATCH` + `confirm-receipt`) — both lock the same order
+  row, fixing a latent **double Payrexx-capture / double `total_sold`** on
+  concurrent or double-clicked completion. `captureTransaction` runs inside the
+  lock (relies on Payrexx idempotency by transaction id).
+- Appointments (`executeAppointmentUpdate`) — now takes `expectedStatus`;
+  generalized the `rate`-only compare-and-set to all transitions.
+
+**Phase 2 — deferred:** a declarative transition-table validator to replace the
+orders `STATUS_TRANSITIONS` matrix + appointments `buildActionUpdate` switch.
+IT-Hilfe's `VALID_REQUEST_TRANSITIONS` stays as-is (its OPEN→MATCHED is a
+two-entity offer acceptance, not a single-row transition).
 
 ---
 

--- a/src/app/api/appointments/[id]/route.ts
+++ b/src/app/api/appointments/[id]/route.ts
@@ -160,11 +160,16 @@ export const PATCH = withAuth<{ id: string }>(async (
 
     const { updateSet, newStatus } = result
 
-    // Execute the DB update
-    const updated = await executeAppointmentUpdate(appointmentId, action, updateSet)
+    // Execute the DB update race-safe — re-checks the status is unchanged
+    // (and, for 'rate', not yet rated) under a row lock before writing.
+    const updated = await executeAppointmentUpdate(appointmentId, action, updateSet, appointment.status)
 
-    if (!updated && action === 'rate') {
-      return apiBadRequest('Dieser Termin wurde bereits bewertet')
+    if (!updated) {
+      return apiBadRequest(
+        action === 'rate'
+          ? 'Dieser Termin wurde bereits bewertet'
+          : 'Der Status des Termins hat sich geändert. Bitte Seite neu laden.',
+      )
     }
 
     // Mirror a service-appointment rating into the canonical `reviews` table so

--- a/src/app/api/it-hilfe/requests/[id]/complete/route.ts
+++ b/src/app/api/it-hilfe/requests/[id]/complete/route.ts
@@ -16,6 +16,7 @@ import { ERROR_MESSAGES } from '@/config/error-messages'
 import { logger } from '@/lib/logger'
 import { REQUEST_STATUS, OFFER_STATUS } from '@/config/it-hilfe'
 import { notifyRequestCompleted } from '@/lib/it-hilfe/notifications'
+import { guardedTransition } from '@/lib/lifecycle'
 
 const UUID_REGEX = /^[0-9a-f]{8}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{12}$/i
 
@@ -83,42 +84,38 @@ export const POST = withAuth<{ id: string }>(async (
       )
     }
 
-    // Mark request as completed + bump helper totals (transactional).
+    // Mark request as completed + bump helper totals, race-safe.
     //
-    // Race: helper double-clicks "Mark complete". Both reads pass (request
-    // MATCHED, offer ACCEPTED, helperId matches). Without a lock both
+    // Race: helper double-clicks "Mark complete". Both reads above pass
+    // (request MATCHED, offer ACCEPTED, helperId matches). Without a lock both
     // transactions run — the status UPDATE is idempotent but the
-    // totalJobsCompleted increment double-fires, inflating the helper's
-    // job count by 1 per duplicate click. Lock the request row with
-    // FOR UPDATE inside the transaction and re-verify status === MATCHED;
-    // a race-loser sees status === 'completed' and aborts cleanly without
-    // re-incrementing. Same shape as 90bdbabf / cc89b7f6.
-    const raceWon = await db.transaction(async (tx) => {
-      const lockedReq = await tx.execute(sql`
-        SELECT status FROM ${sql.raw(reqTable)}
-        WHERE id = ${id}
-        FOR UPDATE
-      `)
-      const lockedStatus = (lockedReq.rows[0] as { status?: string } | undefined)?.status
-      if (lockedStatus !== REQUEST_STATUS.MATCHED) return false
+    // totalJobsCompleted increment double-fires, inflating the helper's job
+    // count by 1 per duplicate click. guardedTransition locks the request row
+    // (FOR UPDATE) and re-verifies status === MATCHED under the lock; a
+    // race-loser sees status === 'completed' (check fails) and aborts cleanly
+    // without re-incrementing.
+    const result = await guardedTransition<{ status: string }, void>({
+      lockTable: reqTable,
+      lockId: id,
+      check: (r) => r.status === REQUEST_STATUS.MATCHED,
+      apply: async (tx) => {
+        await tx
+          .update(itHilfeRequests)
+          .set({
+            status: REQUEST_STATUS.COMPLETED,
+            completedAt: sql`NOW()`,
+            completedBy: session.user.id,
+          })
+          .where(eq(itHilfeRequests.id, id))
 
-      await tx
-        .update(itHilfeRequests)
-        .set({
-          status: REQUEST_STATUS.COMPLETED,
-          completedAt: sql`NOW()`,
-          completedBy: session.user.id,
-        })
-        .where(eq(itHilfeRequests.id, id))
-
-      await tx
-        .update(repairerProfiles)
-        .set({ totalJobsCompleted: sql`${repairerProfiles.totalJobsCompleted} + 1` })
-        .where(eq(repairerProfiles.userId, session.user.id))
-      return true
+        await tx
+          .update(repairerProfiles)
+          .set({ totalJobsCompleted: sql`${repairerProfiles.totalJobsCompleted} + 1` })
+          .where(eq(repairerProfiles.userId, session.user.id))
+      },
     })
 
-    if (!raceWon) {
+    if (!result.ok) {
       // Idempotent: the request is already completed (likely by a sibling
       // double-click). Return success so the UI doesn't show an error for
       // what is essentially the desired end-state.

--- a/src/app/api/it-hilfe/requests/[id]/confirm-review/route.ts
+++ b/src/app/api/it-hilfe/requests/[id]/confirm-review/route.ts
@@ -18,6 +18,7 @@ import { logger } from '@/lib/logger'
 import { REQUEST_STATUS, REVIEW_MIN_CHARS } from '@/config/it-hilfe'
 import { notifyReviewReceived } from '@/lib/it-hilfe/notifications'
 import { createReview, findDuplicateReview } from '@/lib/reviews/create-review'
+import { guardedTransition } from '@/lib/lifecycle'
 
 const UUID_REGEX = /^[0-9a-f]{8}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{12}$/i
 
@@ -137,22 +138,20 @@ export const POST = withAuth<{ id: string }>(async (
     // transaction (the lock already serialized us past the race window;
     // if createReview itself fails after the stamp commits, the user
     // sees "already reviewed" on retry — paper cut, no data corruption.)
-    const raceWon = await db.transaction(async (tx) => {
-      const lockedReq = await tx.execute(sql`
-        SELECT reviewed_at FROM ${sql.raw(reqTable)}
-        WHERE id = ${id}
-        FOR UPDATE
-      `)
-      const lockedReviewedAt = (lockedReq.rows[0] as { reviewed_at?: string | null } | undefined)?.reviewed_at
-      if (lockedReviewedAt != null) return false
-      await tx
-        .update(itHilfeRequests)
-        .set({ reviewedAt: sql`NOW()` })
-        .where(eq(itHilfeRequests.id, id))
-      return true
+    const stamped = await guardedTransition<{ reviewed_at: string | null }, void>({
+      lockTable: reqTable,
+      lockId: id,
+      lockColumns: ['reviewed_at'],
+      check: (r) => r.reviewed_at == null,
+      apply: async (tx) => {
+        await tx
+          .update(itHilfeRequests)
+          .set({ reviewedAt: sql`NOW()` })
+          .where(eq(itHilfeRequests.id, id))
+      },
     })
 
-    if (!raceWon) {
+    if (!stamped.ok) {
       return apiBadRequest('Diese Anfrage wurde bereits bewertet')
     }
 

--- a/src/app/api/marketplace/orders/[id]/__tests__/route.test.ts
+++ b/src/app/api/marketplace/orders/[id]/__tests__/route.test.ts
@@ -186,15 +186,28 @@ const mockSelect = jest.fn()
 const mockUpdate = jest.fn()
 const mockSet = jest.fn()
 const mockUpdateWhere = jest.fn()
+// The FOR UPDATE lock select inside guardedTransition. Returns the row the
+// re-check sees under the lock; set per-test to simulate a race-loser (status
+// changed between the pre-lock fetch and acquiring the lock).
+const mockTxExecute = jest.fn()
 
-jest.mock('@/db', () => ({
-  db: {
-    select: (...args: unknown[]) => mockSelect(...args),
-    update: (...args: unknown[]) => { mockUpdate(...args); return { set: mockSet } },
-    insert: jest.fn(),
-    transaction: jest.fn(),
-  },
-}))
+jest.mock('@/db', () => {
+  const mkUpdate = (...args: unknown[]) => { mockUpdate(...args); return { set: mockSet } }
+  return {
+    db: {
+      select: (...args: unknown[]) => mockSelect(...args),
+      update: mkUpdate,
+      insert: jest.fn(),
+      // guardedTransition runs `db.transaction(cb)`; invoke cb with a fake tx
+      // exposing execute (the FOR UPDATE select) + update/select.
+      transaction: (cb: (tx: unknown) => unknown) => cb({
+        execute: (...a: unknown[]) => mockTxExecute(...a),
+        update: mkUpdate,
+        select: (...args: unknown[]) => mockSelect(...args),
+      }),
+    },
+  }
+})
 
 // ---------------------------------------------------------------------------
 // Imports (after all mocks)
@@ -285,6 +298,10 @@ beforeEach(() => {
   // Default update chain
   mockSet.mockReturnValue({ where: mockUpdateWhere })
   mockUpdateWhere.mockResolvedValue(undefined)
+
+  // Default: the FOR UPDATE lock sees the same status as the pre-lock fetch
+  // (no race). Tests override this to simulate a concurrent transition.
+  mockTxExecute.mockResolvedValue({ rows: [{ status: MOCK_ORDER.status }] })
 
   // Re-wire fire-and-forget email mocks — resetAllMocks() clears implementations,
   // and .catch() on undefined would throw inside the route handler
@@ -411,6 +428,41 @@ describe('PATCH /api/marketplace/orders/[id] — success (buyer cancels)', () =>
     await PATCH(makePatchRequest({ status: 'cancelled' }), makeContext())
     expect(mockUpdate).toHaveBeenCalled()
     expect(mockSet).toHaveBeenCalled()
+  })
+})
+
+// ============================================================================
+// PATCH /api/marketplace/orders/[id] — race safety (guardedTransition)
+//
+// The transition is now applied under a `SELECT ... FOR UPDATE` lock with a
+// re-check, so a caller whose pre-lock fetch saw a still-valid state but who
+// then loses the race (the row changed before it acquired the lock) aborts
+// WITHOUT writing or capturing payment. True FOR UPDATE serialization is a
+// Postgres guarantee (exercised in integration/E2E, not this mock); here we
+// verify the route's re-check wiring rejects a now-stale transition.
+// ============================================================================
+
+describe('PATCH /api/marketplace/orders/[id] — race-loser aborts cleanly', () => {
+  it('does not write or capture when the order changed under the lock', async () => {
+    const payrexx = require('@/lib/payments/payrexx-client')
+    // Pre-lock fetch sees a paid order (buyer cancel is valid)...
+    wireSelectReturning({ ...MOCK_ORDER, status: 'paid' })
+    mockValidateBody.mockReturnValueOnce({
+      success: true,
+      data: { status: 'cancelled', tracking_number: undefined, tracking_url: undefined },
+    })
+    // ...but under the lock the order is already 'cancelled' (a concurrent
+    // caller won). The re-check fails → apply is skipped.
+    mockTxExecute.mockResolvedValueOnce({ rows: [{ status: 'cancelled' }] })
+
+    const response = await PATCH(makePatchRequest({ status: 'cancelled' }), makeContext())
+
+    expect(response.status).toBe(400)
+    const body = await response.json()
+    expect(body.error).toMatch(/geändert/i)
+    expect(mockUpdate).not.toHaveBeenCalled()
+    expect(payrexx.cancelTransaction).not.toHaveBeenCalled()
+    expect(payrexx.captureTransaction).not.toHaveBeenCalled()
   })
 })
 

--- a/src/app/api/marketplace/orders/[id]/confirm-receipt/__tests__/route.test.ts
+++ b/src/app/api/marketplace/orders/[id]/confirm-receipt/__tests__/route.test.ts
@@ -157,13 +157,25 @@ const mockSelect = jest.fn()
 const mockUpdate = jest.fn()
 const mockSet = jest.fn()
 const mockUpdateWhere = jest.fn()
+// The FOR UPDATE lock select inside guardedTransition — the status the
+// re-check sees under the lock. Override per-test to simulate a race-loser.
+const mockTxExecute = jest.fn()
 
-jest.mock('@/db', () => ({
-  db: {
-    select: (...args: unknown[]) => mockSelect(...args),
-    update: (...args: unknown[]) => { mockUpdate(...args); return { set: mockSet } },
-  },
-}))
+jest.mock('@/db', () => {
+  const mkUpdate = (...args: unknown[]) => { mockUpdate(...args); return { set: mockSet } }
+  return {
+    db: {
+      select: (...args: unknown[]) => mockSelect(...args),
+      update: mkUpdate,
+      // guardedTransition runs `db.transaction(cb)`; invoke cb with a fake tx.
+      transaction: (cb: (tx: unknown) => unknown) => cb({
+        execute: (...a: unknown[]) => mockTxExecute(...a),
+        update: mkUpdate,
+        select: (...args: unknown[]) => mockSelect(...args),
+      }),
+    },
+  }
+})
 
 // ---------------------------------------------------------------------------
 // Imports (after all mocks)
@@ -249,6 +261,10 @@ beforeEach(() => {
   // Default update chain — returns itself for multiple parallel updates
   mockSet.mockReturnValue({ where: mockUpdateWhere })
   mockUpdateWhere.mockResolvedValue(undefined)
+
+  // Default: the FOR UPDATE lock sees the same (valid) status as the pre-lock
+  // fetch (no race). Tests override to simulate a concurrent transition.
+  mockTxExecute.mockResolvedValue({ rows: [{ status: MOCK_ORDER.status }] })
 
   // Re-wire fire-and-forget mocks
   const emailMod = require('@/lib/email')
@@ -345,5 +361,27 @@ describe('POST confirm-receipt — cart order (listingId null)', () => {
     wireSelectReturning({ ...MOCK_ORDER, listingId: null, listingTitle: null }, [])
     const response = await POST(makePostRequest(), makeContext())
     expect(response.status).toBe(404)
+  })
+})
+
+// confirm-receipt and PATCH both reach COMPLETED. They now lock the same order
+// row, so a caller that loses the race (the order left shipped/delivered before
+// it acquired the lock) must NOT capture the Payrexx hold or bump total_sold a
+// second time. True FOR UPDATE serialization is a Postgres guarantee; here we
+// verify the re-check skips apply when the locked status is no longer valid.
+describe('POST confirm-receipt — race-loser does not double-capture', () => {
+  it('skips capture + writes when the order already left shipped/delivered under the lock', async () => {
+    const payrexx = require('@/lib/payments/payrexx-client')
+    // Pre-lock fetch sees a shipped order (valid)...
+    wireSelectReturning({ ...MOCK_ORDER, status: 'shipped' })
+    // ...but under the lock it is already 'completed' (a concurrent caller won).
+    mockTxExecute.mockResolvedValueOnce({ rows: [{ status: 'completed' }] })
+
+    const response = await POST(makePostRequest(), makeContext())
+
+    // End-state is the same (completed); we report success without re-applying.
+    expect(response.status).toBe(200)
+    expect(mockUpdate).not.toHaveBeenCalled()
+    expect(payrexx.captureTransaction).not.toHaveBeenCalled()
   })
 })

--- a/src/app/api/marketplace/orders/[id]/confirm-receipt/route.ts
+++ b/src/app/api/marketplace/orders/[id]/confirm-receipt/route.ts
@@ -16,6 +16,8 @@ import { db } from '@/db'
 import { listings, marketplaceOrders, marketplaceOrderItems, sellerProfiles, users } from '@/db/schema'
 import { eq, sql, inArray } from 'drizzle-orm'
 import { ORDER_STATUS, LISTING_STATUS } from '@/config/marketplace'
+import { TABLE_NAMES } from '@/config/database'
+import { guardedTransition } from '@/lib/lifecycle'
 import { logger } from '@/lib/logger'
 import { captureTransaction } from '@/lib/payments/payrexx-client'
 import { sendCustomEmail } from '@/lib/email'
@@ -86,45 +88,66 @@ export const POST = withAuth<{ id: string }>(async (
       )
     }
 
-    // Release escrow if there is a Payrexx hold
-    if (order.payrexxTransactionId) {
-      try {
-        await captureTransaction(
-          order.payrexxTransactionId,
-          Math.round(Number(order.amountChf) * 100),
-        )
-      } catch (captureError) {
-        logger.error('Failed to capture Payrexx transaction on receipt confirmation', {
-          captureError,
-          orderId,
-        })
-        return apiError(captureError, 'Zahlung konnte nicht freigegeben werden')
-      }
+    // Capture escrow + complete the order race-safe. Lock the order row and
+    // re-verify it is still shipped/delivered under the lock, so this route
+    // and the PATCH route (the other path to COMPLETED) serialize against each
+    // other — without the lock both could capture the Payrexx hold and bump
+    // seller total_sold twice. Capture runs INSIDE the lock; a genuine retry
+    // relies on Payrexx idempotency by transaction id.
+    let paymentErrorMsg: string | null = null
+    let result
+    try {
+      result = await guardedTransition<{ status: string }, void>({
+        lockTable: TABLE_NAMES.MARKETPLACE_ORDERS,
+        lockId: orderId,
+        check: (r) => validStates.includes(r.status),
+        apply: async (tx) => {
+          // Release escrow if there is a Payrexx hold
+          if (order.payrexxTransactionId) {
+            try {
+              await captureTransaction(
+                order.payrexxTransactionId,
+                Math.round(Number(order.amountChf) * 100),
+              )
+            } catch (captureError) {
+              logger.error('Failed to capture Payrexx transaction on receipt confirmation', {
+                captureError,
+                orderId,
+              })
+              paymentErrorMsg = 'Zahlung konnte nicht freigegeben werden'
+              throw captureError
+            }
+          }
+
+          await tx
+            .update(marketplaceOrders)
+            .set({
+              status: ORDER_STATUS.COMPLETED,
+              deliveredAt: sql`COALESCE(${marketplaceOrders.deliveredAt}, NOW())`,
+              completedAt: sql`NOW()`,
+              updatedAt: sql`NOW()`,
+            })
+            .where(eq(marketplaceOrders.id, orderId))
+          await tx
+            .update(listings)
+            .set({ status: LISTING_STATUS.SOLD })
+            .where(inArray(listings.id, affectedListingIds))
+          await tx
+            .update(sellerProfiles)
+            .set({ totalSold: sql`COALESCE(${sellerProfiles.totalSold}, 0) + ${affectedListingIds.length}` })
+            .where(eq(sellerProfiles.userId, order.sellerId))
+        },
+      })
+    } catch (txError) {
+      if (paymentErrorMsg) return apiError(txError, paymentErrorMsg)
+      throw txError
     }
 
-    // All three state updates are independent — run in parallel
-    await Promise.all([
-      // Mark order completed
-      db
-        .update(marketplaceOrders)
-        .set({
-          status: ORDER_STATUS.COMPLETED,
-          deliveredAt: sql`COALESCE(${marketplaceOrders.deliveredAt}, NOW())`,
-          completedAt: sql`NOW()`,
-          updatedAt: sql`NOW()`,
-        })
-        .where(eq(marketplaceOrders.id, orderId)),
-      // Mark listing(s) as sold
-      db
-        .update(listings)
-        .set({ status: LISTING_STATUS.SOLD })
-        .where(inArray(listings.id, affectedListingIds)),
-      // Increment seller total_sold (once per item)
-      db
-        .update(sellerProfiles)
-        .set({ totalSold: sql`COALESCE(${sellerProfiles.totalSold}, 0) + ${affectedListingIds.length}` })
-        .where(eq(sellerProfiles.userId, order.sellerId)),
-    ])
+    if (!result.ok) {
+      // The order left shipped/delivered under us (e.g. a concurrent
+      // confirm-receipt won). The end-state is the same; treat as done.
+      return apiSuccess({ orderId, status: ORDER_STATUS.COMPLETED })
+    }
 
     logger.info('Buyer confirmed receipt', {
       orderId,

--- a/src/app/api/marketplace/orders/[id]/route.ts
+++ b/src/app/api/marketplace/orders/[id]/route.ts
@@ -12,6 +12,8 @@ import { listings, listingImages, marketplaceOrders, marketplaceOrderItems, sell
 import { eq, and, sql, inArray } from 'drizzle-orm';
 import { ORDER_STATUS_CONFIG, ORDER_STATUS, LISTING_STATUS } from '@/config/marketplace';
 import type { OrderStatus } from '@/config/marketplace';
+import { TABLE_NAMES } from '@/config/database';
+import { guardedTransition } from '@/lib/lifecycle';
 import { logger } from '@/lib/logger';
 import { validateBody, UpdateOrderStatusSchema } from '@/lib/schemas';
 import { captureTransaction, cancelTransaction } from '@/lib/payments/payrexx-client';
@@ -190,82 +192,104 @@ export const PATCH = withAuth<{ id: string }>(async (
       );
     }
 
-    // Handle payment operations for specific transitions
-    if (newStatus === ORDER_STATUS.COMPLETED && order.payrexxTransactionId) {
-      // Capture the held Payrexx reservation
-      try {
-        await captureTransaction(order.payrexxTransactionId, Math.round(Number(order.amountChf) * 100));
-      } catch (captureError) {
-        logger.error('Failed to capture Payrexx transaction', { captureError, orderId });
-        return apiError(captureError, 'Zahlung konnte nicht abgeschlossen werden');
-      }
+    // Apply the transition race-safe. Lock the order row, re-validate the
+    // transition under the lock, then run the Payrexx capture/cancel + status
+    // write + listing side-effects atomically. Without the lock, the two paths
+    // that reach COMPLETED (this PATCH and the confirm-receipt route) or a
+    // double-click could both pass the read-time check and double-capture the
+    // Payrexx reservation + double-bump seller total_sold. Payment ops run
+    // INSIDE the lock (orders are low volume; correctness > lock duration); a
+    // genuine retry relies on Payrexx idempotency by transaction id.
+    let paymentErrorMsg: string | null = null
+    let result
+    try {
+      result = await guardedTransition<{ status: string }, void>({
+        lockTable: TABLE_NAMES.MARKETPLACE_ORDERS,
+        lockId: orderId,
+        check: (r) => {
+          if (r.status === ORDER_STATUS.PENDING_PAYMENT && newStatus === ORDER_STATUS.CANCELLED) return true
+          return (STATUS_TRANSITIONS[r.status]?.[role] || []).includes(newStatus)
+        },
+        apply: async (tx, r) => {
+          // Payment operations (under the lock)
+          if (newStatus === ORDER_STATUS.COMPLETED && order.payrexxTransactionId) {
+            try {
+              await captureTransaction(order.payrexxTransactionId, Math.round(Number(order.amountChf) * 100))
+            } catch (captureError) {
+              logger.error('Failed to capture Payrexx transaction', { captureError, orderId })
+              paymentErrorMsg = 'Zahlung konnte nicht abgeschlossen werden'
+              throw captureError
+            }
+          }
+          if (newStatus === ORDER_STATUS.CANCELLED && r.status !== ORDER_STATUS.PENDING_PAYMENT && order.payrexxTransactionId) {
+            try {
+              await cancelTransaction(order.payrexxTransactionId)
+            } catch (cancelError) {
+              logger.error('Failed to cancel Payrexx transaction', { cancelError, orderId })
+              paymentErrorMsg = 'Zahlung konnte nicht storniert werden'
+              throw cancelError
+            }
+          }
+
+          // Status write (+ tracking info in shipping_address JSONB)
+          const updateValues: Record<string, unknown> = {
+            status: newStatus,
+            updatedAt: sql`NOW()`,
+          }
+          if (tracking_number || tracking_url) {
+            updateValues.shippingAddress = sql`COALESCE(${marketplaceOrders.shippingAddress}, '{}') || ${JSON.stringify({
+              ...(tracking_number && { tracking_number }),
+              ...(tracking_url && { tracking_url }),
+            })}::jsonb`
+          }
+          await tx.update(marketplaceOrders).set(updateValues).where(eq(marketplaceOrders.id, orderId))
+
+          // Single-item P2P orders carry a listing directly; cart orders
+          // (listing_id null) carry their listings in marketplace_order_items.
+          // Resolve the affected listing ids so completion/cancellation acts on all.
+          let affectedListingIds: string[] = []
+          if (order.listingId) {
+            affectedListingIds = [order.listingId]
+          } else {
+            const items = await tx
+              .select({ listingId: marketplaceOrderItems.listingId })
+              .from(marketplaceOrderItems)
+              .where(eq(marketplaceOrderItems.orderId, orderId))
+            affectedListingIds = items.map(i => i.listingId)
+          }
+
+          // If completed: mark listing(s) SOLD + bump seller total_sold (once per item).
+          if (newStatus === ORDER_STATUS.COMPLETED && affectedListingIds.length > 0) {
+            await tx.update(listings)
+              .set({ status: LISTING_STATUS.SOLD })
+              .where(inArray(listings.id, affectedListingIds))
+            await tx.update(sellerProfiles)
+              .set({ totalSold: sql`${sellerProfiles.totalSold} + ${affectedListingIds.length}` })
+              .where(eq(sellerProfiles.userId, order.sellerId))
+          }
+
+          // If cancelled: restore reserved listing(s) to active
+          if (newStatus === ORDER_STATUS.CANCELLED && affectedListingIds.length > 0) {
+            await tx.update(listings)
+              .set({ status: LISTING_STATUS.ACTIVE })
+              .where(and(
+                inArray(listings.id, affectedListingIds),
+                eq(listings.status, LISTING_STATUS.RESERVED),
+              ))
+          }
+        },
+      })
+    } catch (txError) {
+      // A payment-op failure rolled the transaction back (no status change);
+      // surface the specific message. Anything else bubbles to the outer catch.
+      if (paymentErrorMsg) return apiError(txError, paymentErrorMsg)
+      throw txError
     }
 
-    if (newStatus === ORDER_STATUS.CANCELLED && order.status !== ORDER_STATUS.PENDING_PAYMENT && order.payrexxTransactionId) {
-      // Cancel/release the Payrexx reservation
-      try {
-        await cancelTransaction(order.payrexxTransactionId);
-      } catch (cancelError) {
-        logger.error('Failed to cancel Payrexx transaction', { cancelError, orderId });
-        return apiError(cancelError, 'Zahlung konnte nicht storniert werden');
-      }
-    }
-
-    // Build update values
-    const updateValues: Record<string, unknown> = {
-      status: newStatus,
-      updatedAt: sql`NOW()`,
-    };
-
-    // Store tracking info in shipping_address JSONB
-    if (tracking_number || tracking_url) {
-      updateValues.shippingAddress = sql`COALESCE(${marketplaceOrders.shippingAddress}, '{}') || ${JSON.stringify({
-        ...(tracking_number && { tracking_number }),
-        ...(tracking_url && { tracking_url }),
-      })}::jsonb`;
-    }
-
-    await db
-      .update(marketplaceOrders)
-      .set(updateValues)
-      .where(eq(marketplaceOrders.id, orderId));
-
-    // Single-item P2P orders carry a listing directly; cart orders (listing_id
-    // null) carry their listings in marketplace_order_items. Resolve the set of
-    // affected listing ids so completion/cancellation acts on all of them.
-    const listingId = order.listingId
-    let affectedListingIds: string[] = []
-    if (listingId) {
-      affectedListingIds = [listingId]
-    } else {
-      const items = await db
-        .select({ listingId: marketplaceOrderItems.listingId })
-        .from(marketplaceOrderItems)
-        .where(eq(marketplaceOrderItems.orderId, orderId))
-      affectedListingIds = items.map(i => i.listingId)
-    }
-
-    // If completed: mark listing(s) SOLD + bump seller total_sold (once per item).
-    if (newStatus === ORDER_STATUS.COMPLETED && affectedListingIds.length > 0) {
-      await Promise.all([
-        db.update(listings)
-          .set({ status: LISTING_STATUS.SOLD })
-          .where(inArray(listings.id, affectedListingIds)),
-        db.update(sellerProfiles)
-          .set({ totalSold: sql`${sellerProfiles.totalSold} + ${affectedListingIds.length}` })
-          .where(eq(sellerProfiles.userId, order.sellerId)),
-      ])
-    }
-
-    // If cancelled: restore reserved listing(s) to active
-    if (newStatus === ORDER_STATUS.CANCELLED && affectedListingIds.length > 0) {
-      await db
-        .update(listings)
-        .set({ status: LISTING_STATUS.ACTIVE })
-        .where(and(
-          inArray(listings.id, affectedListingIds),
-          eq(listings.status, LISTING_STATUS.RESERVED),
-        ));
+    if (!result.ok) {
+      // The order changed under us between the read-time check and the lock
+      // (concurrent transition); the requested transition is no longer valid.
+      return apiBadRequest('Der Status der Bestellung hat sich geändert. Bitte Seite neu laden.')
     }
 
     logger.info('Marketplace order status updated', {

--- a/src/lib/it-hilfe/accept-offer.ts
+++ b/src/lib/it-hilfe/accept-offer.ts
@@ -27,6 +27,7 @@ import { REQUEST_STATUS, OFFER_STATUS } from '@/config/it-hilfe'
 import { NOTIFICATION_TYPES, RELATED_TYPES } from '@/config/notifications'
 import { notifyUsers } from '@/lib/services/notifications'
 import { findOrCreateItHilfeConversation } from './conversation'
+import { guardedTransition } from '@/lib/lifecycle'
 import { APP_URL } from '@/config/urls'
 
 export type AcceptOfferReason =
@@ -137,58 +138,55 @@ export async function acceptOffer(params: {
   // emails seconds apart. FOR UPDATE on the request serializes them;
   // the second transaction sees MATCHED and aborts cleanly. Returning
   // a sentinel so the outer function can map it to AcceptOfferResult.
-  const raceFailed = await db.transaction(async (tx) => {
-    const lockedReq = await tx.execute(sql`
-      SELECT status FROM ${sql.raw(reqTable)}
-      WHERE id = ${requestId}
-      FOR UPDATE
-    `)
-    const lockedReqStatus = (lockedReq.rows[0] as { status?: string } | undefined)?.status
-    if (lockedReqStatus !== REQUEST_STATUS.OPEN) return true
+  const applied = await guardedTransition<{ status: string }, void>({
+    lockTable: reqTable,
+    lockId: requestId,
+    // Re-verify request OPEN under the lock, plus the offer is still PENDING.
+    // The request lock serializes all acceptances; the offer is re-read
+    // WITHOUT FOR UPDATE on purpose — correctness comes from serializing on
+    // the request row, and locking the offer too would change lock-
+    // acquisition order and invite deadlocks. We still re-read it so a
+    // separate (non-acceptance) path that WITHDREW the offer aborts here.
+    check: async (lockedReq, tx) => {
+      if (lockedReq.status !== REQUEST_STATUS.OPEN) return false
+      const lockedOff = await tx.execute(sql`
+        SELECT status FROM ${sql.raw(offTable)}
+        WHERE id = ${offerId}
+      `)
+      const lockedOffStatus = (lockedOff.rows[0] as { status?: string } | undefined)?.status
+      return lockedOffStatus === OFFER_STATUS.PENDING
+    },
+    apply: async (tx) => {
+      await tx.update(itHilfeOffers)
+        .set({ status: OFFER_STATUS.ACCEPTED })
+        .where(eq(itHilfeOffers.id, offerId))
 
-    // The request lock serializes all acceptances; an offer can't be
-    // accepted concurrently because the surrounding request transaction
-    // is queued. Still re-read the offer status — if a separate (non-
-    // acceptance) path WITHDREW the offer between the outer SELECT and
-    // this point, we should abort the same way.
-    const lockedOff = await tx.execute(sql`
-      SELECT status FROM ${sql.raw(offTable)}
-      WHERE id = ${offerId}
-    `)
-    const lockedOffStatus = (lockedOff.rows[0] as { status?: string } | undefined)?.status
-    if (lockedOffStatus !== OFFER_STATUS.PENDING) return true
-
-    await tx.update(itHilfeOffers)
-      .set({ status: OFFER_STATUS.ACCEPTED })
-      .where(eq(itHilfeOffers.id, offerId))
-
-    await tx.update(itHilfeOffers)
-      .set({ status: OFFER_STATUS.REJECTED })
-      .where(
-        and(
-          eq(itHilfeOffers.requestId, requestId),
-          ne(itHilfeOffers.id, offerId),
-          eq(itHilfeOffers.status, OFFER_STATUS.PENDING)
+      await tx.update(itHilfeOffers)
+        .set({ status: OFFER_STATUS.REJECTED })
+        .where(
+          and(
+            eq(itHilfeOffers.requestId, requestId),
+            ne(itHilfeOffers.id, offerId),
+            eq(itHilfeOffers.status, OFFER_STATUS.PENDING)
+          )
         )
-      )
 
-    await tx.update(itHilfeRequests)
-      .set({ status: REQUEST_STATUS.MATCHED, matchedOfferId: offerId })
-      .where(eq(itHilfeRequests.id, requestId))
+      await tx.update(itHilfeRequests)
+        .set({ status: REQUEST_STATUS.MATCHED, matchedOfferId: offerId })
+        .where(eq(itHilfeRequests.id, requestId))
 
-    // Ensure the requester ↔ helper conversation exists (shared with the
-    // pre-acceptance "ask a question" flow).
-    await findOrCreateItHilfeConversation(tx, {
-      requestId,
-      userA: requestData.requester_id,
-      userB: offerData.helper_id,
-      requestTitle: requestData.title,
-    })
-
-    return false
+      // Ensure the requester ↔ helper conversation exists (shared with the
+      // pre-acceptance "ask a question" flow).
+      await findOrCreateItHilfeConversation(tx, {
+        requestId,
+        userA: requestData.requester_id,
+        userB: offerData.helper_id,
+        requestTitle: requestData.title,
+      })
+    },
   })
 
-  if (raceFailed) {
+  if (!applied.ok) {
     // Map to the most accurate reason. We can't distinguish here whether
     // the request was already matched vs the offer was withdrawn out-of-
     // band; surface the request-side reason since that's what the

--- a/src/lib/lifecycle/__tests__/guarded-transition.test.ts
+++ b/src/lib/lifecycle/__tests__/guarded-transition.test.ts
@@ -1,0 +1,140 @@
+/**
+ * Tests for lifecycle/guarded-transition.ts — the race-safe transition guard
+ * shared by IT-Hilfe, service appointments, and marketplace orders.
+ *
+ * Behaviors locked:
+ *   - locked row missing            → { ok: false }, apply NOT called
+ *   - check() returns false         → { ok: false }, apply NOT called
+ *   - check() returns true          → apply runs exactly once, result surfaced
+ *   - async check() can read a 2nd entity via the provided tx
+ *   - opts.db = an existing Tx      → reuses it (no new module-level transaction)
+ *
+ * These guarantee the helper aborts cleanly when the precondition fails (so a
+ * second racing caller never double-applies) and runs the flow's writes only
+ * when the precondition holds under the lock.
+ */
+
+// ---------------------------------------------------------------------------
+// Mock the module db: db.transaction(cb) invokes cb with a fake tx.
+// ---------------------------------------------------------------------------
+
+interface FakeTx {
+  execute: jest.Mock
+  transaction: jest.Mock
+}
+
+function makeFakeTx(rowsQueue: Array<{ rows: unknown[] }>): FakeTx {
+  // Each call to execute() shifts the next queued result (FOR UPDATE select
+  // first, then any second-entity read the check performs).
+  const tx: FakeTx = {
+    execute: jest.fn(() => Promise.resolve(rowsQueue.shift() ?? { rows: [] })),
+    transaction: jest.fn((cb: (t: FakeTx) => unknown) => cb(tx)),
+  }
+  return tx
+}
+
+let mockModuleTx: FakeTx
+
+const mockTransaction = jest.fn((cb: (t: FakeTx) => unknown) => cb(mockModuleTx))
+
+jest.mock('@/db', () => ({
+  db: {
+    transaction: (cb: (t: unknown) => unknown) => mockTransaction(cb as (t: FakeTx) => unknown),
+  },
+}))
+
+import { guardedTransition } from '../guarded-transition'
+
+describe('guardedTransition', () => {
+  beforeEach(() => {
+    jest.clearAllMocks()
+  })
+
+  it('returns { ok: false } and does not call apply when the locked row is missing', async () => {
+    mockModuleTx = makeFakeTx([{ rows: [] }])
+    const apply = jest.fn()
+
+    const res = await guardedTransition({
+      lockTable: 'it_hilfe_requests',
+      lockId: 'r1',
+      check: () => true,
+      apply,
+    })
+
+    expect(res).toEqual({ ok: false })
+    expect(apply).not.toHaveBeenCalled()
+  })
+
+  it('returns { ok: false } and does not call apply when check() is false', async () => {
+    mockModuleTx = makeFakeTx([{ rows: [{ status: 'matched' }] }])
+    const apply = jest.fn()
+
+    const res = await guardedTransition<{ status: string }, void>({
+      lockTable: 'it_hilfe_requests',
+      lockId: 'r1',
+      check: (row) => row.status === 'open',
+      apply,
+    })
+
+    expect(res).toEqual({ ok: false })
+    expect(apply).not.toHaveBeenCalled()
+  })
+
+  it('runs apply exactly once and surfaces its result when check() passes', async () => {
+    mockModuleTx = makeFakeTx([{ rows: [{ status: 'open' }] }])
+    const apply = jest.fn((_tx: unknown, _row: unknown) => Promise.resolve('done'))
+
+    const res = await guardedTransition<{ status: string }, string>({
+      lockTable: 'it_hilfe_requests',
+      lockId: 'r1',
+      check: (row) => row.status === 'open',
+      apply,
+    })
+
+    expect(res).toEqual({ ok: true, result: 'done' })
+    expect(apply).toHaveBeenCalledTimes(1)
+    // apply receives (tx, row)
+    expect(apply.mock.calls[0][1]).toEqual({ status: 'open' })
+  })
+
+  it('lets an async check() read a second entity through the same tx', async () => {
+    // First execute() = FOR UPDATE on the request; second = the offer re-read.
+    mockModuleTx = makeFakeTx([
+      { rows: [{ status: 'open' }] },
+      { rows: [{ status: 'pending' }] },
+    ])
+    const apply = jest.fn(() => Promise.resolve(true))
+
+    const res = await guardedTransition<{ status: string }, boolean>({
+      lockTable: 'it_hilfe_requests',
+      lockId: 'r1',
+      check: async (row, tx) => {
+        if (row.status !== 'open') return false
+        const offer = await tx.execute({} as never)
+        return (offer.rows[0] as { status: string }).status === 'pending'
+      },
+      apply,
+    })
+
+    expect(res).toEqual({ ok: true, result: true })
+    expect(mockModuleTx.execute).toHaveBeenCalledTimes(2)
+    expect(apply).toHaveBeenCalledTimes(1)
+  })
+
+  it('reuses a passed-in Tx instead of opening a module-level transaction', async () => {
+    const passedTx = makeFakeTx([{ rows: [{ status: 'open' }] }])
+    const apply = jest.fn(() => Promise.resolve('via-tx'))
+
+    const res = await guardedTransition<{ status: string }, string>({
+      lockTable: 'service_appointments',
+      lockId: 'a1',
+      check: (row) => row.status === 'open',
+      apply,
+      db: passedTx as never,
+    })
+
+    expect(res).toEqual({ ok: true, result: 'via-tx' })
+    expect(passedTx.transaction).toHaveBeenCalledTimes(1)
+    expect(mockTransaction).not.toHaveBeenCalled()
+  })
+})

--- a/src/lib/lifecycle/guarded-transition.ts
+++ b/src/lib/lifecycle/guarded-transition.ts
@@ -1,0 +1,99 @@
+/**
+ * Race-safe state-transition guard — the shared core of the three lifecycle
+ * flows (IT-Hilfe peer-repair, service appointments, marketplace orders).
+ *
+ * Every one of those flows is "a row with a `status` column moving through
+ * role-gated actions". Each performs a state change as: read current state,
+ * decide the transition is legal, then write. Done naively (read, then
+ * `UPDATE ... WHERE id = $1`) two concurrent or double-clicked requests can
+ * both pass the read-time check and both write — double-applying side-effects
+ * (e.g. capturing a Payrexx payment twice, double-counting a sale).
+ *
+ * `guardedTransition` reproduces the proven IT-Hilfe pattern in ONE place:
+ * open a transaction, `SELECT ... FOR UPDATE` the row that serializes the
+ * flow, re-check the precondition under that lock, and only then run the
+ * flow-specific writes inside the same transaction. The second of two racing
+ * callers blocks on the row lock, then sees the already-changed state in
+ * `check()` and aborts cleanly.
+ *
+ * The flow keeps ALL its domain logic — which tables to write, which
+ * side-effects to fire — inside `apply`. This helper only owns the lock +
+ * re-check + transaction scaffolding. Work that must happen AFTER the
+ * transaction commits (e.g. `createReview`, notification fan-out) stays in
+ * the caller, gated on a `{ ok: true }` result.
+ */
+
+import { db as defaultDb } from '@/db'
+import { sql } from 'drizzle-orm'
+
+/** The transaction handle Drizzle passes to a `db.transaction(tx => …)` callback. */
+export type Tx = Parameters<Parameters<typeof defaultDb.transaction>[0]>[0]
+
+/**
+ * Either the module-level `db` (opens a fresh transaction) or an existing
+ * `Tx` (reused in place — Drizzle nests it as a savepoint). No current call
+ * site nests; the option exists so a future caller already inside a
+ * transaction can serialize within it rather than dead-locking on itself.
+ */
+export type DbOrTx = typeof defaultDb | Tx
+
+export interface GuardedTransitionOptions<Row extends Record<string, unknown>, T> {
+  /**
+   * Table to `SELECT ... FOR UPDATE` — the serialization point. Pass a
+   * `TABLE_NAMES.*` value. Interpolated via `sql.raw`, so it MUST be a
+   * trusted code literal, never user input.
+   */
+  lockTable: string
+  /** Primary-key value of the row to lock. Bound as a parameter (safe). */
+  lockId: string
+  /**
+   * Columns to read under the lock and hand to `check`. Trusted code
+   * literals only (interpolated via `sql.raw`). Defaults to `['status']`.
+   */
+  lockColumns?: readonly string[]
+  /**
+   * Re-check the precondition under the lock. Return `false` to abort (the
+   * transaction commits as a no-op and the call returns `{ ok: false }`).
+   * `tx` is provided so the check can read a SECOND entity in the same
+   * transaction (e.g. IT-Hilfe accept re-reads the offer status). Returns
+   * `false` if the locked row does not exist.
+   */
+  check: (row: Row, tx: Tx) => boolean | Promise<boolean>
+  /** All flow-specific writes + side-effects. Runs under the lock; its return value is surfaced as `result`. */
+  apply: (tx: Tx, row: Row) => Promise<T>
+  /** Connection to run on. Defaults to the module `db` (fresh transaction). Pass an existing `Tx` to reuse it. */
+  db?: DbOrTx
+}
+
+export type GuardedTransitionResult<T> = { ok: true; result: T } | { ok: false }
+
+/**
+ * Run `apply` against `lockTable`/`lockId` only if `check` passes under a
+ * `FOR UPDATE` lock, atomically. See file header for the rationale.
+ */
+export async function guardedTransition<Row extends Record<string, unknown>, T>(
+  opts: GuardedTransitionOptions<Row, T>,
+): Promise<GuardedTransitionResult<T>> {
+  const { lockTable, lockId, lockColumns = ['status'], check, apply } = opts
+  const conn = opts.db ?? defaultDb
+
+  const columns = sql.raw(lockColumns.join(', '))
+  const table = sql.raw(lockTable)
+
+  const run = async (tx: Tx): Promise<GuardedTransitionResult<T>> => {
+    const locked = await tx.execute(
+      sql`SELECT ${columns} FROM ${table} WHERE id = ${lockId} FOR UPDATE`,
+    )
+    const row = locked.rows[0] as Row | undefined
+    if (!row) return { ok: false }
+
+    if (!(await check(row, tx))) return { ok: false }
+
+    const result = await apply(tx, row)
+    return { ok: true, result }
+  }
+
+  // `db.transaction` opens a fresh transaction; a passed-in `Tx` is reused in
+  // place (it exposes the same `transaction` method, nesting via savepoint).
+  return conn.transaction(run)
+}

--- a/src/lib/lifecycle/index.ts
+++ b/src/lib/lifecycle/index.ts
@@ -1,0 +1,15 @@
+/**
+ * Shared lifecycle core — the engine common to the three state-machine flows
+ * (IT-Hilfe peer-repair, service appointments, marketplace orders).
+ *
+ * Phase 1 exposes the race-safe transition guard. The declarative
+ * transition-table validator (Phase 2) is intentionally not here yet.
+ */
+
+export {
+  guardedTransition,
+  type Tx,
+  type DbOrTx,
+  type GuardedTransitionOptions,
+  type GuardedTransitionResult,
+} from './guarded-transition'

--- a/src/lib/services/__tests__/execute-appointment-update.test.ts
+++ b/src/lib/services/__tests__/execute-appointment-update.test.ts
@@ -1,0 +1,107 @@
+/**
+ * Tests for executeAppointmentUpdate (lib/services/appointment-actions.ts).
+ *
+ * The write now runs through guardedTransition: it locks the appointment row
+ * (FOR UPDATE), re-checks the precondition under the lock, and only then
+ * writes. This guards the customer ↔ technician flow against a concurrent
+ * action (or a double-click) double-applying a transition or a rating.
+ *
+ * Behaviors locked:
+ *   - status unchanged since validation  → writes, returns the updated row
+ *   - status changed under the lock      → returns null, NO write (race-loser)
+ *   - 'rate' first time (rating null)    → writes
+ *   - 'rate' when already rated          → returns null, NO write
+ *
+ * True FOR UPDATE serialization is a Postgres guarantee (covered by E2E); here
+ * we verify the re-check wiring decides write-vs-skip correctly.
+ */
+
+// The FOR UPDATE lock select. Returns the row the re-check sees under the lock.
+const mockTxExecute = jest.fn()
+// The update().set().where().returning() chain inside apply.
+const mockReturning = jest.fn()
+const mockTxUpdate = jest.fn(() => ({
+  set: () => ({ where: () => ({ returning: mockReturning }) }),
+}))
+
+jest.mock('@/db', () => ({
+  db: {
+    // guardedTransition runs `db.transaction(cb)`; invoke cb with a fake tx.
+    transaction: (cb: (tx: unknown) => unknown) => cb({
+      execute: (...a: unknown[]) => mockTxExecute(...a),
+      update: () => mockTxUpdate(),
+    }),
+  },
+}))
+
+import { executeAppointmentUpdate } from '../appointment-actions'
+import { BOOKING_STATUS } from '@/config/booking-status'
+
+const APPT_ID = 'appt-1'
+const UPDATED_ROW = { id: APPT_ID, status: BOOKING_STATUS.COMPLETED } as never
+
+beforeEach(() => {
+  jest.clearAllMocks()
+  mockReturning.mockResolvedValue([UPDATED_ROW])
+})
+
+describe('executeAppointmentUpdate — status transition', () => {
+  it('writes and returns the row when the status is unchanged under the lock', async () => {
+    mockTxExecute.mockResolvedValue({ rows: [{ status: BOOKING_STATUS.IN_PROGRESS, customer_rating: null }] })
+
+    const result = await executeAppointmentUpdate(
+      APPT_ID,
+      'complete',
+      { status: BOOKING_STATUS.COMPLETED },
+      BOOKING_STATUS.IN_PROGRESS,
+    )
+
+    expect(result).toBe(UPDATED_ROW)
+    expect(mockTxUpdate).toHaveBeenCalledTimes(1)
+  })
+
+  it('returns null and does NOT write when the status changed under the lock', async () => {
+    // Validated against IN_PROGRESS, but a concurrent action already completed it.
+    mockTxExecute.mockResolvedValue({ rows: [{ status: BOOKING_STATUS.COMPLETED, customer_rating: null }] })
+
+    const result = await executeAppointmentUpdate(
+      APPT_ID,
+      'complete',
+      { status: BOOKING_STATUS.COMPLETED },
+      BOOKING_STATUS.IN_PROGRESS,
+    )
+
+    expect(result).toBeNull()
+    expect(mockTxUpdate).not.toHaveBeenCalled()
+  })
+})
+
+describe('executeAppointmentUpdate — rate (compare-and-set)', () => {
+  it('writes the rating when the appointment is not yet rated', async () => {
+    mockTxExecute.mockResolvedValue({ rows: [{ status: BOOKING_STATUS.COMPLETED, customer_rating: null }] })
+
+    const result = await executeAppointmentUpdate(
+      APPT_ID,
+      'rate',
+      { customerRating: 5 },
+      BOOKING_STATUS.COMPLETED,
+    )
+
+    expect(result).toBe(UPDATED_ROW)
+    expect(mockTxUpdate).toHaveBeenCalledTimes(1)
+  })
+
+  it('returns null and does NOT write when the appointment is already rated', async () => {
+    mockTxExecute.mockResolvedValue({ rows: [{ status: BOOKING_STATUS.COMPLETED, customer_rating: 4 }] })
+
+    const result = await executeAppointmentUpdate(
+      APPT_ID,
+      'rate',
+      { customerRating: 5 },
+      BOOKING_STATUS.COMPLETED,
+    )
+
+    expect(result).toBeNull()
+    expect(mockTxUpdate).not.toHaveBeenCalled()
+  })
+})

--- a/src/lib/services/appointment-actions.ts
+++ b/src/lib/services/appointment-actions.ts
@@ -7,11 +7,13 @@
 
 import { db } from '@/db'
 import { serviceAppointments, serviceTypes, users } from '@/db/schema'
-import { eq, and, isNull, sql } from 'drizzle-orm'
+import { eq, sql } from 'drizzle-orm'
 import { alias } from 'drizzle-orm/pg-core'
 import { logger } from '@/lib/logger'
 import { sendCustomEmail, appointmentStatusUpdate, appointmentQuoteReceived } from '@/lib/email'
 import { BOOKING_STATUS, getBookingStatusLabel } from '@/config/booking-status'
+import { TABLE_NAMES } from '@/config/database'
+import { guardedTransition } from '@/lib/lifecycle'
 import { APP_URL } from '@/config/urls'
 import { SERVICE_APPOINTMENT_ROUTES } from '@/config/service-appointments'
 
@@ -171,26 +173,48 @@ export function buildActionUpdate(
 // ============================================================================
 
 /**
- * Apply the appointment update to the database.
- * For 'rate' action, adds a WHERE condition to prevent double-rating.
+ * Apply the appointment update to the database, race-safe.
+ *
+ * `buildActionUpdate` validated the action against `expectedStatus` (the
+ * status read just before). Between that read and this write, a concurrent
+ * action (or a double-click) could move the appointment — without a lock both
+ * would apply, e.g. double-firing a status change or, for 'rate', writing two
+ * ratings. guardedTransition locks the row (FOR UPDATE) and re-checks under it:
+ *   - the status is still `expectedStatus` (no concurrent transition won), and
+ *   - for 'rate', `customer_rating` is still null (generalises the previous
+ *     `isNull(customerRating)` compare-and-set into the same guard).
+ * A race-loser fails the re-check and returns null (no write). Returns the
+ * updated row, or null when the precondition no longer holds.
  */
 export async function executeAppointmentUpdate(
   appointmentId: string,
   action: string,
-  updateSet: Record<string, unknown>
+  updateSet: Record<string, unknown>,
+  expectedStatus: string | null
 ): Promise<typeof serviceAppointments.$inferSelect | null> {
-  const conditions = [eq(serviceAppointments.id, appointmentId)]
-  if (action === 'rate') {
-    conditions.push(isNull(serviceAppointments.customerRating))
-  }
+  const res = await guardedTransition<
+    { status: string | null; customer_rating: number | null },
+    typeof serviceAppointments.$inferSelect | undefined
+  >({
+    lockTable: TABLE_NAMES.SERVICE_APPOINTMENTS,
+    lockId: appointmentId,
+    lockColumns: ['status', 'customer_rating'],
+    check: (row) => {
+      if (expectedStatus !== null && row.status !== expectedStatus) return false
+      if (action === 'rate' && row.customer_rating != null) return false
+      return true
+    },
+    apply: async (tx) => {
+      const [updated] = await tx
+        .update(serviceAppointments)
+        .set(updateSet)
+        .where(eq(serviceAppointments.id, appointmentId))
+        .returning()
+      return updated
+    },
+  })
 
-  const [updated] = await db
-    .update(serviceAppointments)
-    .set(updateSet)
-    .where(and(...conditions))
-    .returning()
-
-  return updated ?? null
+  return res.ok ? (res.result ?? null) : null
 }
 
 // ============================================================================


### PR DESCRIPTION
## What

Phase 1 of #3 pipeline unification ("shared core, separate flows"). Extracts the race-safe `SELECT … FOR UPDATE` → re-check → write-in-tx pattern into one shared helper and adopts it across all three lifecycle flows.

**New core** `src/lib/lifecycle/guardedTransition` — locks the serializing row, re-checks the precondition under the lock (`check(row, tx)` can read a second entity), runs the flow's writes in the same transaction.

| Flow | Change |
|---|---|
| IT-Hilfe (`accept-offer`, `complete`, `confirm-review`) | Collapse the 3× hand-rolled lock blocks → one helper. Behavior-preserving. |
| Marketplace orders (`PATCH` + `confirm-receipt`) | Both lock the same order row → **fixes latent double Payrexx-capture / double `total_sold`** on concurrent/double-clicked completion. Capture moved inside the lock (Payrexx idempotency). |
| Appointments (`executeAppointmentUpdate`) | Takes `expectedStatus`, re-checks under lock; generalizes the `rate`-only compare-and-set to all transitions. |

## Verification
- Typecheck clean · lint clean · full suite **zero new failures vs baseline** (proven by stash-diff)
- Added `guardedTransition` unit tests + per-flow race-loser tests
- Docs: `ARCHITECTURE_DEBT.md` #4

## Deferred
Phase 2 (declarative transition-table validator for orders + appointments). IT-Hilfe's `VALID_REQUEST_TRANSITIONS` stays as-is.

🤖 Generated with [Claude Code](https://claude.com/claude-code)