### PR TITLE
refactor(profiles): route /api/user/profile through db-users DAL (debt #5 phase 3b)

### DIFF
--- a/docs/ARCHITECTURE_DEBT.md
+++ b/docs/ARCHITECTURE_DEBT.md
@@ -243,10 +243,17 @@ API/mapper cleanup was never finished.
   `technician-service` (today writes are inline in `/api/user/technician-profile`); route the
   self-service + admin endpoints through it; collapse the remaining mappers; resolve the
   `serviceTypes`↔`serviceDeliveryTypes` boundary alias to one name.
-- **Phase 3 — one field-list SSOT per profile + canonical avatar.** Derive types from Zod
-  (`z.infer`), drop the duplicated `DEFAULT_PROFILE`/`fieldMap`/interface restatements; route
-  `/api/user/profile` through `db-users.ts`; adopt `<Avatar>` everywhere (retire `AvatarUpload`'s
-  bespoke placeholder + the seller inline upload + the hand-rolled initials); one upload path.
+- **Phase 3 — one field-list SSOT per profile + canonical avatar.**
+  - 3a ✓ DONE: `<Avatar>` is the canonical image-or-initials primitive (shape/size/bordered/
+    colorClassName/maxInitials); adopted across the 6 hand-rolled-initials chrome sites + the
+    technician profile. Header (UserMenu/MobileMenu) left (already photo-capable).
+  - 3b ✓ DONE: `/api/user/profile` now routes through `db-users.ts` (`getOrCreateProfile`/
+    `updateProfile`) — eliminates the duplicate snake→camel field map AND fixes a latent bug
+    (GET previously returned camelCase Drizzle rows, so saved fields never populated the
+    snake_case `ProfileData` client). Removed the dead duplicate `TechnicianProfileInput` in
+    `types/technician.ts` (the Zod-inferred one in `schemas/repairer.ts` is the SSOT).
+  - Remaining: derive the client `ProfileData`/`DEFAULT_PROFILE` from the Zod schema; adopt
+    `<Avatar>` in the seller inline-upload + retire `AvatarUpload`'s bespoke placeholder.
 - **Phase 4 (schema) — consolidate contact/address SSOT.** Make `user_profiles` the canonical
   contact record; stop duplicating phone/address/bio/avatar into role profiles (migration +
   dual-write window). Biggest blast radius; do last.

--- a/src/app/api/user/profile/__tests__/route.test.ts
+++ b/src/app/api/user/profile/__tests__/route.test.ts
@@ -3,8 +3,9 @@
  *
  * Tests for GET + PUT /api/user/profile
  *
- * GET: Return existing profile, or create one if not found
- * PUT: Validate + update profile fields
+ * The route is a thin controller over the db-users DAL:
+ *   GET → getOrCreateProfile (returns the snake_case profile the client reads)
+ *   PUT → validateBody → updateProfile
  */
 
 // ---------------------------------------------------------------------------
@@ -30,29 +31,6 @@ jest.mock('@/lib/api/middleware', () => ({
       }),
 }))
 
