### PR TITLE
refactor(lifecycle): declarative transition-table validator (Phase 2)

### DIFF
--- a/docs/ARCHITECTURE_DEBT.md
+++ b/docs/ARCHITECTURE_DEBT.md
@@ -2,7 +2,7 @@
 
 **Created:** 2026-06-04  
 **Last Modified:** 2026-06-29  
-**Last Modified Summary:** #4 — race-safe lifecycle transition guard (`src/lib/lifecycle`) adopted by IT-Hilfe + orders + appointments (Phase 1)
+**Last Modified Summary:** #4 Phase 2 — declarative transition-table validator (`resolveTransition`) replaces the orders matrix + appointments switch
 
 **Last updated:** 2026-06-15 (auth/onboarding cleanup + notification pipeline closed)
 
@@ -163,7 +163,7 @@ change existing enums.
 
 ## #4 — Lifecycle transition engine (request→accept→complete→review)
 
-**Status:** Phase 1 ✓ DONE (2026-06-29). Phase 2 deferred.
+**Status:** Phase 1 ✓ DONE (2026-06-29). Phase 2 ✓ DONE (2026-06-29).
 
 The three flows — IT-Hilfe peer-repair, service appointments, marketplace
 orders — are each "a row with a `status` column moving through role-gated
@@ -186,10 +186,23 @@ serializing on the request row). All three flows route through it:
 - Appointments (`executeAppointmentUpdate`) — now takes `expectedStatus`;
   generalized the `rate`-only compare-and-set to all transitions.
 
-**Phase 2 — deferred:** a declarative transition-table validator to replace the
-orders `STATUS_TRANSITIONS` matrix + appointments `buildActionUpdate` switch.
-IT-Hilfe's `VALID_REQUEST_TRANSITIONS` stays as-is (its OPEN→MATCHED is a
-two-entity offer acceptance, not a single-row transition).
+**Phase 2 — declarative transition validator (`resolveTransition` in
+`src/lib/lifecycle/state-machine.ts`):** one validator over a per-flow
+`TransitionTable` (rows of `{ action, from, role?, to? }`), returning
+`{ ok, to }` or `{ ok:false, reason: unknown_action|wrong_role|wrong_state }`
+(role checked before state). Replaces the two bespoke mechanisms:
+- Orders: the route's local `STATUS_TRANSITIONS` matrix → `ORDER_TRANSITIONS`
+  SSOT in `config/marketplace.ts` (client sends the target status, so
+  `action === to`). Same table drives the fast-fail check AND the under-lock
+  re-check. Security boundaries + the "nicht erlaubt" message unchanged.
+- Appointments: the `buildActionUpdate` switch's role/from/to gates →
+  `APPOINTMENT_TRANSITIONS` SSOT in `config/booking-status.ts` (carries the
+  exact per-action `roleError`/`stateError` so the 403/400 mapping is
+  preserved). The switch now only builds per-action side-effect fields.
+
+IT-Hilfe keeps `VALID_REQUEST_TRANSITIONS` as-is — its OPEN→MATCHED is a
+two-entity offer acceptance, not a single-row transition, so a shared table
+would add indirection without removing complexity.
 
 ---
 

--- a/src/app/api/marketplace/orders/[id]/__tests__/route.test.ts
+++ b/src/app/api/marketplace/orders/[id]/__tests__/route.test.ts
@@ -68,6 +68,14 @@ jest.mock('@/config/marketplace', () => ({
     completed: { label: 'Abgeschlossen' }, cancelled: { label: 'Storniert' },
     refunded: { label: 'Erstattet' },
   },
+  // Mirror of the real ORDER_TRANSITIONS SSOT (resolveTransition reads this).
+  ORDER_TRANSITIONS: [
+    { action: 'shipped', from: 'paid', role: 'seller', to: 'shipped' },
+    { action: 'delivered', from: 'shipped', role: 'seller', to: 'delivered' },
+    { action: 'completed', from: 'delivered', role: 'buyer', to: 'completed' },
+    { action: 'cancelled', from: 'paid', role: 'buyer', to: 'cancelled' },
+    { action: 'cancelled', from: 'pending_payment', role: ['buyer', 'seller'], to: 'cancelled' },
+  ],
   COMMISSION_RATE: 0.1,
 }))
 

--- a/src/app/api/marketplace/orders/[id]/route.ts
+++ b/src/app/api/marketplace/orders/[id]/route.ts
@@ -10,23 +10,16 @@ import { ERROR_MESSAGES } from '@/config/error-messages'
 import { db } from '@/db';
 import { listings, listingImages, marketplaceOrders, marketplaceOrderItems, sellerProfiles, users } from '@/db/schema';
 import { eq, and, sql, inArray } from 'drizzle-orm';
