### PR TITLE
feat(search): mobile trigger for the user command palette

### DIFF
--- a/src/components/layout/header/Header.tsx
+++ b/src/components/layout/header/Header.tsx
@@ -24,6 +24,7 @@ import { cn } from '@/lib/utils'
 // Skip SSR — both use useSession which requires SessionProvider (lazy-loaded client-side only)
 const UserMenu = dynamic(() => import('@/components/auth/UserMenu').then(m => ({ default: m.UserMenu })), { ssr: false })
 const UserCommandPalette = dynamic(() => import('@/components/search/UserCommandPalette').then(m => ({ default: m.UserCommandPalette })), { ssr: false })
+const CommandPaletteTrigger = dynamic(() => import('@/components/search/CommandPaletteTrigger').then(m => ({ default: m.CommandPaletteTrigger })), { ssr: false })
 const MobileMenu = dynamic(() => import('../MobileMenu').then(m => ({ default: m.MobileMenu })), { ssr: false })
 import { mainNavigation } from '@/config/navigation'
 import { NavItem } from './NavItem'
@@ -159,8 +160,8 @@ export function Header() {
                 </Link>
               )}
 
-              {/* Command palette (logged-in users) */}
-              <UserCommandPalette />
+              {/* Command palette trigger (logged-in users) */}
+              <CommandPaletteTrigger />
 
               {/* Locale Switcher */}
               <LocaleSwitcher />
@@ -177,6 +178,7 @@ export function Header() {
 
             {/* Mobile Right Side - Auth + Menu */}
             <div className="lg:hidden flex items-center gap-1.5">
+              <CommandPaletteTrigger />
               <UserMenu />
               {/* Mobile Menu Button */}
               <Button
@@ -195,6 +197,11 @@ export function Header() {
                 <Menu className="h-5 w-5" />
               </Button>
             </div>
+
+            {/* Single command-palette dialog (always rendered, not in an lg-gated
+                container, so showModal works at every width). Triggers above open
+                it via a window event. */}
+            <UserCommandPalette />
           </nav>
         </div>
       </header>

--- a/src/components/search/CommandPaletteTrigger.tsx
+++ b/src/components/search/CommandPaletteTrigger.tsx
@@ -1,0 +1,34 @@
+'use client'
+
+import { useSession } from 'next-auth/react'
+import { Search } from 'lucide-react'
+import { Button } from '@/components/ui/button'
+import { cn } from '@/lib/utils'
+import { openCommandPalette } from './UserCommandPalette'
+
+/**
+ * Opens the single mounted UserCommandPalette via a window event. Placed in both
+ * the desktop and mobile header action areas — no dialog/⌘K duplication. Icon-only
+ * on phones (<sm), full "Suche ⌘K" box on sm+/lg+. Logged-in users only.
+ */
+export function CommandPaletteTrigger({ className }: { className?: string }) {
+  const { status } = useSession()
+  if (status !== 'authenticated') return null
+
+  return (
+    <Button
+      variant="ghost"
+      size="sm"
+      onClick={openCommandPalette}
+      aria-label="Suche öffnen (⌘K)"
+      className={cn(
+        'flex h-9 w-9 items-center justify-center rounded-md p-0 text-text-tertiary hover:bg-surface-raised sm:w-auto sm:gap-2 sm:px-3',
+        className,
+      )}
+    >
+      <Search className="h-4 w-4" />
+      <span className="hidden text-sm sm:inline">Suche</span>
+      <kbd className="hidden items-center rounded-sm bg-surface-raised px-1.5 py-0.5 font-mono text-xs leading-none lg:inline-flex">⌘K</kbd>
+    </Button>
+  )
+}

--- a/src/components/search/UserCommandPalette.tsx
+++ b/src/components/search/UserCommandPalette.tsx
@@ -19,6 +19,12 @@ import { getDashboardSections } from '@/config/sections'
  * favorites + public marketplace listings + workshops, and jumps to any
  * dashboard destination — plus a "search the marketplace for X" hand-off.
  */
+/** Triggers dispatch this to open the single mounted palette dialog. */
+export const OPEN_COMMAND_PALETTE_EVENT = 'revampit:open-command-palette'
+export function openCommandPalette() {
+  window.dispatchEvent(new Event(OPEN_COMMAND_PALETTE_EVENT))
+}
+
 interface IdTitleStatus { id: string; title: string; status?: string }
 interface SearchIndex {
   myListings: IdTitleStatus[]
@@ -119,6 +125,15 @@ export function UserCommandPalette() {
     return () => window.removeEventListener('keydown', handler)
   }, [loggedIn])
 
+  // Triggers (placed anywhere — desktop + mobile header) open the single dialog
+  // via this event, so we never double-mount the dialog or the ⌘K listener.
+  useEffect(() => {
+    if (!loggedIn) return
+    const open = () => setOpen(true)
+    window.addEventListener(OPEN_COMMAND_PALETTE_EVENT, open)
+    return () => window.removeEventListener(OPEN_COMMAND_PALETTE_EVENT, open)
+  }, [loggedIn])
+
   useEffect(() => {
     const dialog = dialogRef.current
     if (!dialog) return
@@ -168,20 +183,10 @@ export function UserCommandPalette() {
 
   let flatIdx = 0
 
+  // Dialog only — triggers live separately (CommandPaletteTrigger) so the bar can
+  // place them in both the desktop and mobile header without double-mounting.
   return (
     <>
-      <Button
-        variant="ghost"
-        size="sm"
-        onClick={() => setOpen(true)}
-        aria-label="Suche öffnen (⌘K)"
-        className="flex h-9 w-9 items-center justify-center rounded-md p-0 text-text-tertiary hover:bg-surface-raised sm:h-9 sm:w-auto sm:gap-2 sm:px-3"
-      >
-        <Search className="h-4 w-4" />
-        <span className="hidden text-sm sm:inline">Suche</span>
-        <kbd className="hidden items-center rounded-sm bg-surface-raised px-1.5 py-0.5 font-mono text-xs leading-none lg:inline-flex">⌘K</kbd>
-      </Button>
-
       <dialog
         ref={dialogRef}
         className="w-full max-w-xl rounded-xl border border bg-surface-base p-0 shadow-xs backdrop:bg-black/60"


### PR DESCRIPTION
Phase 3b follow-up — the user ⌘K palette is now reachable on phones (was lg+ only).

Split the palette: the `<dialog>` mounts **once** in an always-rendered slot (not in an lg-gated container, so `showModal` works at every width) and opens via a window event. A new `CommandPaletteTrigger` (icon-only on `<sm`, full "Suche ⌘K" box on `sm+`) sits in **both** the desktop and mobile header action areas — no double-mounted dialog or ⌘K listener. Logged-in users only.

typecheck + lint (0) + umlauts clean; full suite 529/7684 green.