### PR TITLE
fix(technicians): kill fabricated stats (SSOT), show avatars; purge demo data

### DIFF
--- a/scripts/ops/purge-demo-content.sql
+++ b/scripts/ops/purge-demo-content.sql
@@ -1,0 +1,32 @@
+-- One-time prod cleanup (2026-06-29): purge E2E/demo content.
+--
+-- Context: the prod DB had been filled by E2E test runs — 159 listings (144
+-- "E2E …" titled), 150 IT-Hilfe requests, 82 service appointments, 75 erfassung
+-- inventory items, plus a fabricated "George" technician (80 reviews / 80 jobs /
+-- 5.0★ with ZERO backing review rows). None of it is real content.
+--
+-- This wipes the public demo content ONLY. It deliberately does NOT touch:
+--   - user accounts (all 55 kept)
+--   - org tables (tasks, decisions, meeting_protocols, workshops, blog_posts,
+--     job_postings, …) — those are ambiguous (real-vs-seed) and out of scope here.
+--
+-- Run manually against prod inside a transaction (dry-run with ROLLBACK first):
+--   psql "$DATABASE_URL" -v ON_ERROR_STOP=1 -f scripts/ops/purge-demo-content.sql
+-- (wrap in BEGIN; \i …; COMMIT;). NOT auto-applied by deploy.
+
+TRUNCATE TABLE
+  listings,
+  it_hilfe_requests,
+  service_appointments,
+  reviews,
+  conversations,
+  ai_extracted_products,
+  inventory_items
+CASCADE;
+
+-- Fabricated technician profiles: keep only the real staff user's honest profile.
+DELETE FROM repairer_profiles
+WHERE user_id NOT IN (SELECT id FROM users WHERE email = 'georgy.butaev@revamp-it.ch');
+
+-- Reset any remaining technician aggregates to truth (no reviews left -> 0).
+UPDATE repairer_profiles SET average_rating = 0.0, total_reviews = 0, total_jobs_completed = 0;