-import { ORDER_STATUS_CONFIG, ORDER_STATUS, LISTING_STATUS } from '@/config/marketplace';
-import type { OrderStatus } from '@/config/marketplace';
+import { ORDER_STATUS_CONFIG, ORDER_STATUS, LISTING_STATUS, ORDER_TRANSITIONS } from '@/config/marketplace';
+import type { OrderStatus, OrderRole } from '@/config/marketplace';
 import { TABLE_NAMES } from '@/config/database';
-import { guardedTransition } from '@/lib/lifecycle';
+import { guardedTransition, resolveTransition } from '@/lib/lifecycle';
 import { logger } from '@/lib/logger';
 import { validateBody, UpdateOrderStatusSchema } from '@/lib/schemas';
 import { captureTransaction, cancelTransaction } from '@/lib/payments/payrexx-client';
 import { sendCustomEmail } from '@/lib/email';
 import { orderStatusUpdate } from '@/lib/email/templates/marketplace';
 import { APP_URL } from '@/config/urls';
-
-// Valid status transitions: { currentStatus: { role: [allowedNewStatuses] } }
-const STATUS_TRANSITIONS: Record<string, Record<string, string[]>> = {
-  [ORDER_STATUS.PAID]:      { seller: [ORDER_STATUS.SHIPPED],    buyer: [ORDER_STATUS.CANCELLED] },
-  [ORDER_STATUS.SHIPPED]:   { seller: [ORDER_STATUS.DELIVERED],  buyer: [] },
-  [ORDER_STATUS.DELIVERED]: { buyer: [ORDER_STATUS.COMPLETED],   seller: [] },
-};
 
 /**
  * Fetch order with full join data (listing, buyer, seller).
@@ -178,14 +171,15 @@ export const PATCH = withAuth<{ id: string }>(async (
 
     if (!role) return apiForbidden('Kein Zugriff auf diese Bestellung');
 
-    // Validate status transition
+    // Validate the transition against the SSOT table (fast-fail; re-checked
+    // under the lock below). The client sends the target status, so the
+    // "action" is the target status itself.
     const currentStatus = order.status;
-    const allowedTransitions = STATUS_TRANSITIONS[currentStatus]?.[role] || [];
-
-    // Allow cancellation from pending_payment for either role
-    if (currentStatus === ORDER_STATUS.PENDING_PAYMENT && newStatus === ORDER_STATUS.CANCELLED) {
-      // OK — allowed
-    } else if (!allowedTransitions.includes(newStatus)) {
+    if (!resolveTransition(ORDER_TRANSITIONS, {
+      from: currentStatus as OrderStatus,
+      action: newStatus as OrderStatus,
+      role: role as OrderRole,
+    }).ok) {
       return apiBadRequest(
         `Statuswechsel von "${ORDER_STATUS_CONFIG[currentStatus as OrderStatus]?.label || currentStatus}" ` +
         `zu "${ORDER_STATUS_CONFIG[newStatus as OrderStatus]?.label || newStatus}" ist nicht erlaubt`
@@ -207,8 +201,11 @@ export const PATCH = withAuth<{ id: string }>(async (
         lockTable: TABLE_NAMES.MARKETPLACE_ORDERS,
         lockId: orderId,
         check: (r) => {
-          if (r.status === ORDER_STATUS.PENDING_PAYMENT && newStatus === ORDER_STATUS.CANCELLED) return true
-          return (STATUS_TRANSITIONS[r.status]?.[role] || []).includes(newStatus)
+          return resolveTransition(ORDER_TRANSITIONS, {
+            from: r.status as OrderStatus,
+            action: newStatus as OrderStatus,
+            role: role as OrderRole,
+          }).ok
         },
         apply: async (tx, r) => {
           // Payment operations (under the lock)

--- a/src/config/booking-status.ts
+++ b/src/config/booking-status.ts
@@ -15,6 +15,7 @@
  */
 
 import { TECHNICIAN_LABEL } from '@/config/terminology'
