### PR TITLE
feat(dashboard): mobile bottom-nav + 'Mehr' sheet (replace horizontal-scroll strip)

### DIFF
--- a/src/app/dashboard/layout.tsx
+++ b/src/app/dashboard/layout.tsx
@@ -5,6 +5,7 @@ import { isSuperAdmin } from '@/lib/permissions'
 import { getAllDashboardCards } from '@/config/dashboard'
 import ConditionalMainLayout from '@/components/layout/ConditionalMainLayout'
 import { DashboardNav } from '@/components/dashboard/DashboardNav'
+import { DashboardMobileNav } from '@/components/dashboard/DashboardMobileNav'
 
 export default async function DashboardLayout({ children }: { children: React.ReactNode }) {
   const messages = await getMessages()
@@ -30,7 +31,10 @@ export default async function DashboardLayout({ children }: { children: React.Re
           double-wrapped. */}
       <ConditionalMainLayout leanChrome>
         <DashboardNav items={navItems} />
-        {children}
+        {/* Mobile/tablet (<lg): bottom tab bar + "Mehr" sheet. The padding keeps
+            content clear of the fixed bar. */}
+        <div className="pb-16 lg:pb-0">{children}</div>
+        <DashboardMobileNav items={navItems} />
       </ConditionalMainLayout>
     </NextIntlClientProvider>
   )

--- a/src/components/dashboard/DashboardMobileNav.tsx
+++ b/src/components/dashboard/DashboardMobileNav.tsx
@@ -1,0 +1,159 @@
+'use client'
+
+import { useEffect, useState } from 'react'
+import { createPortal } from 'react-dom'
+import { Menu, X } from 'lucide-react'
+import { Link, usePathname } from '@/i18n/navigation'
+import { Button } from '@/components/ui/button'
+import { useFocusTrap } from '@/hooks/useFocusTrap'
+import {
+  type DashboardCard,
+  DASHBOARD_CATEGORIES,
+  groupCardsByCategory,
+  type DashboardCategory,
+} from '@/config/dashboard'
+
+/**
+ * User dashboard mobile navigation (`<lg` only) — a thumb-reachable bottom tab
+ * bar (the sections flagged `dashboardBottomNavOrder` in sections.ts) plus a
+ * "Mehr" button that opens a bottom-sheet with every dashboard destination
+ * grouped by category. Replaces the horizontal-scroll strip on phones/tablets;
+ * desktop keeps `DashboardNav`. Mirrors the admin MobileBottomNav pattern.
+ */
+function isActive(pathname: string, href: string): boolean {
+  if (href === '/dashboard') return pathname === '/dashboard'
+  return pathname === href || pathname.startsWith(`${href}/`)
+}
+
+export function DashboardMobileNav({ items }: { items: DashboardCard[] }) {
+  const pathname = usePathname()
+  const [moreOpen, setMoreOpen] = useState(false)
+  const [mounted, setMounted] = useState(false)
+  const sheetRef = useFocusTrap<HTMLDivElement>(moreOpen, () => setMoreOpen(false))
+
+  useEffect(() => setMounted(true), [])
+
+  // Lock body scroll while the sheet is open.
+  useEffect(() => {
+    if (!moreOpen) return
+    const prev = document.body.style.overflow
+    document.body.style.overflow = 'hidden'
+    return () => {
+      document.body.style.overflow = prev
+    }
+  }, [moreOpen])
+
+  // Close the sheet on navigation.
+  useEffect(() => {
+    setMoreOpen(false)
+  }, [pathname])
+
+  if (items.length === 0) return null
+
+  const barItems = items
+    .filter(i => typeof i.bottomNavOrder === 'number')
+    .sort((a, b) => (a.bottomNavOrder ?? 0) - (b.bottomNavOrder ?? 0))
+    .slice(0, 4)
+
+  const grouped = groupCardsByCategory(items)
+  const orderedCategories = (Object.keys(DASHBOARD_CATEGORIES) as DashboardCategory[])
+    .map(id => ({ id, config: DASHBOARD_CATEGORIES[id], cards: grouped.get(id) ?? [] }))
+    .filter(g => g.cards.length > 0)
+    .sort((a, b) => a.config.priority - b.config.priority)
+
+  return (
+    <>
+      {/* Bottom tab bar */}
+      <nav
+        aria-label="Dashboard"
+        className="fixed bottom-0 left-0 right-0 z-40 flex border-t border-subtle bg-surface-base lg:hidden"
+      >
+        {barItems.map(item => {
+          const active = isActive(pathname, item.href)
+          return (
+            <Link
+              key={item.id}
+              href={item.href}
+              aria-current={active ? 'page' : undefined}
+              className={`flex min-h-[56px] flex-1 flex-col items-center justify-center gap-0.5 py-2 text-xs transition-colors ${
+                active ? 'text-action' : 'text-text-tertiary hover:text-text-secondary'
+              }`}
+            >
+              <span aria-hidden="true" className="text-lg leading-none">{item.icon}</span>
+              <span className="max-w-full truncate px-1">{item.shortLabel ?? item.title}</span>
+            </Link>
+          )
+        })}
+        <Button
+          variant="ghost"
+          onClick={() => setMoreOpen(true)}
+          aria-label="Mehr anzeigen"
+          aria-expanded={moreOpen}
+          className="flex min-h-[56px] flex-1 flex-col items-center justify-center gap-0.5 rounded-none py-2 text-xs text-text-tertiary hover:text-text-secondary h-auto"
+        >
+          <Menu className="h-5 w-5" aria-hidden="true" />
+          <span>Mehr</span>
+        </Button>
+      </nav>
+
+      {/* "Mehr" bottom sheet */}
+      {mounted && moreOpen && createPortal(
+        <div className="fixed inset-0 z-50 lg:hidden" role="dialog" aria-modal="true" aria-label="Dashboard-Menü">
+          <Button
+            variant="ghost"
+            aria-label="Schliessen"
+            onClick={() => setMoreOpen(false)}
+            className="absolute inset-0 h-full w-full rounded-none bg-black/40 p-0 backdrop-blur-xs hover:bg-black/40"
+          />
+          <div
+            ref={sheetRef}
+            className="absolute inset-x-0 bottom-0 max-h-[80vh] overflow-y-auto rounded-t-2xl border-t border-subtle bg-surface-base p-4 pb-[max(1rem,env(safe-area-inset-bottom))] shadow-card"
+          >
+            <div className="mb-3 flex items-center justify-between">
+              <span className="text-sm font-semibold text-text-primary">Alle Bereiche</span>
+              <Button
+                variant="ghost"
+                size="icon"
+                onClick={() => setMoreOpen(false)}
+                aria-label="Schliessen"
+                className="h-8 w-8"
+              >
+                <X className="h-5 w-5" />
+              </Button>
+            </div>
+            <div className="space-y-4">
+              {orderedCategories.map(group => (
+                <div key={group.id}>
+                  <p className="mb-1.5 px-1 text-xs font-medium uppercase tracking-wide text-text-tertiary">
+                    {group.config.title}
+                  </p>
+                  <div className="grid grid-cols-2 gap-2">
+                    {group.cards.map(card => {
+                      const active = isActive(pathname, card.href)
+                      return (
+                        <Link
+                          key={card.id}
+                          href={card.href}
+                          aria-current={active ? 'page' : undefined}
+                          className={`flex items-center gap-2 rounded-lg border px-3 py-2.5 text-sm transition-colors ${
+                            active
+                              ? 'border-action bg-action-muted text-action'
+                              : 'border-subtle text-text-secondary hover:border-strong hover:text-text-primary'
+                          }`}
+                        >
+                          <span aria-hidden="true" className="text-base leading-none">{card.icon}</span>
+                          <span className="min-w-0 truncate">{card.title}</span>
+                        </Link>
+                      )
+                    })}
+                  </div>
+                </div>
+              ))}
+            </div>
+          </div>
+        </div>,
+        document.body,
+      )}
+    </>
+  )
+}

--- a/src/components/dashboard/DashboardNav.tsx
+++ b/src/components/dashboard/DashboardNav.tsx
@@ -21,7 +21,7 @@ export function DashboardNav({ items }: DashboardNavProps) {
   return (
     <nav
       aria-label="Dashboard"
-      className="sticky top-14 z-30 border-b border-subtle bg-surface-base/95 backdrop-blur-sm"
+      className="sticky top-16 z-30 hidden border-b border-subtle bg-surface-base/95 backdrop-blur-sm lg:block"
     >
       <div className="mx-auto flex max-w-7xl gap-1 overflow-x-auto px-4 py-2 sm:px-6 lg:px-8">
         {items.map((item) => {

--- a/src/config/dashboard.ts
+++ b/src/config/dashboard.ts
@@ -37,6 +37,10 @@ export interface DashboardCard {
   badge?: string
   color: 'info' | 'success' | 'warning' | 'error' | 'secondary' | 'neutral'
   priority: number
+  /** Position in the mobile bottom nav (1-4); undefined → only in "Mehr". */
+  bottomNavOrder?: number
+  /** Short label for the bottom-nav bar (falls back to title). */
+  shortLabel?: string
 }
 
 /** Community roles (not staff roles) */
@@ -169,6 +173,8 @@ function sectionToCard(section: SectionConfig): DashboardCard {
     category: categoryMapping[section.category],
     color: colorMapping[section.ui.color],
     priority: section.priority,
+    bottomNavOrder: section.dashboardBottomNavOrder,
+    shortLabel: section.ui.mobileBottomNavLabel,
   }
 
   // Handle community role visibility

--- a/src/config/sections.ts
+++ b/src/config/sections.ts
@@ -127,6 +127,11 @@ export interface SectionConfig {
    *  order don't appear in the bottom nav; "Mehr" opens the full sidebar.
    *  Used by `getMobileBottomNavSections()`. */
   mobileBottomNavOrder?: number
+  /** Position in the USER dashboard mobile bottom nav (1-4). Sections without
+   *  an order don't appear in the bar; "Mehr" opens the full dashboard menu.
+   *  Used by `getDashboardBottomNavSections()`. Short label from
+   *  `ui.mobileBottomNavLabel`. */
+  dashboardBottomNavOrder?: number
 }
 
 export type SectionCategory =
@@ -256,10 +261,12 @@ export const SECTIONS: Record<string, SectionConfig> = {
       icon: User,
       emoji: '👤',
       color: 'info',
+      mobileBottomNavLabel: 'Profil',
     },
     visibility: { admin: false, dashboard: true },
     priority: 1,
     category: 'core',
+    dashboardBottomNavOrder: 1,
   },
 
   messages: {
@@ -271,10 +278,12 @@ export const SECTIONS: Record<string, SectionConfig> = {
       icon: MessageSquare,
       emoji: '💬',
       color: 'info',
+      mobileBottomNavLabel: 'Chat',
     },
     visibility: { admin: false, dashboard: true },
     priority: 2,
     category: 'core',
+    dashboardBottomNavOrder: 2,
   },
 
   // ---------------------------------------------------------------------------
@@ -352,10 +361,12 @@ export const SECTIONS: Record<string, SectionConfig> = {
       icon: Package,
       emoji: '📦',
       color: 'primary',
+      mobileBottomNavLabel: 'Inserate',
     },
     visibility: { admin: false, dashboard: true },
     priority: 22,
     category: 'commerce',
+    dashboardBottomNavOrder: 4,
   },
 
   'my-orders': {
@@ -367,10 +378,12 @@ export const SECTIONS: Record<string, SectionConfig> = {
       icon: ShoppingBag,
       emoji: '🛒',
       color: 'info',
+      mobileBottomNavLabel: 'Bestellungen',
     },
     visibility: { admin: false, dashboard: true },
     priority: 23,
     category: 'commerce',
+    dashboardBottomNavOrder: 3,
   },
 
   favorites: {


### PR DESCRIPTION
**Nav overhaul Phase 2.** The user dashboard nav was a single horizontal-scrolling strip of ~15 flat pills at every width — on a phone, most items hid behind a scroll users couldn't find.

- **`<lg` (phones/tablets):** a thumb-reachable **bottom tab bar** with the 4 key destinations (Profil, Chat, Bestellungen, Inserate — flagged via `dashboardBottomNavOrder` in the sections SSOT) + a **"Mehr"** button that opens a focus-trapped **bottom sheet** listing every destination grouped by category.
- **`lg+`:** keeps the existing strip (now `hidden lg:block`, sticky offset fixed to the 64px header).

Driven entirely by the existing `sections.ts` SSOT (new `dashboardBottomNavOrder`, mirrors the admin `mobileBottomNavOrder` pattern). New `DashboardMobileNav` reuses `useFocusTrap` + portal + body-scroll-lock. Content gets bottom padding so the bar never covers it.

typecheck + lint (0 errors) + umlauts clean; full suite 529/7684 green.

(Phase 3 next: make ⌘K cross-surface + mobile-tappable.)

🤖 Generated with [Claude Code](https://claude.com/claude-code)