### PR TITLE
feat(design): shared Avatar primitive + nicer no-image placeholder

### DIFF
--- a/src/app/[locale]/it-hilfe/techniker/[id]/TechnikerProfileView.tsx
+++ b/src/app/[locale]/it-hilfe/techniker/[id]/TechnikerProfileView.tsx
@@ -4,6 +4,7 @@ import { getServiceTypeById, getSkillById, IT_HILFE } from '@/config/it-hilfe'
 import { REPAIRER_PROFILE_TIER } from '@/config/repairer-status'
 import { ROUTES } from '@/config/routes'
 import { formatCentsToChf } from '@/lib/pricing'
+import { Avatar } from '@/components/ui/Avatar'
 import type { TechnicianDetail } from '@/lib/services/technician-service'
 
 export type TechnikerProfileCopy = {
@@ -45,7 +46,6 @@ export function TechnikerProfileView({ technician, copy, meta }: TechnikerProfil
   const isPro = technician.profileTier === REPAIRER_PROFILE_TIER.PROFESSIONAL
   const ctaHref = IT_HILFE.routes.createForTechnician(technician.id)
   const displayName = technician.name ?? copy.community
-  const initial = displayName.trim().charAt(0).toUpperCase() || 'T'
 
   const skillLabels = technician.skills
     .map((id) => getSkillById(id)?.name)
@@ -68,18 +68,7 @@ export function TechnikerProfileView({ technician, copy, meta }: TechnikerProfil
 
         <header className="mt-8 border-b border-subtle pb-8">
           <div className="flex flex-col gap-5 sm:flex-row sm:items-start">
-            {technician.avatarUrl ? (
-               
-              <img
-                src={technician.avatarUrl}
-                alt={displayName}
-                className="h-20 w-20 shrink-0 rounded-lg border border-subtle object-cover"
-              />
-            ) : (
-              <div className="flex h-20 w-20 shrink-0 items-center justify-center rounded-lg border border-subtle bg-action-muted font-mono text-3xl font-semibold text-action">
-                {initial}
-              </div>
-            )}
+            <Avatar src={technician.avatarUrl} name={displayName} size="xl" />
             <div className="min-w-0 flex-1">
               <div className="font-mono text-[10px] uppercase tracking-[0.18em] text-text-tertiary">
                 {meta.eyebrow}

--- a/src/components/marketplace/ListingImage.tsx
+++ b/src/components/marketplace/ListingImage.tsx
@@ -3,6 +3,7 @@
 import { useState } from 'react'
 import Image from 'next/image'
 import { ImageIcon } from 'lucide-react'
+import { cn } from '@/lib/utils'
 
 interface ListingImageProps {
   src: string | null | undefined
@@ -22,8 +23,10 @@ export function ListingImage({ src, alt, className = 'w-full h-full object-cover
 
   if (!src || hasError) {
     return (
-      <div className="flex h-full w-full items-center justify-center bg-[radial-gradient(circle_at_50%_38%,var(--surface-overlay),var(--surface-base)_64%)]">
-        <ImageIcon className={`${fallbackIconSize} text-text-muted/70`} aria-hidden="true" />
+      <div className="flex h-full w-full items-center justify-center bg-surface-raised">
+        <div className="flex items-center justify-center rounded-full border border-subtle bg-surface-base p-3 shadow-xs">
+          <ImageIcon className={cn('text-text-tertiary', fallbackIconSize)} aria-hidden="true" />
+        </div>
       </div>
     )
   }

--- a/src/components/ui/Avatar.tsx
+++ b/src/components/ui/Avatar.tsx
@@ -1,0 +1,57 @@
+import { cn } from '@/lib/utils'
+
+interface AvatarProps {
+  /** Avatar image URL (e.g. user_profiles.avatar_url). When absent, the initial is shown. */
+  src?: string | null
+  /** Display name — drives the alt text and the initial fallback. */
+  name?: string | null
+  size?: 'sm' | 'md' | 'lg' | 'xl'
+  className?: string
+}
+
+const BOX: Record<NonNullable<AvatarProps['size']>, string> = {
+  sm: 'h-9 w-9',
+  md: 'h-12 w-12',
+  lg: 'h-16 w-16',
+  xl: 'h-20 w-20',
+}
+const TEXT: Record<NonNullable<AvatarProps['size']>, string> = {
+  sm: 'text-sm',
+  md: 'text-lg',
+  lg: 'text-2xl',
+  xl: 'text-3xl',
+}
+
+/**
+ * Avatar — one source of truth for "image or initial". Renders the uploaded
+ * photo when present, else a tokenized initial tile (no ad-hoc placeholders).
+ * Square with the card radius to match the fleetcrown public surfaces.
+ */
+export function Avatar({ src, name, size = 'md', className }: AvatarProps) {
+  const initial = name?.trim().charAt(0).toUpperCase() || 'T'
+
+  if (src) {
+    return (
+       
+      <img
+        src={src}
+        alt={name ?? ''}
+        className={cn('shrink-0 rounded-lg border border-subtle object-cover', BOX[size], className)}
+      />
+    )
+  }
+
+  return (
+    <div
+      className={cn(
+        'flex shrink-0 items-center justify-center rounded-lg border border-subtle bg-action-muted font-mono font-semibold text-action',
+        BOX[size],
+        TEXT[size],
+        className,
+      )}
+      aria-hidden="true"
+    >
+      {initial}
+    </div>
+  )
+}


### PR DESCRIPTION
Focused first pass of the public-surface polish:
- **`Avatar` primitive** (`src/components/ui/Avatar.tsx`) — one source of truth for image-or-initial; applied to the technician profile (real R2 avatar + initial fallback), ready to reuse elsewhere.
- **Nicer no-image placeholder** (`ListingImage`) — bordered icon chip on a raised surface instead of the flat radial gradient.

Semantic tokens only (no arbitrary hex), monochrome discipline kept. typecheck + lint + tests green.

🤖 Generated with [Claude Code](https://claude.com/claude-code)