-const mockSelect = jest.fn()
-const mockInsert = jest.fn()
-const mockValues = jest.fn()
-const mockReturning = jest.fn()
-const mockUpdate = jest.fn()
-const mockSet = jest.fn()
-const mockUpdateWhere = jest.fn()
-const mockUpdateReturning = jest.fn()
-
-jest.mock('@/db', () => ({
-  db: {
-    select: (...args: unknown[]) => mockSelect(...args),
-    insert: (...args: unknown[]) => {
-      mockInsert(...args)
-      return { values: mockValues }
-    },
-    update: (...args: unknown[]) => {
-      mockUpdate(...args)
-      return { set: mockSet }
-    },
-  },
-}))
-
 const mockValidateBody = jest.fn()
 jest.mock('@/lib/schemas', () => ({
   validateBody: (...args: unknown[]) => mockValidateBody.apply(null, args),
@@ -71,46 +49,11 @@ jest.mock('@/lib/api/helpers', () => {
   }
 })
 
-jest.mock('drizzle-orm', () => ({
-  eq: (a: unknown, b: unknown) => ({ __eq: [a, b] }),
-  sql: Object.assign((_s: TemplateStringsArray, ..._v: unknown[]) => ({ __sql: true }), {
-    raw: (s: string) => ({ __raw: s }),
-  }),
-}))
-
-jest.mock('@/db/schema/auth', () => ({
-  userProfiles: {
-    userId: 'up_userId',
-    bio: 'up_bio',
-    avatarUrl: 'up_avatarUrl',
-    location: 'up_location',
-    phone: 'up_phone',
-    updatedAt: 'up_updatedAt',
-    firstName: 'up_firstName',
-    lastName: 'up_lastName',
-    companyName: 'up_companyName',
-    mobile: 'up_mobile',
-    addressLine1: 'up_addressLine1',
-    addressLine2: 'up_addressLine2',
-    postalCode: 'up_postalCode',
-    city: 'up_city',
-    canton: 'up_canton',
-    country: 'up_country',
-    interests: 'up_interests',
-    preferredLanguage: 'up_preferredLanguage',
-    newsletterSubscribed: 'up_newsletterSubscribed',
-    isSupporter: 'up_isSupporter',
-    supporterType: 'up_supporterType',
-    displayName: 'up_displayName',
-    profileVisibility: 'up_profileVisibility',
-    showEmail: 'up_showEmail',
-    showPhone: 'up_showPhone',
-    emailNotifications: 'up_emailNotifications',
-    smsNotifications: 'up_smsNotifications',
-    marketplaceUpdates: 'up_marketplaceUpdates',
-    workshopReminders: 'up_workshopReminders',
-    $inferSelect: {} as Record<string, unknown>,
-  },
+const mockGetOrCreateProfile = jest.fn()
+const mockUpdateProfile = jest.fn()
+jest.mock('@/lib/auth/db-users', () => ({
+  getOrCreateProfile: (...args: unknown[]) => mockGetOrCreateProfile(...args),
+  updateProfile: (...args: unknown[]) => mockUpdateProfile(...args),
 }))
 
 // ---------------------------------------------------------------------------
@@ -122,33 +65,20 @@ const MOCK_SESSION = {
     id: 'user-1',
     email: 'user@example.com',
     name: 'Test User',
+    role: 'user',
     isStaff: false,
     staffPermissions: [] as string[],
   },
   expires: '2027-01-01',
 }
 
+// Snake_case — the shape db-users returns and the client reads.
 const MOCK_PROFILE = {
-  userId: 'user-1',
+  user_id: 'user-1',
   bio: 'I repair laptops',
-  avatarUrl: null,
-  location: 'Zürich',
+  avatar_url: null,
   phone: null,
-}
-
-// ---------------------------------------------------------------------------
-// Helper
-// ---------------------------------------------------------------------------
-
-function makeChain(terminal: 'where' | 'returning', result: unknown[]) {
-  const terminalFn = jest.fn().mockResolvedValue(result)
-  const chain: Record<string, unknown> = {}
-  chain.from = jest.fn().mockReturnValue(chain)
-  chain.where = terminal === 'where' ? terminalFn : jest.fn().mockReturnValue(chain)
-  chain.returning = terminal === 'returning' ? terminalFn : jest.fn().mockReturnValue(chain)
-  chain.set = jest.fn().mockReturnValue(chain)
-  chain.as = jest.fn().mockReturnValue(chain)
-  return chain
+  first_name: 'Test',
 }
 
 function makeRequest(method = 'GET', body?: unknown) {
@@ -159,24 +89,13 @@ function makeRequest(method = 'GET', body?: unknown) {
   })
 }
 
-// ---------------------------------------------------------------------------
-// Import under test
-// ---------------------------------------------------------------------------
-
 import { GET, PUT } from '../route'
-
-// ---------------------------------------------------------------------------
-// Tests
-// ---------------------------------------------------------------------------
 
 beforeEach(() => {
   jest.clearAllMocks()
   mockAuth.mockResolvedValue(MOCK_SESSION)
-  mockReturning.mockResolvedValue([MOCK_PROFILE])
-  mockValues.mockReturnValue({ returning: mockReturning })
-  mockUpdateReturning.mockResolvedValue([MOCK_PROFILE])
-  mockUpdateWhere.mockReturnValue({ returning: mockUpdateReturning })
-  mockSet.mockReturnValue({ where: mockUpdateWhere })
+  mockGetOrCreateProfile.mockResolvedValue(MOCK_PROFILE)
+  mockUpdateProfile.mockResolvedValue(MOCK_PROFILE)
 })
 
 describe('GET /api/user/profile', () => {
@@ -186,26 +105,20 @@ describe('GET /api/user/profile', () => {
     expect(res.status).toBe(401)
   })
 
-  it('returns 200 with existing profile', async () => {
-    mockSelect.mockReturnValue(makeChain('where', [MOCK_PROFILE]))
+  it('returns 200 with the snake_case profile + role from db-users', async () => {
     const res = await GET(makeRequest() as never)
     const body = await res.json()
     expect(res.status).toBe(200)
     expect(body.success).toBe(true)
-    expect(body.data.profile.userId).toBe('user-1')
+    expect(body.data.profile.user_id).toBe('user-1')
+    expect(body.data.role).toBe('user')
+    expect(mockGetOrCreateProfile).toHaveBeenCalledWith('user-1')
   })
 
-  it('creates and returns profile when none exists', async () => {
-    // First select returns empty → insert is triggered
-    const selectChain = makeChain('where', [])
-    mockSelect.mockReturnValueOnce(selectChain)
-    mockValues.mockReturnValue({ returning: jest.fn().mockResolvedValue([MOCK_PROFILE]) })
-
+  it('returns 500 when the DAL throws', async () => {
+    mockGetOrCreateProfile.mockRejectedValue(new Error('db down'))
     const res = await GET(makeRequest() as never)
-    const body = await res.json()
-    expect(res.status).toBe(200)
-    expect(body.success).toBe(true)
-    expect(body.data.profile).toBeTruthy()
+    expect(res.status).toBe(500)
   })
 })
 
@@ -225,21 +138,15 @@ describe('PUT /api/user/profile', () => {
     expect(res.status).toBe(400)
   })
 
-  it('returns 200 with updated profile on success', async () => {
-    mockValidateBody.mockReturnValue({
-      success: true,
-      data: { bio: 'Updated bio' },
-    })
-    // getOrCreateProfileDrizzle (ensure exists) → returns profile
-    mockSelect.mockReturnValue(makeChain('where', [MOCK_PROFILE]))
-
-    const updatedProfile = { ...MOCK_PROFILE, bio: 'Updated bio' }
-    mockUpdateReturning.mockResolvedValue([updatedProfile])
+  it('delegates to updateProfile and returns the result', async () => {
+    mockValidateBody.mockReturnValue({ success: true, data: { bio: 'Updated bio' } })
+    mockUpdateProfile.mockResolvedValue({ ...MOCK_PROFILE, bio: 'Updated bio' })
 
     const res = await PUT(makeRequest('PUT', { bio: 'Updated bio' }) as never)
     const body = await res.json()
     expect(res.status).toBe(200)
     expect(body.success).toBe(true)
-    expect(body.data.profile).toBeTruthy()
+    expect(body.data.profile.bio).toBe('Updated bio')
+    expect(mockUpdateProfile).toHaveBeenCalledWith('user-1', { bio: 'Updated bio' })
   })
 })

--- a/src/app/api/user/profile/route.ts
+++ b/src/app/api/user/profile/route.ts
@@ -5,39 +5,18 @@
  */
 
 import { NextRequest } from 'next/server'
-import { db } from '@/db'
-import { userProfiles } from '@/db/schema/auth'
-import { eq, sql } from 'drizzle-orm'
 import { apiError, apiSuccess } from '@/lib/api/helpers'
 import { withAuth } from '@/lib/api/middleware'
 import { validateBody, UpdateProfileSchema } from '@/lib/schemas'
+import { getOrCreateProfile, updateProfile } from '@/lib/auth/db-users'
 
-/**
- * Get or create a user profile using Drizzle ORM.
- */
-async function getOrCreateProfileDrizzle(userId: string) {
-  const existing = await db
-    .select()
-    .from(userProfiles)
-    .where(eq(userProfiles.userId, userId))
-
-  if (existing[0]) {
-    return existing[0]
-  }
-
-  const [created] = await db
-    .insert(userProfiles)
-    .values({ userId })
-    .returning()
-
-  return created
-}
-
-export const GET = withAuth(async (request, session) => {
+export const GET = withAuth(async (_request, session) => {
   try {
-    const profile = await getOrCreateProfileDrizzle(session.user.id)
-    // Include the user's community role so the dashboard profile page can show
-    // the service-provider section (the client reads result.data.role).
+    // db-users is the single DAL for user_profiles — it returns the snake_case
+    // shape the dashboard profile client (ProfileData) reads. (The previous
+    // inline query returned camelCase Drizzle rows, so saved fields never
+    // populated the form.) `role` drives the service-provider section.
+    const profile = await getOrCreateProfile(session.user.id)
     return apiSuccess({ profile, role: session.user.role })
   } catch (error) {
     return apiError(error, 'Profil konnte nicht geladen werden')
@@ -49,65 +28,13 @@ export const PUT = withAuth(async (request: NextRequest, session) => {
     const body = await request.json()
     const validation = validateBody(UpdateProfileSchema, body)
     if (!validation.success) return validation.error
-    const updateData = validation.data
 
-    // Ensure profile exists
-    await getOrCreateProfileDrizzle(session.user.id)
-
-    // Build partial update object — only set fields that are present in updateData
-    const setFields: Record<string, unknown> = {}
-
-    const fieldMap: Record<string, keyof typeof userProfiles.$inferSelect> = {
-      first_name: 'firstName',
-      last_name: 'lastName',
-      company_name: 'companyName',
-      phone: 'phone',
-      mobile: 'mobile',
-      address_line1: 'addressLine1',
-      address_line2: 'addressLine2',
-      postal_code: 'postalCode',
-      city: 'city',
-      canton: 'canton',
-      country: 'country',
-      interests: 'interests',
-      preferred_language: 'preferredLanguage',
-      newsletter_subscribed: 'newsletterSubscribed',
-      is_supporter: 'isSupporter',
-      supporter_type: 'supporterType',
-      avatar_url: 'avatarUrl',
-      display_name: 'displayName',
-      bio: 'bio',
-      profile_visibility: 'profileVisibility',
-      show_email: 'showEmail',
-      show_phone: 'showPhone',
-      email_notifications: 'emailNotifications',
-      sms_notifications: 'smsNotifications',
-      marketplace_updates: 'marketplaceUpdates',
-      workshop_reminders: 'workshopReminders',
-    }
-
-    for (const [dataKey, schemaKey] of Object.entries(fieldMap)) {
-      if ((updateData as Record<string, unknown>)[dataKey] !== undefined) {
-        setFields[schemaKey] = (updateData as Record<string, unknown>)[dataKey]
-      }
-    }
-
-    if (Object.keys(setFields).length === 0) {
-      const profile = await getOrCreateProfileDrizzle(session.user.id)
-      return apiSuccess({ profile })
-    }
-
-    setFields.updatedAt = sql`NOW()`
-
-    const [updatedProfile] = await db
-      .update(userProfiles)
-      .set(setFields)
-      .where(eq(userProfiles.userId, session.user.id))
-      .returning()
-
-    return apiSuccess({
-      profile: updatedProfile,
-    })
+    // updateProfile owns the snake→camel field mapping (SSOT) + get-or-create.
+    const profile = await updateProfile(
+      session.user.id,
+      validation.data as Parameters<typeof updateProfile>[1],
+    )
+    return apiSuccess({ profile })
   } catch (error) {
     return apiError(error, 'Profil konnte nicht aktualisiert werden')
   }

--- a/src/types/technician.ts
+++ b/src/types/technician.ts
@@ -69,21 +69,7 @@ export interface Technician {
   homeVisitFeeCents?: number | null
 }
 
-/**
- * Write-shape for "edit my own profile" forms. Subset of Technician —
- * only fields the user can edit themselves. Server fills id, userId,
- * name, isVerified, ratings, totals.
- */
-export type TechnicianProfileInput = Pick<Technician,
-  | 'bio'
-  | 'skills'
-  | 'serviceDeliveryTypes'
-  | 'postalCode'
-  | 'city'
-  | 'canton'
-  | 'maxTravelKm'
-  | 'hourlyRateCents'
-  | 'acceptsGratis'
-  | 'acceptsKulturlegi'
-  | 'isActive'
->
+// The write-shape for self-service technician edits is the single
+// `TechnicianProfileInput` derived from the Zod schema in
+// `src/lib/schemas/repairer.ts` (z.infer<typeof TechnicianProfileSchema>) —
+// don't redefine a second one here.


### PR DESCRIPTION
Field-list SSOT for the user profile + a latent-bug fix.

- `/api/user/profile` GET/PUT now delegate to `db-users` (`getOrCreateProfile`/`updateProfile`) instead of an inline get-or-create + a duplicate snake→camel `fieldMap` (the route's copy was byte-identical to db-users' — write behavior unchanged).
- **Fixes a latent bug**: GET previously returned the **camelCase** Drizzle row, but the dashboard `ProfileData` client reads **snake_case** (`first_name`, `avatar_url`, …), so a saved profile never populated the edit form. `db-users` returns the snake_case `DbUserProfile` the client expects → the form now loads saved data.
- Removed the dead duplicate `TechnicianProfileInput` in `types/technician.ts` (the Zod-inferred one in `schemas/repairer.ts` is the SSOT). Route test rewritten to mock the DAL.

typecheck + lint (0 errors) clean; profile route tests pass; full suite zero new failures vs baseline.

🤖 Generated with [Claude Code](https://claude.com/claude-code)