### PR TITLE
fix(db): drop empty orphan technician_profiles before rename (migration 105)

### DIFF
--- a/scripts/db/migrations/105_rename_repairer_tables_to_technician.sql
+++ b/scripts/db/migrations/105_rename_repairer_tables_to_technician.sql
@@ -14,6 +14,13 @@
 --
 -- Application references go through TABLE_NAMES (config) + Drizzle pgTable() names,
 -- both updated in lockstep with this migration. Idempotent via IF EXISTS guards.
+--
+-- An empty orphan `technician_profiles` stub exists on prod (created by
+-- 002b-simplified-auth, never adopted — the live data is in repairer_profiles).
+-- It has 0 rows and no inbound FKs, and it blocks the rename below, so drop it
+-- first. (Root cause of this migration's first deploy failing with
+-- "relation technician_profiles already exists".)
+DROP TABLE IF EXISTS technician_profiles;
 
 ALTER TABLE IF EXISTS repairer_profiles     RENAME TO technician_profiles;
 ALTER TABLE IF EXISTS repairer_services     RENAME TO technician_services;


### PR DESCRIPTION
The first deploy of migration 105 failed with `relation "technician_profiles" already exists` — prod has an **empty orphan** `technician_profiles` table (from `002b-simplified-auth`, never adopted; live data is in `repairer_profiles`). The page-render gate aborted cleanly, so prod stayed on the prior release.

Fix: `DROP TABLE IF EXISTS technician_profiles` (0 rows, no inbound FKs) before the renames. **Verified on prod with BEGIN…ROLLBACK** — renames apply cleanly.

🤖 Generated with [Claude Code](https://claude.com/claude-code)