### PR TITLE
feat(search): site-wide ⌘K command palette for logged-in users (nav Phase 3b)

### DIFF
--- a/src/app/api/search-index/route.ts
+++ b/src/app/api/search-index/route.ts
@@ -1,0 +1,148 @@
+import { NextRequest } from 'next/server'
+import { withAuth, ValidSession } from '@/lib/api/middleware'
+import { db } from '@/db'
+import { sql } from 'drizzle-orm'
+import { TABLE_NAMES } from '@/config/database'
+import { logger } from '@/lib/logger'
+import { apiSuccess, apiError } from '@/lib/api/helpers'
+import { ERROR_MESSAGES } from '@/config/error-messages'
+
+/**
+ * GET /api/search-index — compact, user-scoped index for the command palette.
+ *
+ * Mirrors the admin search-index route: every query runs through
+ * Promise.allSettled so one failing entity degrades to an empty array
+ * rather than 500-ing the whole palette. Table names come from TABLE_NAMES
+ * (sql.raw, never bound); the session user id is always a bound parameter.
+ */
+export const GET = withAuth(async (_request: NextRequest, session: ValidSession) => {
+  try {
+    const userId = session.user.id
+
+    const [
+      myListingsResult,
+      myOrdersResult,
+      favoritesResult,
+      marketplaceResult,
+      workshopsResult,
+    ] = await Promise.allSettled([
+      // 1. My own listings (any status except removed), newest first
+      db.execute(sql`
+        SELECT id, title, status
+        FROM ${sql.raw(TABLE_NAMES.LISTINGS)}
+        WHERE seller_id = ${userId}
+          AND status != 'removed'
+        ORDER BY created_at DESC
+        LIMIT 25
+      `),
+      // 2. My orders as buyer OR seller. Single-item orders carry the listing
+      //    title; cart orders (listing_id null) fall back to the first item's
+      //    title — same COALESCE join /api/marketplace/orders uses.
+      db.execute(sql`
+        SELECT mo.id AS id,
+               COALESCE(l.title, (
+                 SELECT it.title
+                 FROM ${sql.raw(TABLE_NAMES.MARKETPLACE_ORDER_ITEMS)} it
+                 WHERE it.order_id = mo.id
+                 ORDER BY it.created_at
+                 LIMIT 1
+               )) AS title,
+               mo.status AS status
+        FROM ${sql.raw(TABLE_NAMES.MARKETPLACE_ORDERS)} mo
+        LEFT JOIN ${sql.raw(TABLE_NAMES.LISTINGS)} l ON mo.listing_id = l.id
+        WHERE mo.buyer_id = ${userId} OR mo.seller_id = ${userId}
+        ORDER BY mo.created_at DESC
+        LIMIT 25
+      `),
+      // 3. Favorited listings, newest favorite first
+      db.execute(sql`
+        SELECT l.id AS id, l.title AS title
+        FROM ${sql.raw(TABLE_NAMES.LISTING_FAVORITES)} f
+        JOIN ${sql.raw(TABLE_NAMES.LISTINGS)} l ON f.listing_id = l.id
+        WHERE f.user_id = ${userId}
+        ORDER BY f.created_at DESC
+        LIMIT 25
+      `),
+      // 4. Recent public active listings — for client-side palette filtering
+      db.execute(sql`
+        SELECT id, title, price_chf
+        FROM ${sql.raw(TABLE_NAMES.LISTINGS)}
+        WHERE status = 'active'
+        ORDER BY created_at DESC
+        LIMIT 50
+      `),
+      // 5. Published workshops (is_active is the public visibility flag — same
+      //    filter /api/workshops uses; workshop dates live on workshop_instances,
+      //    not on the workshop row itself).
+      db.execute(sql`
+        SELECT id, slug, title
+        FROM ${sql.raw(TABLE_NAMES.WORKSHOPS)}
+        WHERE is_active = true
+        ORDER BY created_at DESC
+        LIMIT 25
+      `),
+    ])
+
+    type Row = Record<string, unknown>
+
+    const myListings = myListingsResult.status === 'fulfilled'
+      ? (myListingsResult.value.rows as Row[]).map(r => ({
+          id: String(r.id ?? ''),
+          title: String(r.title ?? ''),
+          status: String(r.status ?? ''),
+        }))
+      : []
+
+    const myOrders = myOrdersResult.status === 'fulfilled'
+      ? (myOrdersResult.value.rows as Row[]).map(r => ({
+          id: String(r.id ?? ''),
+          title: String(r.title ?? ''),
+          status: String(r.status ?? ''),
+        }))
+      : []
+
+    const favorites = favoritesResult.status === 'fulfilled'
+      ? (favoritesResult.value.rows as Row[]).map(r => ({
+          id: String(r.id ?? ''),
+          title: String(r.title ?? ''),
+        }))
+      : []
+
+    const marketplace = marketplaceResult.status === 'fulfilled'
+      ? (marketplaceResult.value.rows as Row[]).map(r => ({
+          id: String(r.id ?? ''),
+          title: String(r.title ?? ''),
+          price_chf: r.price_chf == null ? null : String(r.price_chf),
+        }))
+      : []
+
+    const workshops = workshopsResult.status === 'fulfilled'
+      ? (workshopsResult.value.rows as Row[]).map(r => ({
+          id: String(r.id ?? ''),
+          slug: String(r.slug ?? ''),
+          title: String(r.title ?? ''),
+        }))
+      : []
+
+    if (myListingsResult.status === 'rejected') {
+      logger.warn('search-index: myListings query failed', { error: myListingsResult.reason })
+    }
+    if (myOrdersResult.status === 'rejected') {
+      logger.warn('search-index: myOrders query failed', { error: myOrdersResult.reason })
+    }
+    if (favoritesResult.status === 'rejected') {
+      logger.warn('search-index: favorites query failed', { error: favoritesResult.reason })
+    }
+    if (marketplaceResult.status === 'rejected') {
+      logger.warn('search-index: marketplace query failed', { error: marketplaceResult.reason })
+    }
+    if (workshopsResult.status === 'rejected') {
+      logger.warn('search-index: workshops query failed', { error: workshopsResult.reason })
+    }
+
+    return apiSuccess({ myListings, myOrders, favorites, marketplace, workshops })
+  } catch (error) {
+    logger.error('search-index GET failed', { error })
+    return apiError(error, ERROR_MESSAGES.INTERNAL_SERVER_ERROR)
+  }
+})

