### PR TITLE
fix(marketplace): buyer/seller flow bugs found in E2E

### DIFF
--- a/src/app/api/payments/payrexx-mock-redirect/route.ts
+++ b/src/app/api/payments/payrexx-mock-redirect/route.ts
@@ -37,8 +37,21 @@ export async function GET(request: NextRequest) {
     ? rawCurrency.toUpperCase()
     : 'CHF';
   const amountFormatted = (Number(rawAmount) / 100).toFixed(2);
-  const successUrl = sanitizeReturnTo(searchParams.get('successUrl'), '/');
-  const cancelUrl = sanitizeReturnTo(searchParams.get('cancelUrl'), '/');
+  // The checkout passes ABSOLUTE same-origin success/cancel URLs (that's what the
+  // real Payrexx gateway needs). sanitizeReturnTo only accepts relative paths, so
+  // reduce a same-origin absolute URL to pathname+search first; cross-origin URLs
+  // resolve to null and fall back (open-redirect protection preserved).
+  const toSameOriginPath = (raw: string | null): string | null => {
+    if (!raw) return null;
+    try {
+      const u = new URL(raw, APP_URL);
+      return u.origin === new URL(APP_URL).origin ? u.pathname + u.search : null;
+    } catch {
+      return null;
+    }
+  };
+  const successUrl = sanitizeReturnTo(toSameOriginPath(searchParams.get('successUrl')), '/');
+  const cancelUrl = sanitizeReturnTo(toSameOriginPath(searchParams.get('cancelUrl')), '/');
 
   const webhookUrl = `${APP_URL}/api/payments/payrexx-webhook`;
 
@@ -82,6 +95,10 @@ export async function GET(request: NextRequest) {
     const successUrl = ${JSON.stringify(successUrl)};
     const cancelUrl = ${JSON.stringify(cancelUrl)};
     const referenceId = ${JSON.stringify(referenceIdRaw)};
+    // amount (smallest unit) + currency must be echoed so the webhook's
+    // amount-verification accepts the payment — real Payrexx sends these.
+    const txAmount = ${Number(rawAmount) || 0};
+    const txCurrency = ${JSON.stringify(currency)};
 
     async function handlePay() {
       const btn = document.getElementById('payBtn');
@@ -99,6 +116,8 @@ export async function GET(request: NextRequest) {
               id: mockTxId,
               status: ${JSON.stringify(PAYREXX_TRANSACTION_STATUS.RESERVED)},
               referenceId: referenceId,
+              amount: txAmount,
+              currency: txCurrency,
             },
           }),
         });

--- a/src/app/dashboard/listings/page.tsx
+++ b/src/app/dashboard/listings/page.tsx
@@ -20,7 +20,7 @@ import { ConfirmDialog } from '@/components/ui/ConfirmDialog'
 import { EmptyState } from '@/components/ui/EmptyState'
 import { Button } from '@/components/ui/button'
 import { ListingImage } from '@/components/marketplace/ListingImage'
-import { LISTING_STATUS_CONFIG, LISTING_STATUS, formatCHF } from '@/config/marketplace'
+import { LISTING_STATUS_CONFIG, LISTING_STATUS, formatCHF, getCategoryLabel } from '@/config/marketplace'
 import type { ListingStatus } from '@/config/marketplace'
 import { getConditionBadge } from '@/config/erfassung/conditions'
 import { useMyListings } from '@/hooks/useMyListings'
@@ -185,7 +185,7 @@ export default function MyListingsPage() {
                       <span className="font-semibold text-text-primary">
                         {formatCHF(Number(listing.price_chf))}
                       </span>
-                      <span>{listing.category}</span>
+                      <span>{getCategoryLabel(listing.category)}</span>
                       <span className={`inline-flex rounded-sm px-1.5 py-0.5 ${conditionInfo.color}`}>
                         {conditionInfo.label}
                       </span>

--- a/src/lib/schemas/marketplace.ts
+++ b/src/lib/schemas/marketplace.ts
@@ -127,10 +127,12 @@ export const UpdateListingSchema = z.object({
   condition: z.enum(LISTING_CONDITIONS as unknown as [string, ...string[]]).optional(),
   brand: z.string().max(100).optional().nullable(),
   model: z.string().max(100).optional().nullable(),
+  // No .min(1): create allows image-less listings (images defaults to []), so
+  // edit must too — otherwise an image-less listing can never be saved.
   images: z.array(z.string().refine(
     (s) => s.startsWith('/uploads/') || s.startsWith('http://') || s.startsWith('https://'),
     'Ungültige Bild-URL',
-  )).min(1).max(MARKETPLACE_LIMITS.MAX_IMAGES).optional(),
+  )).max(MARKETPLACE_LIMITS.MAX_IMAGES).optional(),
   delivery_options: z.enum(DELIVERY_OPTIONS as unknown as [string, ...string[]]).optional(),
   shipping_cost_chf: z.number().min(0).optional().nullable(),
   pickup_location: z.string().max(200).optional().nullable(),


### PR DESCRIPTION
End-to-end tested the full **buyer (Peter) + seller (Paul)** marketplace journey on **web + mobile** and fixed every break found.

**Prod bugs:**
- **F1** — `/dashboard/listings` card showed the raw category code (`10`) instead of "Laptops". Now uses `getCategoryLabel()`.
- **F2** — editing an **image-less** listing returned 400 (`images: Too small expected >=1`). Create allows 0 images but `UpdateListingSchema` required `.min(1)`, so any image-less listing was uneditable. Dropped `.min(1)` to match create.

**Dev checkout (mock-Payrexx, prod route is dev-gated):**
- **F4** — mock payment never completed: the webhook's amount-verification (replay protection) needs `amount`+`currency`, which the mock omitted. Mock now echoes them → orders mark paid.
- **F5** — post-payment redirect went to `/`: `sanitizeReturnTo` only accepts relative paths but checkout passes absolute same-origin URLs. Mock now reduces same-origin absolute URLs to a path first (cross-origin still falls back — open-redirect protection kept).

**Verified E2E (desktop + mobile):** post → list/edit/duplicate/delete; browse/search/filter; listing detail (P2P contact vs RevampIT cart); favorite; contact seller; add-to-cart → cart → checkout → mock pay → paid → shipped → delivered → confirm receipt → **completed + listing sold**. Payment correctly gated on Payrexx (prod) / mock (dev).

typecheck + lint + umlauts clean; full suite **529 suites / 7682 tests green**.

🤖 Generated with [Claude Code](https://claude.com/claude-code)