### PR TITLE
refactor(profiles): technician read+write in service, thin route (debt #5 phase 2)

### DIFF
--- a/src/app/api/user/technician-profile/route.ts
+++ b/src/app/api/user/technician-profile/route.ts
@@ -10,18 +10,11 @@
 
 import { NextRequest } from 'next/server'
 import { withAuth, ValidSession } from '@/lib/api/middleware'
-import { db } from '@/db'
-import { repairerProfiles, userSkills } from '@/db/schema'
-import { eq, sql } from 'drizzle-orm'
-import {
-  apiError,
-  apiSuccess,
-} from '@/lib/api/helpers'
+import { apiError, apiSuccess } from '@/lib/api/helpers'
 import { ERROR_MESSAGES } from '@/config/error-messages'
-import { REPAIRER_STATUS, REPAIRER_PROFILE_TIER } from '@/config/repairer-status'
 import { logger } from '@/lib/logger'
-import { IT_SKILLS } from '@/config/it-hilfe'
 import { validateBody, TechnicianProfileSchema } from '@/lib/schemas'
+import { getTechnicianSelfProfile, upsertTechnicianProfile } from '@/lib/services/technician-service'
 
 /**
  * GET /api/user/technician-profile
@@ -29,67 +22,8 @@ import { validateBody, TechnicianProfileSchema } from '@/lib/schemas'
  */
 export const GET = withAuth(async (_request: NextRequest, session: ValidSession) => {
   try {
-    const [profileRow] = await db
-      .select({
-        bio: repairerProfiles.description,
-        hourlyRateCents: repairerProfiles.hourlyRateCents,
-        acceptsGratis: repairerProfiles.acceptsGratis,
-        acceptsKulturlegi: repairerProfiles.acceptsKulturlegi,
-        serviceTypes: repairerProfiles.serviceDeliveryTypes,
-        postalCode: repairerProfiles.postalCode,
-        city: repairerProfiles.city,
-        canton: repairerProfiles.canton,
-        maxTravelKm: repairerProfiles.maxTravelKm,
-        isActive: repairerProfiles.isActive,
-        profileTier: repairerProfiles.profileTier,
-      })
-      .from(repairerProfiles)
-      .where(eq(repairerProfiles.userId, session.user.id))
-
-    const skillRows = await db
-      .select({
-        skillId: userSkills.skillId,
-        categoryId: userSkills.categoryId,
-      })
-      .from(userSkills)
-      .where(eq(userSkills.userId, session.user.id))
-
-    const profile = profileRow
-      ? {
-          skills: skillRows.map((r) => r.skillId),
-          bio: profileRow.bio || '',
-          hourlyRateCents: profileRow.hourlyRateCents,
-          acceptsGratis: profileRow.acceptsGratis ?? true,
-          acceptsKulturlegi: profileRow.acceptsKulturlegi ?? true,
-          serviceTypes: profileRow.serviceTypes || ['flexible'],
-          postalCode: profileRow.postalCode || '',
-          city: profileRow.city || '',
-          canton: profileRow.canton || '',
-          maxTravelKm: profileRow.maxTravelKm ?? 10,
-          isActive: profileRow.isActive ?? false,
-          profileTier: profileRow.profileTier,
-        }
-      : skillRows.length > 0
-        ? {
-            skills: skillRows.map((r) => r.skillId),
-            bio: '',
-            hourlyRateCents: null,
-            acceptsGratis: true,
-            acceptsKulturlegi: true,
-            serviceTypes: ['flexible'],
-            postalCode: '',
-            city: '',
-            canton: '',
-            maxTravelKm: 10,
-            isActive: false,
-            profileTier: REPAIRER_PROFILE_TIER.COMMUNITY,
-          }
-        : null
-
-    return apiSuccess({
-      profile,
-      hasProfile: !!profileRow,
-    })
+    const { profile, hasProfile } = await getTechnicianSelfProfile(session.user.id)
+    return apiSuccess({ profile, hasProfile })
   } catch (error) {
     logger.error('Error fetching technician profile', { error })
     return apiError(error, ERROR_MESSAGES.INTERNAL_SERVER_ERROR)
@@ -106,84 +40,13 @@ export const PUT = withAuth(async (request: NextRequest, session: ValidSession) 
     const body = await request.json()
     const validation = validateBody(TechnicianProfileSchema, body)
     if (!validation.success) return validation.error
-    const {
-      skills,
-      bio,
-      hourlyRateCents,
-      acceptsGratis,
-      acceptsKulturlegi,
-      serviceTypes,
-      postalCode,
-      city,
-      canton,
-      maxTravelKm,
-      isActive,
-    } = validation.data
 
-    // repairer_profiles requires phone, address, city, postal_code (NOT NULL).
-    // For community self-registration, use defaults so the INSERT succeeds.
-    // These can be updated later via a fuller profile form.
-    await db
-      .insert(repairerProfiles)
-      .values({
-        userId: session.user.id,
-        description: bio || undefined,
-        hourlyRateCents,
-        acceptsGratis,
-        acceptsKulturlegi,
-        serviceDeliveryTypes: serviceTypes.length > 0 ? serviceTypes : undefined,
-        city: city || '',
-        canton: canton || null,
-        postalCode: postalCode || '',
-        // required NOT NULL columns — use empty strings as placeholder for community users
-        phone: '',
-        address: '',
-        maxTravelKm,
-        isActive,
-        profileTier: REPAIRER_PROFILE_TIER.COMMUNITY,
-        status: REPAIRER_STATUS.ACTIVE,
-      })
-      .onConflictDoUpdate({
-        target: repairerProfiles.userId,
-        set: {
-          description: bio || null,
-          hourlyRateCents,
-          acceptsGratis,
-          acceptsKulturlegi,
-          serviceDeliveryTypes: serviceTypes.length > 0 ? serviceTypes : null,
-          city: city || '',
-          canton: canton || null,
-          postalCode: postalCode || '',
-          maxTravelKm,
-          isActive,
-          // Only set tier to 'community' if it is not already 'professional'
-          // (don't demote a verified professional via this endpoint)
-          profileTier: sql`CASE WHEN ${repairerProfiles.profileTier} = ${REPAIRER_PROFILE_TIER.PROFESSIONAL} THEN ${REPAIRER_PROFILE_TIER.PROFESSIONAL} ELSE ${REPAIRER_PROFILE_TIER.COMMUNITY} END`,
-          updatedAt: sql`NOW()`,
-        },
-      })
-
-    // Replace skills: delete existing, insert new
-    await db
-      .delete(userSkills)
-      .where(eq(userSkills.userId, session.user.id))
-
-    if (skills.length > 0) {
-      const skillValues = skills.map((skillId: string) => ({
-        userId: session.user.id,
-        skillId,
-        categoryId: getCategoryForSkill(skillId),
-      }))
-
-      await db
-        .insert(userSkills)
-        .values(skillValues)
-    }
+    await upsertTechnicianProfile(session.user.id, validation.data)
 
     logger.info('Updated technician profile', {
       userId: session.user.id,
-      skillCount: skills.length,
-      isActive,
+      skillCount: validation.data.skills.length,
+      isActive: validation.data.isActive,
     })
 
     return apiSuccess({
@@ -194,17 +57,3 @@ export const PUT = withAuth(async (request: NextRequest, session: ValidSession) 
     return apiError(error, ERROR_MESSAGES.INTERNAL_SERVER_ERROR)
   }
 })
-
-/**
- * Get category ID for a skill
- */
-function getCategoryForSkill(skillId: string): string {
-  for (const [categoryId, skills] of Object.entries(IT_SKILLS)) {
-    if (
-      (skills as Array<{ id: string }>).some((s) => s.id === skillId)
-    ) {
-      return categoryId
-    }
-  }
-  return 'other'
-}

--- a/src/lib/services/technician-service.ts
+++ b/src/lib/services/technician-service.ts
@@ -9,7 +9,9 @@ import { db } from '@/db'
 import { repairerProfiles, repairerServices, userSkills, users, userProfiles } from '@/db/schema'
 import { eq, and, sql } from 'drizzle-orm'
 import { logger } from '@/lib/logger'
-import { REPAIRER_PROFILE_TIER } from '@/config/repairer-status'
+import { REPAIRER_PROFILE_TIER, REPAIRER_STATUS } from '@/config/repairer-status'
+import { IT_SKILLS } from '@/config/it-hilfe'
+import type { TechnicianProfileInput } from '@/lib/schemas'
 
 export const TECHNICIAN_UUID_RE =
   /^[0-9a-f]{8}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{12}$/i
@@ -178,4 +180,167 @@ export async function getTechnicianByIdOrUserId(id: string): Promise<TechnicianD
 
   if (!profile) return null
   return getTechnicianById(profile.profileId)
+}
+
+// ============================================================================
+// Self-service profile (community technicians) — read + write
+// ============================================================================
+
+export interface TechnicianSelfProfile {
+  skills: string[]
+  bio: string
+  hourlyRateCents: number | null
+  acceptsGratis: boolean
+  acceptsKulturlegi: boolean
+  serviceTypes: string[]
+  postalCode: string
+  city: string
+  canton: string
+  maxTravelKm: number
+  isActive: boolean
+  profileTier: string | null
+}
+
+/**
+ * Read the current user's own technician profile + skills (the self-service
+ * edit shape — keyed by user_id, not profile id). Returns the profile (or a
+ * skills-only stub if the user has skills but no profile row yet) and whether a
+ * profile row exists.
+ */
+export async function getTechnicianSelfProfile(
+  userId: string,
+): Promise<{ profile: TechnicianSelfProfile | null; hasProfile: boolean }> {
+  const [profileRow] = await db
+    .select({
+      bio: repairerProfiles.description,
+      hourlyRateCents: repairerProfiles.hourlyRateCents,
+      acceptsGratis: repairerProfiles.acceptsGratis,
+      acceptsKulturlegi: repairerProfiles.acceptsKulturlegi,
+      serviceTypes: repairerProfiles.serviceDeliveryTypes,
+      postalCode: repairerProfiles.postalCode,
+      city: repairerProfiles.city,
+      canton: repairerProfiles.canton,
+      maxTravelKm: repairerProfiles.maxTravelKm,
+      isActive: repairerProfiles.isActive,
+      profileTier: repairerProfiles.profileTier,
+    })
+    .from(repairerProfiles)
+    .where(eq(repairerProfiles.userId, userId))
+
+  const skillRows = await db
+    .select({ skillId: userSkills.skillId })
+    .from(userSkills)
+    .where(eq(userSkills.userId, userId))
+  const skills = skillRows.map((r) => r.skillId)
+
+  let profile: TechnicianSelfProfile | null = null
+  if (profileRow) {
+    profile = {
+      skills,
+      bio: profileRow.bio || '',
+      hourlyRateCents: profileRow.hourlyRateCents,
+      acceptsGratis: profileRow.acceptsGratis ?? true,
+      acceptsKulturlegi: profileRow.acceptsKulturlegi ?? true,
+      serviceTypes: profileRow.serviceTypes || ['flexible'],
+      postalCode: profileRow.postalCode || '',
+      city: profileRow.city || '',
+      canton: profileRow.canton || '',
+      maxTravelKm: profileRow.maxTravelKm ?? 10,
+      isActive: profileRow.isActive ?? false,
+      profileTier: profileRow.profileTier,
+    }
+  } else if (skills.length > 0) {
+    profile = {
+      skills,
+      bio: '',
+      hourlyRateCents: null,
+      acceptsGratis: true,
+      acceptsKulturlegi: true,
+      serviceTypes: ['flexible'],
+      postalCode: '',
+      city: '',
+      canton: '',
+      maxTravelKm: 10,
+      isActive: false,
+      profileTier: REPAIRER_PROFILE_TIER.COMMUNITY,
+    }
+  }
+
+  return { profile, hasProfile: !!profileRow }
+}
+
+/** Resolve a skill id to its IT_SKILLS category (for user_skills.category_id). */
+function getCategoryForSkill(skillId: string): string {
+  for (const [categoryId, skills] of Object.entries(IT_SKILLS)) {
+    if ((skills as Array<{ id: string }>).some((s) => s.id === skillId)) {
+      return categoryId
+    }
+  }
+  return 'other'
+}
+
+/**
+ * Create or update the current user's self-service (community) technician
+ * profile, then replace their skill set. Upserts repairer_profiles with
+ * tier=community but NEVER demotes an existing professional (tier guard in the
+ * conflict update). NOT-NULL placeholder columns (phone/address) default to ''.
+ */
+export async function upsertTechnicianProfile(
+  userId: string,
+  input: TechnicianProfileInput,
+): Promise<void> {
+  const {
+    skills, bio, hourlyRateCents, acceptsGratis, acceptsKulturlegi,
+    serviceTypes, postalCode, city, canton, maxTravelKm, isActive,
+  } = input
+
+  await db
+    .insert(repairerProfiles)
+    .values({
+      userId,
+      description: bio || undefined,
+      hourlyRateCents,
+      acceptsGratis,
+      acceptsKulturlegi,
+      serviceDeliveryTypes: serviceTypes.length > 0 ? serviceTypes : undefined,
+      city: city || '',
+      canton: canton || null,
+      postalCode: postalCode || '',
+      phone: '',
+      address: '',
+      maxTravelKm,
+      isActive,
+      profileTier: REPAIRER_PROFILE_TIER.COMMUNITY,
+      status: REPAIRER_STATUS.ACTIVE,
+    })
+    .onConflictDoUpdate({
+      target: repairerProfiles.userId,
+      set: {
+        description: bio || null,
+        hourlyRateCents,
+        acceptsGratis,
+        acceptsKulturlegi,
+        serviceDeliveryTypes: serviceTypes.length > 0 ? serviceTypes : null,
+        city: city || '',
+        canton: canton || null,
+        postalCode: postalCode || '',
+        maxTravelKm,
+        isActive,
+        // Never demote a verified professional via this self-service endpoint.
+        profileTier: sql`CASE WHEN ${repairerProfiles.profileTier} = ${REPAIRER_PROFILE_TIER.PROFESSIONAL} THEN ${REPAIRER_PROFILE_TIER.PROFESSIONAL} ELSE ${REPAIRER_PROFILE_TIER.COMMUNITY} END`,
+        updatedAt: sql`NOW()`,
+      },
+    })
+
+  // Replace skills: delete existing, insert new.
+  await db.delete(userSkills).where(eq(userSkills.userId, userId))
+  if (skills.length > 0) {
+    await db.insert(userSkills).values(
+      skills.map((skillId) => ({
+        userId,
+        skillId,
+        categoryId: getCategoryForSkill(skillId),
+      })),
+    )
+  }
 }


### PR DESCRIPTION
Phase 2 of the profile-fragmentation cleanup. Gives technicians a single read+write domain layer.

- `technician-service`: + `getTechnicianSelfProfile(userId)` (self-edit read) and `upsertTechnicianProfile(userId, input)` (upsert `repairer_profiles` + replace `user_skills` + professional-demotion guard + `getCategoryForSkill`).
- `/api/user/technician-profile` GET/PUT now validate + delegate (~160 lines of inline query/mapping/business-rule removed from the route — SoC fix).

Behavior-preserving. typecheck + lint clean; route + service tests pass; full suite zero new failures vs baseline.

**Remaining for #5 phase 2 (follow-up):** route the live `/api/admin/it-hilfe/helpers` through the service + rename to `/api/admin/technicians`; consolidate the `/api/technicians` list mapper; resolve the `serviceTypes`↔`serviceDeliveryTypes` alias.

🤖 Generated with [Claude Code](https://claude.com/claude-code)