--- a/src/components/layout/header/Header.tsx
+++ b/src/components/layout/header/Header.tsx
@@ -23,6 +23,7 @@ import { cn } from '@/lib/utils'
 
 // Skip SSR — both use useSession which requires SessionProvider (lazy-loaded client-side only)
 const UserMenu = dynamic(() => import('@/components/auth/UserMenu').then(m => ({ default: m.UserMenu })), { ssr: false })
+const UserCommandPalette = dynamic(() => import('@/components/search/UserCommandPalette').then(m => ({ default: m.UserCommandPalette })), { ssr: false })
 const MobileMenu = dynamic(() => import('../MobileMenu').then(m => ({ default: m.MobileMenu })), { ssr: false })
 import { mainNavigation } from '@/config/navigation'
 import { NavItem } from './NavItem'
@@ -157,6 +158,9 @@ export function Header() {
                   {contactItem.nameKey ? tNav(contactItem.nameKey as never) : contactItem.name}
                 </Link>
               )}
+
+              {/* Command palette (logged-in users) */}
+              <UserCommandPalette />
 
               {/* Locale Switcher */}
               <LocaleSwitcher />

--- a/src/components/search/UserCommandPalette.tsx
+++ b/src/components/search/UserCommandPalette.tsx
@@ -1,0 +1,247 @@
+'use client'
+
+import { useCallback, useEffect, useMemo, useRef, useState, type ReactNode } from 'react'
+import { useSession } from 'next-auth/react'
+import { useRouter } from '@/i18n/navigation'
+import {
+  Search, ChevronRight, Package, ShoppingBag, Heart, Store, GraduationCap, ArrowRight, Compass,
+} from 'lucide-react'
+import { Button } from '@/components/ui/button'
+import { Input } from '@/components/ui/input'
+import { cn } from '@/lib/utils'
+import { apiFetch } from '@/lib/api/client'
+import { getDashboardSections } from '@/config/sections'
+
+/**
+ * Site-wide command palette for logged-in users (⌘K / tap). Mounted once in the
+ * global Header, so it's available on the dashboard, marketplace and public
+ * pages (admin has its own palette). Searches the user's own listings/orders/
+ * favorites + public marketplace listings + workshops, and jumps to any
+ * dashboard destination — plus a "search the marketplace for X" hand-off.
+ */
+interface IdTitleStatus { id: string; title: string; status?: string }
+interface SearchIndex {
+  myListings: IdTitleStatus[]
+  myOrders: IdTitleStatus[]
+  favorites: { id: string; title: string }[]
+  marketplace: { id: string; title: string; price_chf?: string | number }[]
+  workshops: { id: string; slug?: string; title: string }[]
+}
+
+interface ResultItem {
+  key: string
+  label: string
+  sub?: string
+  href: string
+  icon: ReactNode
+  group: string
+}
+
+function norm(s: string) {
+  return s.toLowerCase().trim()
+}
+
+function buildResults(index: SearchIndex | null, query: string): ResultItem[] {
+  const q = norm(query)
+  const items: ResultItem[] = []
+
+  // Navigation destinations (always available, filtered by query).
+  for (const s of getDashboardSections()) {
+    if (q && !norm(s.ui.label).includes(q)) continue
+    items.push({
+      key: `nav:${s.id}`, label: s.ui.label, href: s.path, group: 'Gehe zu',
+      icon: <Compass className="h-4 w-4" />,
+    })
+  }
+  // Cap nav results when no query so data results show.
+  const navItems = q ? items : items.slice(0, 4)
+  const out = [...navItems]
+
+  if (!index) return out
+
+  const matches = (t: string) => !q || norm(t).includes(q)
+
+  for (const l of index.myListings) {
+    if (!matches(l.title)) continue
+    out.push({ key: `ml:${l.id}`, label: l.title, sub: l.status, href: `/marketplace/${l.id}`, group: 'Meine Inserate', icon: <Package className="h-4 w-4" /> })
+  }
+  for (const o of index.myOrders) {
+    if (!matches(o.title)) continue
+    out.push({ key: `mo:${o.id}`, label: o.title, sub: o.status, href: `/dashboard/orders/${o.id}`, group: 'Meine Bestellungen', icon: <ShoppingBag className="h-4 w-4" /> })
+  }
+  for (const f of index.favorites) {
+    if (!matches(f.title)) continue
+    out.push({ key: `fav:${f.id}`, label: f.title, href: `/marketplace/${f.id}`, group: 'Favoriten', icon: <Heart className="h-4 w-4" /> })
+  }
+  for (const m of index.marketplace) {
+    if (!matches(m.title)) continue
+    out.push({ key: `mk:${m.id}`, label: m.title, sub: m.price_chf != null ? `CHF ${m.price_chf}` : undefined, href: `/marketplace/${m.id}`, group: 'Marktplatz', icon: <Store className="h-4 w-4" /> })
+  }
+  for (const w of index.workshops) {
+    if (!matches(w.title)) continue
+    out.push({ key: `ws:${w.id}`, label: w.title, href: `/workshops/${w.slug ?? w.id}`, group: 'Workshops', icon: <GraduationCap className="h-4 w-4" /> })
+  }
+
+  // Hand-off: full marketplace search for the typed query.
+  if (q) {
+    out.push({ key: 'mk-search', label: `Im Marktplatz suchen: „${query.trim()}“`, href: `/marketplace?search=${encodeURIComponent(query.trim())}`, group: 'Suche', icon: <ArrowRight className="h-4 w-4" /> })
+  }
+  return out
+}
+
+export function UserCommandPalette() {
+  const { status } = useSession()
+  const loggedIn = status === 'authenticated'
+  const [open, setOpen] = useState(false)
+  const [query, setQuery] = useState('')
+  const [index, setIndex] = useState<SearchIndex | null>(null)
+  const [activeIdx, setActiveIdx] = useState(0)
+  const dialogRef = useRef<HTMLDialogElement>(null)
+  const inputRef = useRef<HTMLInputElement>(null)
+  const router = useRouter()
+
+  useEffect(() => {
+    if (!open || index || !loggedIn) return
+    apiFetch<SearchIndex>('/api/search-index').then(r => {
+      if (r.success && r.data) setIndex(r.data)
+    })
+  }, [open, index, loggedIn])
+
+  useEffect(() => {
+    if (!loggedIn) return
+    const handler = (e: KeyboardEvent) => {
+      if ((e.metaKey || e.ctrlKey) && e.key === 'k') {
+        e.preventDefault()
+        setOpen(p => !p)
+      }
+    }
+    window.addEventListener('keydown', handler)
+    return () => window.removeEventListener('keydown', handler)
+  }, [loggedIn])
+
+  useEffect(() => {
+    const dialog = dialogRef.current
+    if (!dialog) return
+    if (open) {
+      dialog.showModal()
+      // eslint-disable-next-line react-hooks/set-state-in-effect -- reset on open
+      setQuery('')
+      setActiveIdx(0)
+      setTimeout(() => inputRef.current?.focus(), 0)
+    } else {
+      dialog.close()
+    }
+  }, [open])
+
+  const close = useCallback(() => setOpen(false), [])
+
+  useEffect(() => {
+    const dialog = dialogRef.current
+    if (!dialog) return
+    const handler = (e: MouseEvent) => { if (e.target === dialog) close() }
+    dialog.addEventListener('click', handler)
+    return () => dialog.removeEventListener('click', handler)
+  }, [close])
+
+  const results = useMemo(() => buildResults(index, query), [index, query])
+  const groups = useMemo(() => {
+    const map = new Map<string, ResultItem[]>()
+    for (const item of results) {
+      const g = map.get(item.group) ?? []
+      g.push(item)
+      map.set(item.group, g)
+    }
+    return map
+  }, [results])
+
+  const handleKeyDown = (e: React.KeyboardEvent) => {
+    if (e.key === 'ArrowDown') { e.preventDefault(); setActiveIdx(i => Math.min(i + 1, results.length - 1)) }
+    else if (e.key === 'ArrowUp') { e.preventDefault(); setActiveIdx(i => Math.max(i - 1, 0)) }
+    else if (e.key === 'Enter') {
+      e.preventDefault()
+      const item = results[activeIdx]
+      if (item) { router.push(item.href); close() }
+    } else if (e.key === 'Escape') { close() }
+  }
+
+  if (!loggedIn) return null
+
+  let flatIdx = 0
+
+  return (
+    <>
+      <Button
+        variant="ghost"
+        size="sm"
+        onClick={() => setOpen(true)}
+        aria-label="Suche öffnen (⌘K)"
+        className="flex h-9 w-9 items-center justify-center rounded-md p-0 text-text-tertiary hover:bg-surface-raised sm:h-9 sm:w-auto sm:gap-2 sm:px-3"
+      >
+        <Search className="h-4 w-4" />
+        <span className="hidden text-sm sm:inline">Suche</span>
+        <kbd className="hidden items-center rounded-sm bg-surface-raised px-1.5 py-0.5 font-mono text-xs leading-none lg:inline-flex">⌘K</kbd>
+      </Button>
+
+      <dialog
+        ref={dialogRef}
+        className="w-full max-w-xl rounded-xl border border bg-surface-base p-0 shadow-xs backdrop:bg-black/60"
+        onKeyDown={handleKeyDown}
+        onClose={close}
+        aria-label="Befehlspalette"
+      >
+        <div className="flex items-center gap-3 border-b border px-4 py-3">
+          <Search className="h-4 w-4 shrink-0 text-text-muted" aria-hidden="true" />
+          <Input
+            ref={inputRef}
+            type="search"
+            placeholder="Suche Inserate, Bestellungen, Workshops…"
+            value={query}
+            onChange={e => { setQuery(e.target.value); setActiveIdx(0) }}
+            className="flex-1 border-0 bg-transparent px-0 focus:ring-0 focus-visible:ring-0"
+            autoComplete="off"
+            spellCheck={false}
+          />
+          <kbd className="shrink-0 rounded-sm bg-surface-raised px-1.5 py-0.5 font-mono text-xs leading-none text-text-tertiary">Esc</kbd>
+        </div>
+
+        <div className="max-h-96 overflow-y-auto py-2">
+          {results.length === 0 ? (
+            <p className="px-4 py-8 text-center text-sm text-text-muted">
+              {query ? `Keine Ergebnisse für „${query}“` : 'Tippe, um zu suchen…'}
+            </p>
+          ) : (
+            Array.from(groups.entries()).map(([groupLabel, gItems]) => (
+              <div key={groupLabel}>
+                <p className="px-4 py-1.5 text-xs font-semibold uppercase tracking-wide text-text-muted">{groupLabel}</p>
+                {gItems.map(item => {
+                  const isCurrent = flatIdx === activeIdx
+                  const currentFlatIdx = flatIdx
+                  flatIdx++
+                  return (
+                    <Button
+                      key={item.key}
+                      variant="ghost"
+                      onClick={() => { router.push(item.href); close() }}
+                      onMouseEnter={() => setActiveIdx(currentFlatIdx)}
+                      className={cn(
+                        'flex h-auto w-full items-center justify-start gap-3 rounded-none px-4 py-2.5 text-left',
+                        isCurrent ? 'bg-action-muted text-action' : 'text-text-secondary hover:bg-surface-raised',
+                      )}
+                    >
+                      <span className={`shrink-0 ${isCurrent ? 'text-action' : 'text-text-muted'}`}>{item.icon}</span>
+                      <span className="min-w-0 flex-1">
+                        <span className="block truncate text-sm font-medium leading-snug">{item.label}</span>
+                        {item.sub && <span className="mt-0.5 block truncate text-xs text-text-muted">{item.sub}</span>}
+                      </span>
+                      {isCurrent && <ChevronRight className="h-3.5 w-3.5 shrink-0 text-action" aria-hidden="true" />}
+                    </Button>
+                  )
+                })}
+              </div>
+            ))
+          )}
+        </div>
+      </dialog>
+    </>
+  )
+}

