### PR TITLE
ci: read-only post-deploy smoke (replace mutating prod E2E)

### DIFF
--- a/.github/workflows/deploy-selfhost.yml
+++ b/.github/workflows/deploy-selfhost.yml
@@ -88,32 +88,18 @@ jobs:
         if: steps.secrets.outputs.configured == 'true'
         run: echo "deployed=true" >> "$GITHUB_OUTPUT"
 
-  post-deploy-e2e:
-    name: Dual-persona inventory smoke
+  post-deploy-smoke:
+    name: Read-only prod smoke
     runs-on: ubuntu-latest
     needs: deploy
     if: needs.deploy.outputs.deployed == 'true'
-    timeout-minutes: 15
+    timeout-minutes: 5
     steps:
       - name: Checkout code
         uses: actions/checkout@v4
 
-      - name: Setup Node.js
-        uses: actions/setup-node@v4
-        with:
-          node-version: '20'
-          cache: npm
-
-      - name: Install dependencies
-        run: npm ci
-
-      - name: Install Playwright browser
-        run: npx playwright install --with-deps chromium
-
-      - name: Run inventory smoke (user + admin)
-        env:
-          AUTH_TEST_USER_PASSWORD: ${{ secrets.AUTH_TEST_USER_PASSWORD }}
-          AUTH_TEST_ADMIN_PASSWORD: ${{ secrets.AUTH_TEST_ADMIN_PASSWORD }}
-          AUTH_TEST_USER_EMAIL: ${{ secrets.AUTH_TEST_USER_EMAIL }}
-          AUTH_TEST_ADMIN_EMAIL: ${{ secrets.AUTH_TEST_ADMIN_EMAIL }}
-        run: bash scripts/e2e-inventory-prod.sh
+      # Read-only: public pages render + DB-backed public APIs return success.
+      # No login, no prod mutation. The heavier authenticated dual-persona
+      # journeys (which mutate prod) are manual: npm run test:e2e:inventory:prod.
+      - name: Run read-only smoke (public pages + APIs)
+        run: bash scripts/post-deploy-smoke.sh

--- a/scripts/e2e-inventory-prod.sh
+++ b/scripts/e2e-inventory-prod.sh
@@ -33,7 +33,10 @@ if [ "$ready" -ne 1 ]; then
 fi
 
 export PLAYWRIGHT_BASE_URL="$BASE_URL"
-export AUTH_TEST_USER_EMAIL="${AUTH_TEST_USER_EMAIL:-butaeff@gmail.com}"
+# No hardcoded user default — the old butaeff@gmail.com test account was removed.
+# Set AUTH_TEST_USER_EMAIL to a real non-admin account (ideally against a staging
+# URL, since these journeys mutate data). The admin default is a real account.
+export AUTH_TEST_USER_EMAIL="${AUTH_TEST_USER_EMAIL:?set AUTH_TEST_USER_EMAIL to a real non-admin account}"
 export AUTH_TEST_ADMIN_EMAIL="${AUTH_TEST_ADMIN_EMAIL:-georgy.butaev@revamp-it.ch}"
 
 echo "=== dual-persona inventory smoke → ${BASE_URL} ==="

--- a/scripts/post-deploy-smoke.sh
+++ b/scripts/post-deploy-smoke.sh
@@ -1,0 +1,80 @@
+#!/usr/bin/env bash
+# Read-only post-deploy smoke against production (or SMOKE_BASE_URL).
+#
+# Deliberately read-only: it never logs in and never mutates prod. It asserts the
+# key public pages render (HTTP 200) and the key DB-backed public APIs return
+# `"success":true` — which exercises the real queries (technicians, listings,
+# workshops, services, stats), catching a broken deploy or schema/query mismatch
+# that the page-render gate alone might miss.
+#
+# The heavier authenticated, mutating dual-persona journeys are NOT run here (they
+# pollute prod and depend on test accounts); run them deliberately via
+# `npm run test:e2e:inventory:prod` against a staging URL when needed.
+
+set -euo pipefail
+
+BASE_URL="${SMOKE_BASE_URL:-${PLAYWRIGHT_BASE_URL:-https://revampit.orangecat.ch}}"
+
+# Public pages that must render (HTTP 200).
+PAGES=(
+  /
+  /marketplace
+  /it-hilfe
+  /it-hilfe/techniker
+  /workshops
+  /blog
+  /services
+)
+
+# Public DB-backed APIs that must return 200 + `"success":true`.
+APIS=(
+  /api/health
+  /api/technicians
+  /api/listings
+  /api/workshops
+  /api/services
+  /api/stats/community
+)
+
+echo "=== wait for ${BASE_URL}/api/health ==="
+ready=0
+for _ in 1 2 3 4 5 6; do
+  if curl -sf --max-time 15 "${BASE_URL}/api/health" >/dev/null; then ready=1; break; fi
+  sleep 10
+done
+if [ "$ready" -ne 1 ]; then
+  echo "ERROR: ${BASE_URL}/api/health did not become ready"
+  exit 1
+fi
+
+fails=0
+
+echo "=== pages (expect 200) → ${BASE_URL} ==="
+for path in "${PAGES[@]}"; do
+  code=$(curl -s -o /dev/null -w "%{http_code}" --max-time 20 "${BASE_URL}${path}")
+  if [ "$code" = "200" ]; then
+    echo "  ok  ${path} (${code})"
+  else
+    echo "  FAIL ${path} (${code})"
+    fails=$((fails + 1))
+  fi
+done
+
+echo "=== APIs (expect 200 + success:true) → ${BASE_URL} ==="
+for path in "${APIS[@]}"; do
+  body=$(mktemp)
+  code=$(curl -s -o "$body" -w "%{http_code}" --max-time 20 "${BASE_URL}${path}")
+  if [ "$code" = "200" ] && grep -q '"success":true' "$body"; then
+    echo "  ok  ${path} (${code})"
+  else
+    echo "  FAIL ${path} (${code}, success!=true)"
+    fails=$((fails + 1))
+  fi
+  rm -f "$body"
+done
+
+if [ "$fails" -ne 0 ]; then
+  echo "=== smoke FAILED: ${fails} check(s) failed ==="
+  exit 1
+fi
+echo "=== smoke OK: all $(( ${#PAGES[@]} + ${#APIS[@]} )) checks passed ==="


### PR DESCRIPTION
The "Dual-persona inventory smoke" job **failed on every recent deploy** — it logs in as `butaeff@gmail.com` (a test account purged this session) and runs 14 journeys, several of which **mutate production** (it-hilfe/marketplace/workshops), re-polluting the E2E data we cleaned. A perpetually-red, prod-polluting check gives no signal.

Replaced with `scripts/post-deploy-smoke.sh`: **read-only, no login, no mutation** — asserts key public pages render (200) and DB-backed public APIs return `"success":true` (technicians, listings, workshops, services, stats, health). Exercises the real queries (incl. the just-renamed `technician_profiles`), catching a broken deploy/schema mismatch the render-gate alone might miss. Fast (curl-only — drops Node/Playwright install), 5-min timeout.

The heavier authenticated journeys remain manual via `npm run test:e2e:inventory:prod` (now requires an explicit real `AUTH_TEST_USER_EMAIL` — the purged-account default removed).

Verified: new smoke passes all 13 checks against prod.

🤖 Generated with [Claude Code](https://claude.com/claude-code)