### PR TITLE
fix: green the test suite — real blog bug + 6 stale-mock suites

### DIFF
--- a/src/app/api/admin/team/profiles/__tests__/route.test.ts
+++ b/src/app/api/admin/team/profiles/__tests__/route.test.ts
@@ -45,6 +45,7 @@ const mockSelect = jest.fn()
 const mockFrom = jest.fn()
 const mockInnerJoin = jest.fn()
 const mockWhere = jest.fn()
+const mockLimit = jest.fn()
 const mockOrderBy = jest.fn()
 const mockInsert = jest.fn()
 const mockValues = jest.fn()
@@ -229,8 +230,9 @@ describe('POST /api/admin/team/profiles — validation', () => {
 
   it('returns 400 when profile already exists', async () => {
     mockWhere
-      .mockResolvedValueOnce([{ id: 'u-1' }])          // user lookup: found
-      .mockResolvedValueOnce([{ id: 'prof-existing' }]) // profile check: exists
+      .mockResolvedValueOnce([{ id: 'u-1' }])      // user lookup: found (awaited directly)
+      .mockReturnValueOnce({ limit: mockLimit })   // profile check: select().from().where().limit(1)
+    mockLimit.mockResolvedValueOnce([{ id: 'prof-existing' }]) // profile exists
     const response = await POST(makeRequest('POST', VALID_POST_BODY))
     expect(response.status).toBe(400)
   })
@@ -239,8 +241,9 @@ describe('POST /api/admin/team/profiles — validation', () => {
 describe('POST /api/admin/team/profiles — success', () => {
   it('returns 201 on success', async () => {
     mockWhere
-      .mockResolvedValueOnce([{ id: 'u-1' }])  // user lookup: found
-      .mockResolvedValueOnce([])                 // profile check: no existing
+      .mockResolvedValueOnce([{ id: 'u-1' }])      // user lookup: found (awaited directly)
+      .mockReturnValueOnce({ limit: mockLimit })   // profile check: select().from().where().limit(1)
+    mockLimit.mockResolvedValueOnce([])            // no existing profile
     const response = await POST(makeRequest('POST', VALID_POST_BODY))
     expect(response.status).toBe(201)
     const body = await response.json()

--- a/src/app/api/it-hilfe/__tests__/offers.test.ts
+++ b/src/app/api/it-hilfe/__tests__/offers.test.ts
@@ -27,15 +27,18 @@ const mockUpdateChain = {
   where: jest.fn().mockResolvedValue([]),
 }
 
-// db.transaction mock: provide tx.update returning a happy-path chain, and
-// tx.execute returning status='pending' so the withdraw race-recheck passes.
+// db.transaction mock: the POST route inserts the offer AND bumps offerCount
+// inside one transaction, so tx must expose insert + update (and execute for
+// the withdraw race-recheck). tx.insert delegates to the shared mockInsertChain
+// so individual tests configure the returned offer via
+// mockInsertChain.returning.mockResolvedValueOnce(...).
 // Individual tests can override via jest.requireMock('@/db').db.transaction.
 const mockDbTransaction = jest.fn(async (fn: (tx: unknown) => unknown) => {
   const txUpdate = jest.fn(() => ({
     set: jest.fn(() => ({ where: jest.fn().mockResolvedValue(undefined) })),
   }))
   const txExecute = jest.fn().mockResolvedValue({ rows: [{ status: 'pending' }] })
-  return fn({ update: txUpdate, execute: txExecute })
+  return fn({ insert: jest.fn(() => mockInsertChain), update: txUpdate, execute: txExecute })
 })
 
 jest.mock('@/db', () => ({

--- a/src/app/api/it-hilfe/requests/[id]/matches/__tests__/route.test.ts
+++ b/src/app/api/it-hilfe/requests/[id]/matches/__tests__/route.test.ts
@@ -67,6 +67,14 @@ jest.mock('@/lib/it-hilfe/sql', () => ({
   technicianHasSkillMatch: jest.fn().mockReturnValue({ __skillMatch: true }),
 }))
 
+// The route composes its WHERE from publicTechnicianListCondition(), whose
+// internals call drizzle's or()/REPAIRER_STATUS (not part of these unit mocks).
+// Mock it like technicianHasSkillMatch — it returns an opaque SQL fragment the
+// route only feeds into and().
+jest.mock('@/lib/domain/technician-visibility', () => ({
+  publicTechnicianListCondition: jest.fn().mockReturnValue({ __publicVisibility: true }),
+}))
+
 // ── Fixtures ───────────────────────────────────────────────────────────────
 
 const VALID_UUID = 'a1b2c3d4-e5f6-7890-abcd-ef1234567890'

--- a/src/config/__tests__/payrexx.test.ts
+++ b/src/config/__tests__/payrexx.test.ts
@@ -44,25 +44,33 @@ describe('isPayrexxConfigured', () => {
 })
 
 describe('isPayrexxCheckoutUnavailable', () => {
-  const env = process.env as Record<string, string | undefined>
-  const originalNodeEnv = env.NODE_ENV
+  // NOTE: the top-level beforeEach reassigns `process.env` to a fresh object
+  // before every test. Capturing `const env = process.env` here (at collection
+  // time) would freeze a stale reference to the ORIGINAL object, so writes to
+  // it never reach the copy the code under test reads — write to the live
+  // `process.env` via this helper instead. The cast is needed because Node's
+  // types declare NODE_ENV read-only.
+  const setNodeEnv = (value: string | undefined) => {
+    ;(process.env as Record<string, string | undefined>).NODE_ENV = value
+  }
+  const originalNodeEnv = process.env.NODE_ENV
 
   afterEach(() => {
-    env.NODE_ENV = originalNodeEnv
+    setNodeEnv(originalNodeEnv)
   })
 
   it('is false in non-production even without credentials', () => {
-    env.NODE_ENV = 'development'
+    setNodeEnv('development')
     expect(isPayrexxCheckoutUnavailable()).toBe(false)
   })
 
   it('is true in production without credentials', () => {
-    env.NODE_ENV = 'production'
+    setNodeEnv('production')
     expect(isPayrexxCheckoutUnavailable()).toBe(true)
   })
 
   it('is false in production when configured', () => {
-    env.NODE_ENV = 'production'
+    setNodeEnv('production')
     process.env[PAYREXX_ENV.INSTANCE] = 'demo'
     process.env[PAYREXX_ENV.API_SECRET] = 'secret'
     expect(isPayrexxCheckoutUnavailable()).toBe(false)

--- a/src/lib/blog.ts
+++ b/src/lib/blog.ts
@@ -2,7 +2,21 @@ import fs from 'fs'
 import path from 'path'
 import matter from 'gray-matter'
 
+// js-yaml@4 ships no bundled type declarations and @types/js-yaml is not a
+// project dependency, so import it with the minimal typed surface we consume.
+const { load: loadYaml } = require('js-yaml') as { load: (str: string) => unknown }
+
 const postsDirectory = path.join(process.cwd(), 'content/posts')
+
+// gray-matter@4 is pinned to js-yaml@3 (which had yaml.safeLoad), but this repo
+// hoists js-yaml@4 where safeLoad was removed and now throws. Supply our own
+// YAML engine backed by js-yaml@4's `load` so frontmatter parsing works against
+// the installed yaml instead of crashing on every post.
+const matterOptions = {
+  engines: {
+    yaml: (str: string) => (loadYaml(str) ?? {}) as Record<string, unknown>,
+  },
+}
 
 export interface BlogPost {
   slug: string
@@ -31,7 +45,7 @@ export function getAllPosts(): BlogPost[] {
       const slug = fileName.replace(/\.md$/, '')
       const fullPath = path.join(postsDirectory, fileName)
       const fileContents = fs.readFileSync(fullPath, 'utf8')
-      const { data, content } = matter(fileContents)
+      const { data, content } = matter(fileContents, matterOptions)
 
       // Get file stats for creation date
       const stats = fs.statSync(fullPath)
@@ -66,7 +80,7 @@ export function getPostBySlug(slug: string): BlogPost | null {
   try {
     const fullPath = path.join(postsDirectory, `${slug}.md`)
     const fileContents = fs.readFileSync(fullPath, 'utf8')
-    const { data, content } = matter(fileContents)
+    const { data, content } = matter(fileContents, matterOptions)
     const stats = fs.statSync(fullPath)
 
     return {

--- a/src/lib/services/__tests__/payment-webhook.test.ts
+++ b/src/lib/services/__tests__/payment-webhook.test.ts
@@ -33,13 +33,15 @@
  *   - skips when payment transaction is not PENDING
  *   - updates payment transaction to SUCCEEDED
  *   - confirms workshop registration when workshopRegistrationId is set
- *   - confirms service appointment when serviceAppointmentId is set
+ *   - moves service appointment to IN_PROGRESS when serviceAppointmentId is set
+ *     (a paid, quote-approved booking starts the repair — see booking-status.ts)
  *   - does NOT update workshop/appointment when IDs are null
  *
  *   handleGenericPayment — CANCELLED / DECLINED
  *   - updates payment transaction to FAILED
  *   - cancels workshop registration when workshopRegistrationId is set
- *   - cancels service appointment when serviceAppointmentId is set
+ *   - reverts service appointment to QUOTE_APPROVED when serviceAppointmentId is
+ *     set (pre-payment payable state, so the customer can retry — not a dead end)
  *
  *   handleGenericPayment — REFUNDED
  *   - updates payment transaction to REFUNDED
@@ -190,16 +192,10 @@ jest.mock('@/lib/payments/payrexx-client', () => ({
   },
 }))
 
-jest.mock('@/config/appointment-status', () => ({
-  APPOINTMENT_STATUS: {
-    PENDING_APPROVAL: 'pending_approval',
-    REQUESTED: 'requested',
-    CONFIRMED: 'confirmed',
-    IN_PROGRESS: 'in_progress',
-    CANCELLED: 'cancelled',
-    COMPLETED: 'completed',
-  },
-}))
+// NOTE: service appointments follow the BOOKING_STATUS lifecycle
+// (requested → … → quote_approved → in_progress → completed), NOT the legacy
+// APPOINTMENT_STATUS model. The module under test imports @/config/booking-status
+// directly; we use the real (unmocked) config here so assertions track the SSOT.
 
 jest.mock('@/config/workshop-registration-status', () => ({
   WORKSHOP_REGISTRATION_STATUS: {
@@ -235,7 +231,7 @@ import { ORDER_STATUS, LISTING_STATUS } from '@/config/marketplace'
 import { PAYMENT_STATUS } from '@/config/payment-status'
 import { PAYREXX_TRANSACTION_STATUS } from '@/lib/payments/payrexx-client'
 import { WORKSHOP_REGISTRATION_STATUS, WORKSHOP_PAYMENT_STATUS } from '@/config/workshop-registration-status'
-import { APPOINTMENT_STATUS } from '@/config/appointment-status'
+import { BOOKING_STATUS } from '@/config/booking-status'
 
 // ---------------------------------------------------------------------------
 // Fixtures
@@ -581,14 +577,14 @@ describe('handleGenericPayment — RESERVED', () => {
     )
   })
 
-  it('confirms service appointment when serviceAppointmentId is set', async () => {
+  it('moves service appointment to IN_PROGRESS when serviceAppointmentId is set', async () => {
     const tx = makePaymentTx({ status: PAYMENT_STATUS.PENDING, serviceAppointmentId: 'appt-1' })
 
     await handleGenericPayment(tx, PAYREXX_TRANSACTION_STATUS.RESERVED, null, { amount: 5000, currency: 'CHF' })
 
     expect(mockDbUpdate).toHaveBeenCalledTimes(2)
     expect(mockUpdateSet).toHaveBeenCalledWith(
-      expect.objectContaining({ status: APPOINTMENT_STATUS.CONFIRMED }),
+      expect.objectContaining({ status: BOOKING_STATUS.IN_PROGRESS }),
     )
   })
 
@@ -714,13 +710,13 @@ describe('handleGenericPayment — CANCELLED / DECLINED', () => {
     expect(mockDbExecute).not.toHaveBeenCalled()
   })
 
-  it('cancels service appointment when serviceAppointmentId is set', async () => {
+  it('reverts service appointment to QUOTE_APPROVED when serviceAppointmentId is set', async () => {
     const tx = makePaymentTx({ serviceAppointmentId: 'appt-2' })
 
     await handleGenericPayment(tx, PAYREXX_TRANSACTION_STATUS.DECLINED, null, { amount: 5000, currency: 'CHF' })
 
     expect(mockUpdateSet).toHaveBeenCalledWith(
-      expect.objectContaining({ status: APPOINTMENT_STATUS.CANCELLED }),
+      expect.objectContaining({ status: BOOKING_STATUS.QUOTE_APPROVED }),
     )
   })
 

--- a/src/lib/services/__tests__/presentation.test.ts
+++ b/src/lib/services/__tests__/presentation.test.ts
@@ -9,8 +9,13 @@
  *
  * Behaviors locked:
  *   getServicePresentation
- *   - returns specific config for known slugs (computer-repair-upgrades, data-recovery-transfer, etc.)
- *   - falls back to defaultPresentation for unknown slug
+ *   - returns specific config for the template/booking slugs that have a
+ *     servicePresentation entry (computer-repair-upgrades, data-recovery-transfer, custom-build)
+ *   - falls back to defaultPresentation for unknown slugs AND for bespoke
+ *     services that render via their own static page (hardware-recycling,
+ *     linux-open-source, web-design-development, consultation) — these were
+ *     intentionally removed from servicePresentation in the dedupe refactor
+ *     (5d131dc9) and must NOT be reintroduced.
  *   - returned object contains icon, hero, and features
  *
  *   getServicePricing
@@ -72,32 +77,21 @@ describe('getServicePresentation', () => {
     expect(result.hero.title).toContain('Datenrettung')
   })
 
-  it('returns config for hardware-recycling', () => {
-    const result = getServicePresentation('hardware-recycling')
-
-    expect(result).not.toBe(defaultPresentation)
-    expect(result.hero.title).toContain('Hardware-Recycling')
-  })
-
-  it('returns config for linux-open-source', () => {
-    const result = getServicePresentation('linux-open-source')
-
-    expect(result).not.toBe(defaultPresentation)
-    expect(result.hero.title).toContain('Linux')
-  })
-
-  it('returns config for web-design-development', () => {
-    const result = getServicePresentation('web-design-development')
-
-    expect(result).not.toBe(defaultPresentation)
-    expect(result.hero.title).toContain('Webdesign')
-  })
-
-  it('returns config for consultation', () => {
-    const result = getServicePresentation('consultation')
-
-    expect(result).not.toBe(defaultPresentation)
-    expect(result.hero.title).toContain('Beratung')
+  it('falls back to defaultPresentation for bespoke static-page services', () => {
+    // hardware-recycling, linux-open-source and web-design-development each
+    // render via a dedicated static page (literal route segments shadow the
+    // [service] dynamic route), and consultation is bookable but not featured.
+    // Their servicePresentation entries were removed in the dedupe refactor
+    // (5d131dc9) because they fed nowhere visible — re-adding them is a
+    // content trap. They must therefore fall back to the default.
+    for (const slug of [
+      'hardware-recycling',
+      'linux-open-source',
+      'web-design-development',
+      'consultation',
+    ]) {
+      expect(getServicePresentation(slug)).toBe(defaultPresentation)
+    }
   })
 
   it('returns config for custom-build', () => {
@@ -179,10 +173,15 @@ describe('getServicePricing', () => {
     expect(result.base).toBe('CHF 50.00')
   })
 
-  it('hardware-recycling override shows "Kostenlos"', () => {
+  it('bespoke service (hardware-recycling) has no override → falls through to formatPriceCents', () => {
+    // hardware-recycling renders via its own static page; its presentation
+    // (and pricingOverride) was removed in the dedupe refactor, so pricing
+    // now falls through to the DB-derived value via formatPriceCents.
+    mockFormatPriceCents.mockReturnValueOnce('Auf Anfrage')
+
     const result = getServicePricing('hardware-recycling', null)
 
-    expect(result.base).toBe('Kostenlos')
-    expect(mockFormatPriceCents).not.toHaveBeenCalled()
+    expect(mockFormatPriceCents).toHaveBeenCalledWith(null)
+    expect(result.base).toBe('Auf Anfrage')
   })
 })


### PR DESCRIPTION
The suite had **7 long-red suites (26 failing tests)**. Root-caused each and fixed legitimately (no skipped/weakened assertions). **Suite is now fully green: 529 suites / 7682 tests.**

**Real production bug:**
- `src/lib/blog.ts` — `gray-matter@4` calls js-yaml's `safeLoad`, but the repo has `js-yaml@4` hoisted (where `safeLoad` throws), so **every frontmatter parse threw → `/blog` was broken/empty in prod.** Fixed by passing a js-yaml-v4 `load` engine to gray-matter. (Tests were correct + unchanged.)

**Stale tests (prod code correct; mocks/assertions outdated):**
- it-hilfe **offers** — `tx` mock lacked `insert` (route does insert + offer-count bump in one transaction).
- it-hilfe **matches** — drizzle mock lacked `or` / `REPAIRER_STATUS` for `publicTechnicianListCondition`.
- admin/**team/profiles** — db mock chain missing `.limit(1)` → threw 500 instead of 400/201.
- **payrexx** — test captured `process.env` before `beforeEach` reassigned it.
- **payment-webhook** — asserted legacy `APPOINTMENT_STATUS`; appointments use `BOOKING_STATUS` (paid → IN_PROGRESS, failed → QUOTE_APPROVED).
- **presentation** — 4 slugs were deliberately removed from config (dedicated static pages); test now asserts the intended `defaultPresentation` fallback.

typecheck + lint (0) + umlauts clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)