+import type { Transition } from '@/lib/lifecycle'
 
 export const BOOKING_STATUS = {
   REQUESTED: 'requested',
@@ -32,6 +33,98 @@ export const BOOKING_STATUS = {
 } as const
 
 export type BookingStatus = typeof BOOKING_STATUS[keyof typeof BOOKING_STATUS]
+
+// ============================================================================
+// Appointment Transitions (SSOT) — who can do what, from which state
+// ============================================================================
+//
+// One row per action. `to` is omitted for actions that change no status
+// (update, rate). `role` lists who may perform it (cancel: either party).
+// `roleError` / `stateError` are the exact user-facing messages the API
+// returns — `roleError` maps to 403, `stateError` to 400 (see the
+// appointments PATCH route). Validated via resolveTransition() from
+// @/lib/lifecycle; the per-action side-effect fields stay in buildActionUpdate.
+
+export type AppointmentRole = 'customer' | 'repairer'
+
+export type AppointmentAction =
+  | 'accept' | 'reject' | 'quote' | 'approve_quote' | 'reject_quote'
+  | 'start' | 'complete' | 'update' | 'rate' | 'cancel'
+
+export interface AppointmentTransition
+  extends Transition<BookingStatus, AppointmentAction, AppointmentRole> {
+  /** 403 — actor's role may not perform this action. */
+  roleError: string
+  /** 400 — action not allowed from the current status. */
+  stateError: string
+}
+
+export const APPOINTMENT_TRANSITIONS: readonly AppointmentTransition[] = [
+  {
+    action: 'accept', role: 'repairer',
+    from: [BOOKING_STATUS.REQUESTED], to: BOOKING_STATUS.ACCEPTED,
+    roleError: 'Nur der Techniker kann annehmen',
+    stateError: 'Termin kann nicht angenommen werden',
+  },
+  {
+    action: 'reject', role: 'repairer',
+    from: [BOOKING_STATUS.REQUESTED], to: BOOKING_STATUS.REJECTED,
+    roleError: 'Nur der Techniker kann ablehnen',
+    stateError: 'Termin kann nicht abgelehnt werden',
+  },
+  {
+    action: 'quote', role: 'repairer',
+    from: [BOOKING_STATUS.ACCEPTED, BOOKING_STATUS.QUOTE_REJECTED], to: BOOKING_STATUS.QUOTED,
+    roleError: 'Nur der Techniker kann Angebote erstellen',
+    stateError: 'Angebot kann in diesem Status nicht erstellt werden',
+  },
+  {
+    action: 'approve_quote', role: 'customer',
+    from: [BOOKING_STATUS.QUOTED], to: BOOKING_STATUS.QUOTE_APPROVED,
+    roleError: 'Nur der Kunde kann Angebote bestätigen',
+    stateError: 'Kein Angebot zum Bestätigen',
+  },
+  {
+    action: 'reject_quote', role: 'customer',
+    from: [BOOKING_STATUS.QUOTED], to: BOOKING_STATUS.QUOTE_REJECTED,
+    roleError: 'Nur der Kunde kann Angebote ablehnen',
+    stateError: 'Kein Angebot zum Ablehnen',
+  },
+  {
+    action: 'start', role: 'repairer',
+    from: [BOOKING_STATUS.ACCEPTED, BOOKING_STATUS.QUOTE_APPROVED], to: BOOKING_STATUS.IN_PROGRESS,
+    roleError: 'Nur der Techniker kann starten',
+    stateError: 'Termin kann nicht gestartet werden',
+  },
+  {
+    action: 'complete', role: 'repairer',
+    from: [BOOKING_STATUS.IN_PROGRESS], to: BOOKING_STATUS.COMPLETED,
+    roleError: 'Nur der Techniker kann abschliessen',
+    stateError: 'Termin ist nicht in Bearbeitung',
+  },
+  {
+    action: 'update', role: 'customer',
+    from: [BOOKING_STATUS.REQUESTED], // no status change
+    roleError: 'Nur der Kunde kann Angaben bearbeiten',
+    stateError: 'Angaben können nur im Status "Angefragt" bearbeitet werden',
+  },
+  {
+    action: 'rate', role: 'customer',
+    from: [BOOKING_STATUS.COMPLETED], // no status change
+    roleError: 'Nur der Kunde kann bewerten',
+    stateError: 'Nur abgeschlossene Termine können bewertet werden',
+  },
+  {
+    // Either party may cancel before the job is in progress. No role gate
+    // beyond "is a participant" (the route's upfront access check covers that),
+    // so roleError is unreachable in practice.
+    action: 'cancel', role: ['customer', 'repairer'],
+    from: [BOOKING_STATUS.REQUESTED, BOOKING_STATUS.ACCEPTED, BOOKING_STATUS.QUOTED, BOOKING_STATUS.QUOTE_APPROVED],
+    to: BOOKING_STATUS.CANCELLED,
+    roleError: 'Kein Zugriff auf diesen Termin',
+    stateError: 'Termin kann nicht mehr storniert werden',
+  },
+]
 
 export interface BookingStatusBadge {
   label: string

--- a/src/config/marketplace.ts
+++ b/src/config/marketplace.ts
@@ -10,6 +10,7 @@
 
 import { KATEGORIEN } from '@/config/erfassung/categories'
 import { UI_STATUS } from '@/config/ui/status'
+import type { TransitionTable } from '@/lib/lifecycle'
 import { PAGINATION } from '@/config/pagination'
 
 // ============================================================================
@@ -209,6 +210,31 @@ export const ORDER_STATUS_CONFIG: Record<OrderStatus, { label: string; color: st
   cancelled:       { label: 'Storniert',          color: UI_STATUS.neutral },
   refunded:        { label: 'Erstattet',          color: UI_STATUS.danger },
 };
+
+// ============================================================================
+// Order Transitions (SSOT) — who can move an order where
+// ============================================================================
+//
+// This table is the SOLE protection against a buyer/seller bypassing the
+// Payrexx payment flow. It is the manual PATCH path (the client sends the
+// target status, so `action === to`). Validated via resolveTransition()
+// from @/lib/lifecycle.
+//
+// NOTE: the buyer's final DELIVERED → COMPLETED (which captures escrow) also
+// has a dedicated route (confirm-receipt) that additionally accepts SHIPPED →
+// COMPLETED. That second path is intentionally NOT folded in here — keep the
+// two allowed-from sets distinct (see confirm-receipt/route.ts).
+
+export type OrderRole = 'buyer' | 'seller';
+
+export const ORDER_TRANSITIONS: TransitionTable<OrderStatus, OrderStatus, OrderRole> = [
+  { action: ORDER_STATUS.SHIPPED,   from: ORDER_STATUS.PAID,      role: 'seller',             to: ORDER_STATUS.SHIPPED },
+  { action: ORDER_STATUS.DELIVERED, from: ORDER_STATUS.SHIPPED,   role: 'seller',             to: ORDER_STATUS.DELIVERED },
+  { action: ORDER_STATUS.COMPLETED, from: ORDER_STATUS.DELIVERED, role: 'buyer',              to: ORDER_STATUS.COMPLETED },
+  { action: ORDER_STATUS.CANCELLED, from: ORDER_STATUS.PAID,      role: 'buyer',              to: ORDER_STATUS.CANCELLED },
+  // Either party may walk away before payment is captured.
+  { action: ORDER_STATUS.CANCELLED, from: ORDER_STATUS.PENDING_PAYMENT, role: ['buyer', 'seller'], to: ORDER_STATUS.CANCELLED },
+];
 
 // ============================================================================
 // Gratis Config

--- a/src/lib/lifecycle/__tests__/state-machine.test.ts
+++ b/src/lib/lifecycle/__tests__/state-machine.test.ts
@@ -1,0 +1,107 @@
+/**
+ * Tests for lifecycle/state-machine.ts — the declarative transition validator
+ * shared by marketplace orders and service appointments.
+ *
+ * Behaviors locked:
+ *   - no row for the action            → { ok: false, reason: 'unknown_action' }
+ *   - row exists, role mismatch        → { ok: false, reason: 'wrong_role' }
+ *   - role ok, from mismatch           → { ok: false, reason: 'wrong_state' }
+ *   - role + from match                → { ok: true, to }
+ *   - role omitted on a row            → any actor allowed
+ *   - role as an array                 → any listed actor allowed
+ *   - to omitted                       → { ok: true, to: null } (non-status action)
+ *   - multiple rows per action         → first matching role+from wins
+ *   - reason priority: role before state
+ */
+
+import { resolveTransition, canTransition, type TransitionTable } from '../state-machine'
+
+// An order-shaped table (action === target status, role-gated).
+const ORDER_TABLE: TransitionTable<'paid' | 'shipped' | 'delivered' | 'completed' | 'cancelled' | 'pending_payment',
+  'shipped' | 'delivered' | 'completed' | 'cancelled', 'buyer' | 'seller'> = [
+  { action: 'shipped', from: 'paid', role: 'seller', to: 'shipped' },
+  { action: 'cancelled', from: 'paid', role: 'buyer', to: 'cancelled' },
+  { action: 'delivered', from: 'shipped', role: 'seller', to: 'delivered' },
+  { action: 'completed', from: 'delivered', role: 'buyer', to: 'completed' },
+  { action: 'cancelled', from: 'pending_payment', role: ['buyer', 'seller'], to: 'cancelled' },
+]
+
+describe('resolveTransition — basic decisions', () => {
+  it('unknown_action when no row matches the action', () => {
+    expect(resolveTransition(ORDER_TABLE, { from: 'paid', action: 'completed', role: 'buyer' }))
+      .toEqual({ ok: false, reason: 'wrong_state' }) // completed exists but from!=delivered
+    expect(resolveTransition(ORDER_TABLE, { from: 'paid', action: 'delivered', role: 'buyer' }))
+      .toEqual({ ok: false, reason: 'wrong_role' }) // delivered is seller-only
+  })
+
+  it('wrong_role when the actor cannot perform the action', () => {
+    expect(resolveTransition(ORDER_TABLE, { from: 'paid', action: 'shipped', role: 'buyer' }))
+      .toEqual({ ok: false, reason: 'wrong_role' })
+  })
+
+  it('wrong_state when role is allowed but the current status is wrong', () => {
+    expect(resolveTransition(ORDER_TABLE, { from: 'paid', action: 'delivered', role: 'seller' }))
+      .toEqual({ ok: false, reason: 'wrong_state' })
+  })
+
+  it('ok with the target status when role and from both match', () => {
+    expect(resolveTransition(ORDER_TABLE, { from: 'paid', action: 'shipped', role: 'seller' }))
+      .toEqual({ ok: true, to: 'shipped' })
+    expect(resolveTransition(ORDER_TABLE, { from: 'delivered', action: 'completed', role: 'buyer' }))
+      .toEqual({ ok: true, to: 'completed' })
+  })
+})
+
+describe('resolveTransition — role variants', () => {
+  it('accepts any listed role for an array role', () => {
+    expect(resolveTransition(ORDER_TABLE, { from: 'pending_payment', action: 'cancelled', role: 'buyer' }))
+      .toEqual({ ok: true, to: 'cancelled' })
+    expect(resolveTransition(ORDER_TABLE, { from: 'pending_payment', action: 'cancelled', role: 'seller' }))
+      .toEqual({ ok: true, to: 'cancelled' })
+  })
+
+  it('picks the matching row when an action has multiple rows (cancelled from paid vs pending_payment)', () => {
+    expect(resolveTransition(ORDER_TABLE, { from: 'paid', action: 'cancelled', role: 'buyer' }))
+      .toEqual({ ok: true, to: 'cancelled' })
+    // seller may cancel, but only from pending_payment — so a paid order is
+    // wrong_state for the seller (the seller-eligible row requires pending_payment).
+    expect(resolveTransition(ORDER_TABLE, { from: 'paid', action: 'cancelled', role: 'seller' }))
+      .toEqual({ ok: false, reason: 'wrong_state' })
+  })
+})
+
+describe('resolveTransition — appointment-shaped (role omitted, to omitted, role array)', () => {
+  const APPT_TABLE: TransitionTable<'requested' | 'completed' | 'cancelled' | 'accepted', 'rate' | 'cancel' | 'unknownish', 'customer' | 'repairer'> = [
+    { action: 'rate', from: 'completed', role: 'customer' }, // no `to` — non-status action
+    { action: 'cancel', from: ['requested', 'accepted'], role: ['customer', 'repairer'], to: 'cancelled' },
+  ]
+
+  it('returns to: null for an action with no target status', () => {
+    expect(resolveTransition(APPT_TABLE, { from: 'completed', action: 'rate', role: 'customer' }))
+      .toEqual({ ok: true, to: null })
+  })
+
+  it('honours an array of allowed from-states', () => {
+    expect(resolveTransition(APPT_TABLE, { from: 'accepted', action: 'cancel', role: 'repairer' }))
+      .toEqual({ ok: true, to: 'cancelled' })
+    expect(resolveTransition(APPT_TABLE, { from: 'completed', action: 'cancel', role: 'customer' }))
+      .toEqual({ ok: false, reason: 'wrong_state' })
+  })
+
+  it('unknown_action for an action with no rows', () => {
+    expect(resolveTransition(APPT_TABLE, { from: 'completed', action: 'unknownish', role: 'customer' }))
+      .toEqual({ ok: false, reason: 'unknown_action' })
+  })
+
+  it('null actor role fails role-gated rows', () => {
+    expect(resolveTransition(APPT_TABLE, { from: 'completed', action: 'rate', role: null }))
+      .toEqual({ ok: false, reason: 'wrong_role' })
+  })
+})
+
+describe('canTransition', () => {
+  it('is true only when resolveTransition is ok', () => {
+    expect(canTransition(ORDER_TABLE, { from: 'paid', action: 'shipped', role: 'seller' })).toBe(true)
+    expect(canTransition(ORDER_TABLE, { from: 'paid', action: 'shipped', role: 'buyer' })).toBe(false)
+  })
+})

--- a/src/lib/lifecycle/index.ts
+++ b/src/lib/lifecycle/index.ts
@@ -2,8 +2,9 @@
  * Shared lifecycle core — the engine common to the three state-machine flows
  * (IT-Hilfe peer-repair, service appointments, marketplace orders).
  *
- * Phase 1 exposes the race-safe transition guard. The declarative
- * transition-table validator (Phase 2) is intentionally not here yet.
+ * Two halves:
+ *   - guarded-transition — race-safe WRITE (lock + re-check + apply in tx)
+ *   - state-machine      — declarative transition-table VALIDATION (legality)
  */
 
 export {
@@ -13,3 +14,12 @@ export {
   type GuardedTransitionOptions,
   type GuardedTransitionResult,
 } from './guarded-transition'
+
+export {
+  resolveTransition,
+  canTransition,
+  type Transition,
+  type TransitionTable,
+  type ResolveReason,
+  type ResolveResult,
+} from './state-machine'

--- a/src/lib/lifecycle/state-machine.ts
+++ b/src/lib/lifecycle/state-machine.ts
@@ -1,0 +1,104 @@
+/**
+ * Declarative state-machine validator — the second half of the shared
+ * lifecycle core (Phase 2). It answers ONE question for a flow: given the
+ * current status, an actor's role, and the action they want, is the
+ * transition legal, and what is the target status?
+ *
+ * Each flow declares its OWN transition table (a list of `Transition` rows)
+ * and shares this one validator, replacing the three bespoke mechanisms that
+ * grew up independently (a `Record<status, next[]>` map, a `switch`, and a
+ * `Record<status, Record<role, next[]>>` matrix). One shape, one validator,
+ * impossible to drift, and the table is auditable data — "what can a buyer
+ * do to a paid order?" is now a value you can read, not control flow.
+ *
+ * The race-safe WRITE side lives in `./guarded-transition`. This module is
+ * pure (no DB) — it only decides legality. IT-Hilfe deliberately does NOT use
+ * it: its OPEN→MATCHED is a two-entity offer acceptance, not a single-row
+ * status transition, so a table shape would add indirection without removing
+ * complexity.
+ */
+
+/**
+ * One legal transition: performing `action` (as `role`) from any status in
+ * `from` moves the row to `to`. `to` is omitted for actions that are gated
+ * by role/state but change no status (e.g. an appointment "rate" or "update").
+ * `role` omitted = any actor.
+ */
+export interface Transition<
+  S extends string = string,
+  A extends string = string,
+  R extends string = string,
+> {
+  action: A
+  from: S | readonly S[]
+  role?: R | readonly R[]
+  /** Target status. Omit for non-status-changing actions (resolve returns `to: null`). */
+  to?: S
+}
+
+export type TransitionTable<
+  S extends string = string,
+  A extends string = string,
+  R extends string = string,
+> = readonly Transition<S, A, R>[]
+
+export type ResolveReason = 'unknown_action' | 'wrong_role' | 'wrong_state'
+
+export type ResolveResult<S extends string = string> =
+  | { ok: true; to: S | null }
+  | { ok: false; reason: ResolveReason }
+
+function toArray<T>(v: T | readonly T[] | undefined): readonly T[] | undefined {
+  if (v === undefined) return undefined
+  return Array.isArray(v) ? (v as readonly T[]) : ([v] as readonly T[])
+}
+
+function roleMatches<R extends string>(
+  transitionRole: R | readonly R[] | undefined,
+  actorRole: R | null | undefined,
+): boolean {
+  // A transition with no `role` is open to any actor.
+  if (transitionRole === undefined) return true
+  if (actorRole == null) return false
+  return toArray(transitionRole)!.includes(actorRole)
+}
+
+function fromMatches<S extends string>(from: S | readonly S[], current: S): boolean {
+  return toArray(from)!.includes(current)
+}
+
+/**
+ * Resolve `{ from, action, role }` against a transition table.
+ *
+ * Reason priority (mirrors hand-rolled "check role, then state" gates):
+ *   - no row for `action`                         → unknown_action
+ *   - row(s) exist, none match the actor's role   → wrong_role
+ *   - role matches but `from` doesn't             → wrong_state
+ *
+ * Multiple rows may share an action (e.g. an order may be cancellable from
+ * several states by different roles); the first row matching both role and
+ * `from` wins.
+ */
+export function resolveTransition<S extends string, A extends string, R extends string>(
+  table: TransitionTable<S, A, R>,
+  input: { from: S; action: A; role?: R | null },
+): ResolveResult<S> {
+  const candidates = table.filter((t) => t.action === input.action)
+  if (candidates.length === 0) return { ok: false, reason: 'unknown_action' }
+
+  const roleOk = candidates.filter((t) => roleMatches(t.role, input.role))
+  if (roleOk.length === 0) return { ok: false, reason: 'wrong_role' }
+
+  const match = roleOk.find((t) => fromMatches(t.from, input.from))
+  if (!match) return { ok: false, reason: 'wrong_state' }
+
+  return { ok: true, to: match.to ?? null }
+}
+
+/** Convenience boolean check when the caller doesn't need the reason or target. */
+export function canTransition<S extends string, A extends string, R extends string>(
+  table: TransitionTable<S, A, R>,
+  input: { from: S; action: A; role?: R | null },
+): boolean {
+  return resolveTransition(table, input).ok
+}

--- a/src/lib/services/appointment-actions.ts
+++ b/src/lib/services/appointment-actions.ts
@@ -11,9 +11,13 @@ import { eq, sql } from 'drizzle-orm'
 import { alias } from 'drizzle-orm/pg-core'
 import { logger } from '@/lib/logger'
 import { sendCustomEmail, appointmentStatusUpdate, appointmentQuoteReceived } from '@/lib/email'
-import { BOOKING_STATUS, getBookingStatusLabel } from '@/config/booking-status'
+import {
+  getBookingStatusLabel,
+  APPOINTMENT_TRANSITIONS,
+  type BookingStatus,
+} from '@/config/booking-status'
 import { TABLE_NAMES } from '@/config/database'
-import { guardedTransition } from '@/lib/lifecycle'
+import { guardedTransition, resolveTransition } from '@/lib/lifecycle'
 import { APP_URL } from '@/config/urls'
 import { SERVICE_APPOINTMENT_ROUTES } from '@/config/service-appointments'
 
@@ -51,7 +55,12 @@ export interface ActionResult {
 
 /**
  * Validate the action and build the update set.
- * Returns null + error message if the action is not allowed.
+ *
+ * Legality (who may do what, from which state, → which status) is the
+ * `APPOINTMENT_TRANSITIONS` SSOT, decided by the shared `resolveTransition`
+ * validator. This function then layers on the per-action SIDE EFFECTS (quote
+ * price, completion notes, rating, …) that the table doesn't carry.
+ * Returns `{ error }` when the action is not allowed.
  */
 export function buildActionUpdate(
   appointment: AppointmentRow,
@@ -64,100 +73,53 @@ export function buildActionUpdate(
   if (!isCustomer && !isRepairer) {
     return { error: 'Kein Zugriff auf diesen Termin' }
   }
-
-  let newStatus: string | null = null
-  const updateSet: Record<string, unknown> = {}
+  // Customer and repairer are distinct accounts on an appointment; map the
+  // actor to one role for the table lookup.
+  const role = isCustomer ? 'customer' : 'repairer'
   const { action } = actionData
 
+  const resolved = resolveTransition(APPOINTMENT_TRANSITIONS, {
+    from: (appointment.status ?? '') as BookingStatus,
+    action: action as (typeof APPOINTMENT_TRANSITIONS)[number]['action'],
+    role,
+  })
+
+  if (!resolved.ok) {
+    if (resolved.reason === 'unknown_action') {
+      return { error: 'Ungültige Aktion: ' + action }
+    }
+    const entry = APPOINTMENT_TRANSITIONS.find((t) => t.action === action)!
+    return { error: resolved.reason === 'wrong_role' ? entry.roleError : entry.stateError }
+  }
+
+  const newStatus = resolved.to
+  const updateSet: Record<string, unknown> = {}
+
+  // Per-action side effects (the table owns from/role/to; this owns the fields).
   switch (action) {
-    case 'accept':
-      if (!isRepairer) return { error: 'Nur der Techniker kann annehmen' }
-      if (appointment.status !== BOOKING_STATUS.REQUESTED) return { error: 'Termin kann nicht angenommen werden' }
-      newStatus = BOOKING_STATUS.ACCEPTED
-      break
-
-    case 'reject':
-      if (!isRepairer) return { error: 'Nur der Techniker kann ablehnen' }
-      if (appointment.status !== BOOKING_STATUS.REQUESTED) return { error: 'Termin kann nicht abgelehnt werden' }
-      newStatus = BOOKING_STATUS.REJECTED
-      break
-
     case 'quote':
-      if (!isRepairer) return { error: 'Nur der Techniker kann Angebote erstellen' }
-      if (!([BOOKING_STATUS.ACCEPTED, BOOKING_STATUS.QUOTE_REJECTED] as string[]).includes(appointment.status!)) {
-        return { error: 'Angebot kann in diesem Status nicht erstellt werden' }
-      }
-      newStatus = BOOKING_STATUS.QUOTED
       updateSet.quotedPriceChf = actionData.quoted_price_chf
-      if (actionData.diagnosis_notes) {
-        updateSet.diagnosisNotes = actionData.diagnosis_notes
-      }
+      if (actionData.diagnosis_notes) updateSet.diagnosisNotes = actionData.diagnosis_notes
       break
-
     case 'approve_quote':
-      if (!isCustomer) return { error: 'Nur der Kunde kann Angebote bestätigen' }
-      if (appointment.status !== BOOKING_STATUS.QUOTED) return { error: 'Kein Angebot zum Bestätigen' }
-      newStatus = BOOKING_STATUS.QUOTE_APPROVED
       updateSet.quoteApproved = true
       updateSet.quoteApprovedAt = sql`CURRENT_TIMESTAMP`
       break
-
-    case 'reject_quote':
-      if (!isCustomer) return { error: 'Nur der Kunde kann Angebote ablehnen' }
-      if (appointment.status !== BOOKING_STATUS.QUOTED) return { error: 'Kein Angebot zum Ablehnen' }
-      newStatus = BOOKING_STATUS.QUOTE_REJECTED
-      break
-
     case 'start':
-      if (!isRepairer) return { error: 'Nur der Techniker kann starten' }
-      if (!([BOOKING_STATUS.ACCEPTED, BOOKING_STATUS.QUOTE_APPROVED] as string[]).includes(appointment.status!)) {
-        return { error: 'Termin kann nicht gestartet werden' }
-      }
-      newStatus = BOOKING_STATUS.IN_PROGRESS
-      if (actionData.confirmed_date) {
-        updateSet.confirmedDate = actionData.confirmed_date
-      }
+      if (actionData.confirmed_date) updateSet.confirmedDate = actionData.confirmed_date
       break
-
     case 'complete':
-      if (!isRepairer) return { error: 'Nur der Techniker kann abschliessen' }
-      if (appointment.status !== BOOKING_STATUS.IN_PROGRESS) return { error: 'Termin ist nicht in Bearbeitung' }
-      newStatus = BOOKING_STATUS.COMPLETED
       updateSet.completedAt = sql`CURRENT_TIMESTAMP`
-      if (actionData.completion_notes) {
-        updateSet.completionNotes = actionData.completion_notes
-      }
+      if (actionData.completion_notes) updateSet.completionNotes = actionData.completion_notes
       break
-
     case 'update':
-      if (!isCustomer) return { error: 'Nur der Kunde kann Angaben bearbeiten' }
-      if (appointment.status !== BOOKING_STATUS.REQUESTED) return { error: 'Angaben können nur im Status "Angefragt" bearbeitet werden' }
-      if (actionData.description) {
-        updateSet.description = actionData.description
-      }
-      if (actionData.preferred_date) {
-        updateSet.preferredDate = actionData.preferred_date
-      }
+      if (actionData.description) updateSet.description = actionData.description
+      if (actionData.preferred_date) updateSet.preferredDate = actionData.preferred_date
       break
-
     case 'rate':
-      if (!isCustomer) return { error: 'Nur der Kunde kann bewerten' }
-      if (appointment.status !== BOOKING_STATUS.COMPLETED) return { error: 'Nur abgeschlossene Termine können bewertet werden' }
       updateSet.customerRating = actionData.customer_rating
-      if (actionData.customer_review) {
-        updateSet.customerReview = actionData.customer_review
-      }
+      if (actionData.customer_review) updateSet.customerReview = actionData.customer_review
       break
-
-    case 'cancel':
-      if (!([BOOKING_STATUS.REQUESTED, BOOKING_STATUS.ACCEPTED, BOOKING_STATUS.QUOTED, BOOKING_STATUS.QUOTE_APPROVED] as string[]).includes(appointment.status!)) {
-        return { error: 'Termin kann nicht mehr storniert werden' }
-      }
-      newStatus = BOOKING_STATUS.CANCELLED
-      break
-
-    default:
-      return { error: 'Ungültige Aktion: ' + action }
   }
 
   if (newStatus) {


### PR DESCRIPTION
## What

Phase 2 of #3 pipeline unification (Piece A). Adds `resolveTransition` — one validator over a per-flow `TransitionTable` (`{ action, from, role?, to? }`), returning `{ ok, to }` or `{ ok:false, reason: unknown_action | wrong_role | wrong_state }` (role checked before state). Replaces the two bespoke validation mechanisms with one shared, auditable SSOT.

| Flow | Before | After |
|---|---|---|
| Orders | route-local `STATUS_TRANSITIONS` matrix + special-case | `ORDER_TRANSITIONS` SSOT in `config/marketplace.ts`; same table drives fast-fail **and** under-lock re-check |
| Appointments | `buildActionUpdate` switch (role/from/to gates tangled with side-effects) | `APPOINTMENT_TRANSITIONS` SSOT in `config/booking-status.ts` (carries exact `roleError`/`stateError`); switch now builds only side-effect fields |

IT-Hilfe keeps `VALID_REQUEST_TRANSITIONS` as-is (two-entity offer acceptance, not a single-row transition).

## Behavior preserved
- Orders: all security boundaries + the "nicht erlaubt" message unchanged (the table is the sole guard against bypassing the Payrexx flow).
- Appointments: exact per-action error strings + 403/400 mapping unchanged.

## Verification
- Typecheck clean · lint clean · umlauts clean
- `resolveTransition` unit tests added; order/appointment test mocks updated
- Full suite: **zero new failures vs baseline** (identical 7-suite pre-existing set)

🤖 Generated with [Claude Code](https://claude.com/claude-code)