### PR TITLE
chore: Next 16 proxy migration + remove vestigial availability + clarify sidebar group ids (P2)

### DIFF
--- a/src/app/dashboard/profile/hooks/useProfileData.ts
+++ b/src/app/dashboard/profile/hooks/useProfileData.ts
@@ -39,15 +39,6 @@ export interface ProfileData {
   expertise_areas?: string[]
   website?: string
   service_radius_km?: number
-  availability?: {
-    monday?: { start: string; end: string; available: boolean }
-    tuesday?: { start: string; end: string; available: boolean }
-    wednesday?: { start: string; end: string; available: boolean }
-    thursday?: { start: string; end: string; available: boolean }
-    friday?: { start: string; end: string; available: boolean }
-    saturday?: { start: string; end: string; available: boolean }
-    sunday?: { start: string; end: string; available: boolean }
-  }
 }
 
 const DEFAULT_PROFILE: ProfileData = {
@@ -78,15 +69,6 @@ const DEFAULT_PROFILE: ProfileData = {
   expertise_areas: [],
   website: '',
   service_radius_km: 50,
-  availability: {
-    monday: { start: '09:00', end: '17:00', available: true },
-    tuesday: { start: '09:00', end: '17:00', available: true },
-    wednesday: { start: '09:00', end: '17:00', available: true },
-    thursday: { start: '09:00', end: '17:00', available: true },
-    friday: { start: '09:00', end: '17:00', available: true },
-    saturday: { start: '09:00', end: '17:00', available: false },
-    sunday: { start: '09:00', end: '17:00', available: false },
-  },
 }
 
 export function useProfileData() {

--- a/src/config/sections.ts
+++ b/src/config/sections.ts
@@ -183,6 +183,12 @@ export interface SidebarGroup {
  * - Analyse:      Analytics & reporting — financials, KPIs, impact
  * - System:       Configuration
  */
+// NOTE: a few group `id`s do not match their display `label` for historical
+// reasons — the labels were revised without renaming the keys. In particular:
+//   id 'angebot' → label 'Betrieb'   ·   id 'betrieb' → label 'Organisation'
+// The `label` is what users see and is authoritative; the `id` is just an
+// internal key (used in section `sidebarGroup` assignments + AdminSidebar). Match
+// on `id` when wiring, not on the German word.
 export const SIDEBAR_GROUPS: Record<SidebarGroupId, SidebarGroup> = {
   uebersicht: {
     id: 'uebersicht',

--- a/src/proxy.ts
+++ b/src/proxy.ts
@@ -46,7 +46,7 @@ async function hasValidSession(request: NextRequest): Promise<boolean> {
   return Boolean(token)
 }
 
-export async function middleware(request: NextRequest) {
+export async function proxy(request: NextRequest) {
   const { pathname } = request.nextUrl
   const method = request.method
 


### PR DESCRIPTION
P2 correctness & polish:

- **Next 16 `middleware`→`proxy`**: renamed `src/middleware.ts`→`src/proxy.ts` + the `middleware` fn→`proxy` (documented migration; matcher/config + behaviour unchanged). Clears the deprecation Next dev-tools flagged as "1 Issue". Verified routing intact (`/` 200, `/dashboard` 307, `/marketplace` 200; logs show `proxy.ts`).
- **Removed vestigial profile availability**: dashboard `ProfileData` carried a `{start,end,available}` per-day shape no UI edits and nothing displays (schema only accepts `{available,hours}`, so times were stripped anyway). Verified not a live bug — dead state removed.
- **Clarified sidebar group ids**: documented the historical id≠label crossing (id `angebot`→"Betrieb", id `betrieb`→"Organisation"). Full rename = churn, zero user impact — deferred.

typecheck + lint (0) + umlauts clean; full suite 530/7688 green.