### PR TITLE
refactor(profiles): nullable repairer contact + drop dead seller columns (debt #5 phase 4)

### DIFF
--- a/docs/ARCHITECTURE_DEBT.md
+++ b/docs/ARCHITECTURE_DEBT.md
@@ -1,8 +1,8 @@
 # Architecture Debt — Parallel Implementations + Spaghetti Patterns
 
 **Created:** 2026-06-04  
-**Last Modified:** 2026-06-29  
-**Last Modified Summary:** #5 — profile fragmentation audit (SSOT/DRY/SoC) + Phase 1 (remove dead technician read paths)
+**Last Modified:** 2026-06-30  
+**Last Modified Summary:** #5 profile cleanup Phases 1–4 done (Phase 4 re-scoped: contact fields are intentionally distinct, only dead/placeholder columns cleaned)
 
 **Last updated:** 2026-06-15 (auth/onboarding cleanup + notification pipeline closed)
 
@@ -254,9 +254,15 @@ API/mapper cleanup was never finished.
     `types/technician.ts` (the Zod-inferred one in `schemas/repairer.ts` is the SSOT).
   - Remaining: derive the client `ProfileData`/`DEFAULT_PROFILE` from the Zod schema; adopt
     `<Avatar>` in the seller inline-upload + retire `AvatarUpload`'s bespoke placeholder.
-- **Phase 4 (schema) — consolidate contact/address SSOT.** Make `user_profiles` the canonical
-  contact record; stop duplicating phone/address/bio/avatar into role profiles (migration +
-  dual-write window). Biggest blast radius; do last.
+- **Phase 4 (schema) ✓ DONE — re-scoped after investigation.** The original idea (consolidate
+  contact into `user_profiles`) was **dropped as contraindicated**: a per-field write-site audit
+  found NO mirror duplication. The role-profile contact/bio/avatar/display_name fields hold
+  legitimately-distinct business data (seller storefront, repairer service description +
+  application-flow business contact/location, team HR phone) entered via separate forms — collapsing
+  them would destroy real data. The only genuine cleanup (migration 104): `repairer_profiles.phone/
+  address` NOT NULL → nullable (self-service techs stored `''` placeholders only to satisfy NOT NULL;
+  normalized to NULL + dropped the placeholder writes), and dropped the dead `seller_profiles.phone/
+  address/postal_code` columns (never written by any code path).
 
 ---
 

--- a/scripts/db/migrations/104_profile_column_cleanup.sql
+++ b/scripts/db/migrations/104_profile_column_cleanup.sql
@@ -1,0 +1,22 @@
+-- Migration 104: profile column cleanup (debt #5 phase 4)
+--
+-- Phase 4 of the profile audit found that the role-profile "contact" fields are
+-- NOT mirror-duplicates of user_profiles — they hold legitimately-distinct
+-- business data (seller storefront, repairer service location/contact via the
+-- application flow, team HR phone). The only real cleanup is the dead/placeholder
+-- columns; the broad "consolidate contact into user_profiles" idea was dropped.
+--
+-- 1. repairer_profiles.phone/address were NOT NULL, which forced self-service
+--    community technicians (who never enter business contact) to store ''
+--    placeholders. Make them nullable and normalize the '' placeholders to NULL.
+ALTER TABLE repairer_profiles ALTER COLUMN phone DROP NOT NULL;
+ALTER TABLE repairer_profiles ALTER COLUMN address DROP NOT NULL;
+UPDATE repairer_profiles SET phone = NULL WHERE phone = '';
+UPDATE repairer_profiles SET address = NULL WHERE address = '';
+
+-- 2. seller_profiles.phone/address/postal_code are never written by any code path
+--    (always NULL) — drop the dead columns. The seller form only collects
+--    city/canton; storefront contact lives elsewhere.
+ALTER TABLE seller_profiles DROP COLUMN IF EXISTS phone;
+ALTER TABLE seller_profiles DROP COLUMN IF EXISTS address;
+ALTER TABLE seller_profiles DROP COLUMN IF EXISTS postal_code;

--- a/src/db/schema/marketplace.ts
+++ b/src/db/schema/marketplace.ts
@@ -259,11 +259,9 @@ export const sellerProfiles = pgTable('seller_profiles', {
   businessType: text('business_type'),
   taxId: text('tax_id'),
 
-  // Contact information (nullable after 031 P2P migration)
-  address: text('address'),
+  // Contact: only city is written (storefront location). phone/address/postal_code
+  // were never written by any code path — dropped in migration 104.
   city: text('city'),
-  postalCode: text('postal_code'),
-  phone: text('phone'),
 
   // Seller settings
   productTypes: text('product_types').array().default([]),

--- a/src/db/schema/services.ts
+++ b/src/db/schema/services.ts
@@ -150,10 +150,14 @@ export const repairerProfiles = pgTable('repairer_profiles', {
   description: text('description'),
   yearsExperience: integer('years_experience').default(0),
 
-  // Contact information
-  phone: text('phone').notNull(),
+  // Contact information.
+  // phone/address are nullable: self-service community technicians don't enter
+  // business contact (they were stored as '' placeholders only because these
+  // were NOT NULL — see migration 104). The repairer application flow still
+  // populates real business contact for professionals.
+  phone: text('phone'),
   website: text('website'),
-  address: text('address').notNull(),
+  address: text('address'),
   city: text('city').notNull(),
   postalCode: text('postal_code').notNull(),
   canton: text('canton'),

--- a/src/lib/services/technician-service.ts
+++ b/src/lib/services/technician-service.ts
@@ -306,8 +306,8 @@ export async function upsertTechnicianProfile(
       city: city || '',
       canton: canton || null,
       postalCode: postalCode || '',
-      phone: '',
-      address: '',
+      // phone/address are nullable now (migration 104) — self-service community
+      // technicians don't enter business contact; leave them NULL, not ''.
       maxTravelKm,
       isActive,
       profileTier: REPAIRER_PROFILE_TIER.COMMUNITY,


### PR DESCRIPTION
Phase 4, **re-scoped after investigation**. A per-field write-site audit found **no mirror duplication** — the role-profile contact/bio/avatar/display_name fields hold legitimately-distinct business data entered via separate forms, so the original "consolidate contact into user_profiles" migration was dropped as contraindicated (it would destroy real data). Only the dead/placeholder columns are cleaned:

- **Migration 104**: `repairer_profiles.phone/address` NOT NULL → nullable + normalize the `''` placeholders to NULL (self-service community techs never enter business contact); **drop dead** `seller_profiles.phone/address/postal_code` (never written by any code path — seller form only collects city).
- Schema + `technician-service` updated (no more `''` placeholder writes).

No readers of the dropped seller columns. typecheck + lint clean; full suite zero new failures vs baseline. Migration auto-applies to prod on deploy.

🤖 Generated with [Claude Code](https://claude.com/claude-code)