--- a/src/config/database.ts
+++ b/src/config/database.ts
@@ -154,6 +154,7 @@ export const TABLE_NAMES = {
   LISTING_FAVORITES: 'listing_favorites',
   LISTING_REPORTS: 'listing_reports',
   MARKETPLACE_ORDERS: 'marketplace_orders',
+  MARKETPLACE_ORDER_ITEMS: 'marketplace_order_items',
 
   // Organizational Numbers (shared SSOT)
   ORG_NUMBERS: 'org_numbers',


### PR DESCRIPTION
The final navigation phase: a **user-facing command palette**, mounted once in the global Header (available on dashboard + marketplace + public; admin keeps its own), gated to logged-in users. **⌘K** or tap **Suche** to jump anywhere or find a product in one keystroke.

- New user-scoped `GET /api/search-index` (`withAuth`) → compact index of the user's own listings/orders/favorites + recent active marketplace listings + workshops, each query failing gracefully. (Also added the missing `MARKETPLACE_ORDER_ITEMS` to `TABLE_NAMES`.)
- `UserCommandPalette` — native `<dialog>` + keyboard nav, groups results (Gehe zu / Meine Inserate / Bestellungen / Favoriten / Marktplatz / Workshops) + a "Im Marktplatz suchen: X" hand-off.

**Verified live:** typing "ThinkPad" surfaces the listing (CHF 305) + the search hand-off; API returns 200 with the right shape.

typecheck + lint (0) + umlauts clean; full suite 529/7684 green.

Trigger shows on lg+ for now; a mobile trigger is a small follow-up (mobile users have the Phase-2 bottom nav).

🤖 Generated with [Claude Code](https://claude.com/claude-code)