### PR TITLE
fix(i18n): default non-prefixed routes to German, not browser language

### DIFF
--- a/src/i18n/request.ts
+++ b/src/i18n/request.ts
@@ -1,5 +1,5 @@
 import { getRequestConfig } from 'next-intl/server'
-import { cookies, headers } from 'next/headers'
+import { cookies } from 'next/headers'
 import { routing } from './routing'
 import { hasLocale } from 'next-intl'
 
@@ -22,14 +22,6 @@ function deepMerge<T extends Record<string, unknown>>(target: T, source: Partial
   return result
 }
 
-/** Parse the first matching locale from an Accept-Language header
- *  ("en-US,en;q=0.9,de;q=0.8" → "en"). Used as a last-resort fallback
- *  when neither the URL nor the cookie tells us the locale. */
-function pickLocaleFromAcceptLanguage(header: string | null): string | undefined {
-  if (!header) return undefined
-  const tags = header.split(',').map(t => t.trim().split(';')[0].split('-')[0].toLowerCase())
-  return tags.find(t => (routing.locales as readonly string[]).includes(t))
-}
 
 export default getRequestConfig(async ({ requestLocale }) => {
   // Resolution order:
@@ -37,11 +29,12 @@ export default getRequestConfig(async ({ requestLocale }) => {
   //   2. NEXT_LOCALE cookie  — what next-intl + LanguageSwitcher write when
   //      the user picks or visits a locale; persists across /auth/* and other
   //      BYPASS_INTL routes where there is no URL locale
-  //   3. Accept-Language header  — first-time visitors with no cookie yet
-  //   4. defaultLocale  — last resort
-  // This is the fix for "/en/admin redirects to /auth/login and the login
-  // page renders in German" — /auth/* is in BYPASS_INTL so requestLocale
-  // is empty; the cookie carries the user's actual preference across.
+  //   3. defaultLocale (German)  — last resort
+  // We deliberately do NOT sniff the Accept-Language header: the Swiss site
+  // defaults to German and only switches when the user explicitly picks another
+  // locale (cookie) or visits a /[locale]/* URL — matching routing.localeDetection:
+  // false. (BYPASS_INTL routes like /dashboard, /admin, /auth have no URL locale,
+  // so the cookie carries the user's actual preference across them.)
   const requested = await requestLocale
   let locale: string = routing.defaultLocale
   if (hasLocale(routing.locales, requested)) {
@@ -50,11 +43,6 @@ export default getRequestConfig(async ({ requestLocale }) => {
     const cookieLocale = (await cookies()).get('NEXT_LOCALE')?.value
     if (hasLocale(routing.locales, cookieLocale)) {
       locale = cookieLocale
-    } else {
-      const headerLocale = pickLocaleFromAcceptLanguage((await headers()).get('accept-language'))
-      if (hasLocale(routing.locales, headerLocale)) {
-        locale = headerLocale
-      }
     }
   }
 


### PR DESCRIPTION
`routing.ts` already sets `localeDetection: false`, but `request.ts` (resolving the locale for BYPASS_INTL routes like `/dashboard`, `/admin`, `/auth` that have no URL locale) still fell back to the **Accept-Language** header — so a visitor with an English browser saw those pages in English instead of German.

Dropped the Accept-Language step. Resolution is now: URL `[locale]` → `NEXT_LOCALE` cookie (explicit choice) → **German default**. The Swiss site defaults to German and only switches when the user picks another locale — matching `localeDetection: false`. Removed the now-dead helper + `headers` import.

typecheck + lint + umlauts clean; full suite **529/7682 green**.

🤖 Generated with [Claude Code](https://claude.com/claude-code)