### PR TITLE
fix(marketplace): payment-cancelled banner never showed (wrong error param)

### DIFF
--- a/src/app/api/marketplace/cart/checkout/route.ts
+++ b/src/app/api/marketplace/cart/checkout/route.ts
@@ -126,7 +126,7 @@ export const POST = withAuth(async (request: NextRequest, session: ValidSession)
         purpose: `${ORG.name}: ${itemCount} Artikel`,
         successRedirectUrl: `${APP_URL}/marketplace/checkout/success?orderId=${orderId}`,
         failedRedirectUrl: `${APP_URL}/marketplace/cart?error=payment_failed`,
-        cancelRedirectUrl: `${APP_URL}/marketplace/cart?error=cancelled`,
+        cancelRedirectUrl: `${APP_URL}/marketplace/cart?error=payment_cancelled`,
       })
     } catch (gatewayError) {
       // Rollback: delete order (items cascade) + restore listings to ACTIVE.

--- a/src/app/api/marketplace/orders/route.ts
+++ b/src/app/api/marketplace/orders/route.ts
@@ -151,7 +151,7 @@ export const POST = withAuth(async (request: NextRequest, session: ValidSession)
         purpose: `${ORG.name}: ${listing.title}`,
         successRedirectUrl: `${APP_URL}/marketplace/checkout/success?orderId=${orderId}`,
         failedRedirectUrl: `${APP_URL}/marketplace/checkout/${listing.id}?error=payment_failed`,
-        cancelRedirectUrl: `${APP_URL}/marketplace/checkout/${listing.id}?error=cancelled`,
+        cancelRedirectUrl: `${APP_URL}/marketplace/checkout/${listing.id}?error=payment_cancelled`,
       });
     } catch (gatewayError) {
       // Rollback: delete order + restore listing to ACTIVE atomically.


### PR DESCRIPTION
Both checkout routes built the Payrexx `cancelRedirectUrl` with `?error=cancelled`, but the return-state parser (`paymentErrorToReturnState`) only recognises `payment_cancelled` — so a buyer who **cancels payment** returned to the cart/checkout with **no feedback banner**. (The failed path already used `payment_failed`, which works, so only cancellation was affected.)

Aligned both cancel URLs to the parser SSOT (`error=payment_cancelled`): `cart/checkout/route.ts` + `marketplace/orders/route.ts`.

Verified: `/marketplace/cart?error=payment_cancelled` now shows the "Zahlung abgebrochen." banner. typecheck + affected suites green.

🤖 Generated with [Claude Code](https://claude.com/claude-code)