### PR TITLE
fix(admin): correct two broken admin dashboard queries (wrong columns)

### DIFF
--- a/src/app/admin/users/[id]/page.tsx
+++ b/src/app/admin/users/[id]/page.tsx
@@ -71,10 +71,11 @@ async function getUser(id: string): Promise<UserData | null> {
         u.staff_permissions,
         u."createdAt" as created_at,
         u."emailVerified" as email_verified,
-        u.phone,
-        u.address,
+        up.phone,
+        up.address_line1 as address,
         tp.id as team_profile_id
        FROM ${TABLE_NAMES.USERS} u
+       LEFT JOIN ${TABLE_NAMES.USER_PROFILES} up ON u.id = up.user_id
        LEFT JOIN ${TABLE_NAMES.TEAM_PROFILES} tp ON u.id = tp.user_id
        WHERE u.id = $1`,
       [id]

--- a/src/components/admin/dashboard/getDashboardStats.ts
+++ b/src/components/admin/dashboard/getDashboardStats.ts
@@ -191,7 +191,7 @@ export async function getDashboardStats(isSuper: boolean): Promise<DashboardStat
     db.execute(sql`
       SELECT COUNT(*) AS count
       FROM ${sql.raw(blogTable)}
-      WHERE status = ${APPROVAL_STATUS.PUBLISHED} AND published_at >= ${weekAgoISO}
+      WHERE is_published = true AND published_at >= ${weekAgoISO}
     `),
 
     // Mission metrics — this month's impact


### PR DESCRIPTION
Two pre-existing raw-SQL queries referenced non-existent columns (caught + logged, pages degraded silently — found via prod error logs):

- **`getDashboardStats`**: counted weekly blog posts with `WHERE status = 'published'`, but `blog_posts` has no `status` column → use `is_published = true`.
- **`/admin/users/[id]`**: selected `u.phone` / `u.address` from `users` (neither exists; Postgres hinted "did you mean tp.phone") → source both from `user_profiles` via LEFT JOIN.

Both corrected queries verified against the prod schema. typecheck + lint clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)