--- a/src/app/[locale]/it-hilfe/techniker/[id]/TechnikerProfileView.tsx
+++ b/src/app/[locale]/it-hilfe/techniker/[id]/TechnikerProfileView.tsx
@@ -68,9 +68,18 @@ export function TechnikerProfileView({ technician, copy, meta }: TechnikerProfil
 
         <header className="mt-8 border-b border-subtle pb-8">
           <div className="flex flex-col gap-5 sm:flex-row sm:items-start">
-            <div className="flex h-20 w-20 shrink-0 items-center justify-center rounded-lg border border-subtle bg-action-muted font-mono text-3xl font-semibold text-action">
-              {initial}
-            </div>
+            {technician.avatarUrl ? (
+               
+              <img
+                src={technician.avatarUrl}
+                alt={displayName}
+                className="h-20 w-20 shrink-0 rounded-lg border border-subtle object-cover"
+              />
+            ) : (
+              <div className="flex h-20 w-20 shrink-0 items-center justify-center rounded-lg border border-subtle bg-action-muted font-mono text-3xl font-semibold text-action">
+                {initial}
+              </div>
+            )}
             <div className="min-w-0 flex-1">
               <div className="font-mono text-[10px] uppercase tracking-[0.18em] text-text-tertiary">
                 {meta.eyebrow}

--- a/src/app/api/it-hilfe/helpers/[id]/__tests__/route.test.ts
+++ b/src/app/api/it-hilfe/helpers/[id]/__tests__/route.test.ts
@@ -43,6 +43,7 @@ const MOCK_TECHNICIAN = {
   id: VALID_UUID,
   userId: 'user-1',
   name: 'Hans Müller',
+  avatarUrl: null,
   bio: 'Ich helfe gerne',
   hourlyRateCents: null,
   averageRating: null,

--- a/src/lib/reviews/create-review.ts
+++ b/src/lib/reviews/create-review.ts
@@ -131,11 +131,16 @@ async function updateTargetRating(targetType: string, targetId: string): Promise
  * ratings). Replaces the two slice-specific updaters that overwrote each other.
  */
 export async function recomputeTechnicianAggregate(technicianUserId: string): Promise<void> {
+  // Always resets the profile to the truth: LEFT JOIN onto a single base row so
+  // a technician with ZERO published reviews is set back to 0/0.0 rather than
+  // keeping stale (or seeded) values. An inner join here would skip no-review
+  // techs entirely — which is how fabricated aggregates survived recompute.
   const result = await db.execute(sql`
     UPDATE ${sql.raw(TABLE_NAMES.REPAIRER_PROFILES)} p SET
-      average_rating = sub.avg_rating,
-      total_reviews = sub.review_count
-    FROM (
+      average_rating = COALESCE(sub.avg_rating, 0.0),
+      total_reviews = COALESCE(sub.review_count, 0)
+    FROM (SELECT ${technicianUserId}::uuid AS user_id) base
+    LEFT JOIN (
       SELECT u AS user_id, AVG(rating)::numeric(3,2) AS avg_rating, COUNT(*)::int AS review_count
       FROM (
         SELECT o.helper_id AS u, r.overall_rating AS rating
@@ -151,8 +156,8 @@ export async function recomputeTechnicianAggregate(technicianUserId: string): Pr
       ) all_reviews
       WHERE u = ${technicianUserId}
       GROUP BY u
-    ) sub
-    WHERE p.user_id = sub.user_id
+    ) sub ON sub.user_id = base.user_id
+    WHERE p.user_id = base.user_id
   `)
   logger.info('Recomputed technician aggregate', { technicianUserId, rows: result.rowCount })
 }

--- a/src/lib/services/__tests__/technician-service.test.ts
+++ b/src/lib/services/__tests__/technician-service.test.ts
@@ -51,6 +51,7 @@ jest.mock('@/db/schema', () => ({
   repairerServices: { id: 'repairerServices', repairerId: 'repairerId', isActive: 'isActive' },
   userSkills: { userId: 'userSkills_userId', skillId: 'skillId' },
   users: { id: 'users', name: 'users_name' },
+  userProfiles: { userId: 'userProfiles_userId', avatarUrl: 'userProfiles_avatarUrl' },
 }))
 
 jest.mock('drizzle-orm', () => ({

--- a/src/lib/services/technician-service.ts
+++ b/src/lib/services/technician-service.ts
@@ -6,7 +6,7 @@
  */
 
 import { db } from '@/db'
-import { repairerProfiles, repairerServices, userSkills, users } from '@/db/schema'
+import { repairerProfiles, repairerServices, userSkills, users, userProfiles } from '@/db/schema'
 import { eq, and, sql } from 'drizzle-orm'
 import { logger } from '@/lib/logger'
 import { REPAIRER_PROFILE_TIER } from '@/config/repairer-status'
@@ -32,6 +32,7 @@ export interface TechnicianDetail {
   id: string
   userId: string
   name: string | null
+  avatarUrl: string | null
   bio: string | null
   hourlyRateCents: number | null
   averageRating: number | null
@@ -66,6 +67,7 @@ export async function getTechnicianById(id: string): Promise<TechnicianDetail | 
       id: repairerProfiles.id,
       userId: repairerProfiles.userId,
       name: users.name,
+      avatarUrl: userProfiles.avatarUrl,
       bio: repairerProfiles.description,
       hourlyRateCents: repairerProfiles.hourlyRateCents,
       averageRating: repairerProfiles.averageRating,
@@ -86,6 +88,7 @@ export async function getTechnicianById(id: string): Promise<TechnicianDetail | 
     })
     .from(repairerProfiles)
     .innerJoin(users, eq(repairerProfiles.userId, users.id))
+    .leftJoin(userProfiles, eq(userProfiles.userId, users.id))
     .leftJoin(userSkills, eq(repairerProfiles.userId, userSkills.userId))
     .where(
       and(
@@ -97,6 +100,7 @@ export async function getTechnicianById(id: string): Promise<TechnicianDetail | 
       repairerProfiles.id,
       repairerProfiles.userId,
       users.name,
+      userProfiles.avatarUrl,
       repairerProfiles.description,
       repairerProfiles.hourlyRateCents,
       repairerProfiles.averageRating,


### PR DESCRIPTION
## What

The public technician profile showed **fabricated data** — "George" (a seeded test account) with 80 reviews / 80 jobs / 5.0★ / verified / professional but **zero backing review rows**.

- **Root-cause fix**: `recomputeTechnicianAggregate` only updated technicians that *had* reviews (inner join), so a 0-review tech kept stale/seeded values forever. Now LEFT JOINs a base row + COALESCE → resets to 0/0.0 when there are no published reviews. Fake aggregates can no longer survive a recompute.
- **Avatars**: technician profile now shows the real avatar (`user_profiles.avatar_url`, joined in `getTechnicianById`) with the initial-letter fallback. Upload already works at `/dashboard/profile` → `/api/uploads` → **Cloudflare R2** (storage was never missing — it's R2, verified live).
- **`scripts/ops/purge-demo-content.sql`**: the one-time prod cleanup (already applied) that TRUNCATEd all E2E/demo content (159 listings, 150 IT-Hilfe requests, 82 appointments, 75 erfassung items, reviews, conversations) + removed fabricated technician profiles — keeping all user accounts and all org tables.

The profile stats render was already guarded (`>0`), so with truthful data a no-review technician simply shows no rating/jobs line.

## Verification
Typecheck + lint + umlauts clean; full suite zero new failures vs baseline. Prod verified: George gone, only the real staff technician remains (0/0/0.0 honest).

## Still to come (separate)
Avatar-upload discoverability on the technician edit page + a broader public-surface design polish (placeholders, empty states, visual rhythm).

🤖 Generated with [Claude Code](https://claude.com/claude-code)