### PR TITLE
refactor(db): rename repairer_* tables to technician_* (debt #1)

### DIFF
--- a/scripts/db/migrations/105_rename_repairer_tables_to_technician.sql
+++ b/scripts/db/migrations/105_rename_repairer_tables_to_technician.sql
@@ -1,0 +1,22 @@
+-- Migration 105: rename the repairer_* tables to technician_* (debt #1 — entity rename)
+--
+-- "Repairer" and "technician" are the same concept; the public/API layer already
+-- uses "technician" (/api/technicians is the SSOT, technician-service, etc.), but
+-- the DB tables still carried the old "repairer" name. This renames the tables so
+-- the schema matches the concept.
+--
+-- Scope: TABLE names only. Postgres ALTER TABLE RENAME automatically carries the
+-- table's indexes + the FK constraints that point AT it (views/FKs track by OID,
+-- so nothing else breaks). Deliberately NOT changed here (separately riskier):
+--   - the `repairer_id` / `repairer_profile_id` COLUMN names on other tables
+--   - the `'repairer'` user-role VALUE (stored data + every role check)
+--   - index/constraint NAMES (cosmetic labels; left as-is)
+--
+-- Application references go through TABLE_NAMES (config) + Drizzle pgTable() names,
+-- both updated in lockstep with this migration. Idempotent via IF EXISTS guards.
+
+ALTER TABLE IF EXISTS repairer_profiles     RENAME TO technician_profiles;
+ALTER TABLE IF EXISTS repairer_services     RENAME TO technician_services;
+ALTER TABLE IF EXISTS repairer_availability RENAME TO technician_availability;
+ALTER TABLE IF EXISTS repairer_reviews      RENAME TO technician_reviews;
+ALTER TABLE IF EXISTS repairer_applications RENAME TO technician_applications;

--- a/src/config/database.ts
+++ b/src/config/database.ts
@@ -44,11 +44,11 @@ export const TABLE_NAMES = {
   // Applications & Profiles
   SELLER_APPLICATIONS: 'seller_applications',
   SELLER_PROFILES: 'seller_profiles',
-  REPAIRER_APPLICATIONS: 'repairer_applications',
-  REPAIRER_PROFILES: 'repairer_profiles',
-  REPAIRER_SERVICES: 'repairer_services',
-  REPAIRER_AVAILABILITY: 'repairer_availability',
-  REPAIRER_REVIEWS: 'repairer_reviews',
+  REPAIRER_APPLICATIONS: 'technician_applications',
+  REPAIRER_PROFILES: 'technician_profiles',
+  REPAIRER_SERVICES: 'technician_services',
+  REPAIRER_AVAILABILITY: 'technician_availability',
+  REPAIRER_REVIEWS: 'technician_reviews',
   REPAIRER_CERTIFICATIONS: 'repairer_certifications',
 
   // Membership
@@ -104,7 +104,7 @@ export const TABLE_NAMES = {
   IT_HILFE_REQUESTS: 'it_hilfe_requests',
   IT_HILFE_OFFERS: 'it_hilfe_offers',
   USER_SKILLS: 'user_skills',
-  IT_HILFE_TECHNICIAN_PROFILES: 'repairer_profiles',
+  IT_HILFE_TECHNICIAN_PROFILES: 'technician_profiles',
 
   // HIRN AI System
   HIRN_DOCUMENTS: 'hirn_documents',

--- a/src/db/schema/services.ts
+++ b/src/db/schema/services.ts
@@ -139,7 +139,7 @@ export type NewServiceAppointment = typeof serviceAppointments.$inferInsert
 // CHECK (business_type IN ('individual', 'business', 'freelance'))
 // CHECK (status IN ('pending_review', 'active', 'suspended', 'inactive'))
 
-export const repairerProfiles = pgTable('repairer_profiles', {
+export const repairerProfiles = pgTable('technician_profiles', {
   id: uuid('id').primaryKey().defaultRandom(),
   userId: uuid('user_id').notNull().unique().references(() => users.id, { onDelete: 'cascade' }),
 
@@ -235,7 +235,7 @@ export type NewRepairerProfile = typeof repairerProfiles.$inferInsert
 // From 008_repairer_system.sql.
 // UNIQUE (repairer_id, service_category, service_name)
 
-export const repairerServices = pgTable('repairer_services', {
+export const repairerServices = pgTable('technician_services', {
   id: uuid('id').primaryKey().defaultRandom(),
   repairerId: uuid('repairer_id').notNull().references(() => repairerProfiles.id, { onDelete: 'cascade' }),
 
@@ -275,7 +275,7 @@ export type NewRepairerService = typeof repairerServices.$inferInsert
 // CHECK (availability_type IN ('available', 'booked', 'blocked'))
 // UNIQUE (repairer_id, date, start_time)
 
-export const repairerAvailability = pgTable('repairer_availability', {
+export const repairerAvailability = pgTable('technician_availability', {
   id: uuid('id').primaryKey().defaultRandom(),
   repairerId: uuid('repairer_id').notNull().references(() => repairerProfiles.id, { onDelete: 'cascade' }),
 
@@ -317,7 +317,7 @@ export type NewRepairerAvailability = typeof repairerAvailability.$inferInsert
 // CHECK (communication_rating >= 1 AND communication_rating <= 5)
 // UNIQUE (repairer_id, customer_id, appointment_id)
 
-export const repairerReviews = pgTable('repairer_reviews', {
+export const repairerReviews = pgTable('technician_reviews', {
   id: uuid('id').primaryKey().defaultRandom(),
   repairerId: uuid('repairer_id').notNull().references(() => repairerProfiles.id, { onDelete: 'cascade' }),
   customerId: uuid('customer_id').notNull().references(() => users.id, { onDelete: 'cascade' }),
@@ -365,7 +365,7 @@ export type NewRepairerReview = typeof repairerReviews.$inferInsert
 // CHECK (status IN ('pending', 'approved', 'rejected', 'requires_changes'))
 // UNIQUE (user_id)
 
-export const repairerApplications = pgTable('repairer_applications', {
+export const repairerApplications = pgTable('technician_applications', {
   id: uuid('id').primaryKey().defaultRandom(),
   userId: uuid('user_id').notNull().unique().references(() => users.id, { onDelete: 'cascade' }),
 


### PR DESCRIPTION
"Repairer" and "technician" are the same concept — the API/service layer already uses "technician" (`/api/technicians` SSOT, `technician-service`), but the DB tables still carried the old name. This renames the tables so the schema matches.

- **Migration 105**: `ALTER TABLE repairer_{profiles,services,availability,reviews,applications} RENAME TO technician_*` (idempotent; Postgres carries indexes + inbound FKs automatically).
- Drizzle `pgTable()` names + `TABLE_NAMES` values updated in lockstep, so every query (Drizzle + `sql.raw(TABLE_NAMES.*)`) targets the new names.

**Scope (bounded on purpose — each separately riskier):** kept the `repairer_id`/`repairer_profile_id` **columns**, the `'repairer'` **role value** (stored data + every role check), and the internal JS identifiers `repairerProfiles`/`REPAIRER_PROFILES` (cosmetic, tsc-guarded — follow-up). Verified no production code hardcodes the table names outside `TABLE_NAMES`/Drizzle, so no un-tsc-guarded raw-SQL risk.

typecheck + lint + umlauts clean; full suite identical 7-suite baseline failures, zero new. Migration auto-applies after 104.

🤖 Generated with [Claude Code](https://claude.com/claude-code)