### PR TITLE
fix(ui): Button renders its own link from href — unbreaks /space (Server Component crash)

### DIFF
--- a/src/app/[locale]/space/page.tsx
+++ b/src/app/[locale]/space/page.tsx
@@ -116,7 +116,7 @@ export default async function SpacePage({ params }: SpacePageProps) {
               </p>
             </div>
             <div className="md:justify-self-end">
-              <Button as={Link} href="/contact" variant="outline">
+              <Button href="/contact" variant="outline">
                 {t('currentLocation.moreBtn')} <ChevronRight className="w-4 h-4 ml-1" />
               </Button>
             </div>
@@ -183,7 +183,7 @@ export default async function SpacePage({ params }: SpacePageProps) {
 
             <div className="mt-6 text-center">
               <p className="text-text-secondary mb-4">{t('future.params.knowSpace')}</p>
-              <Button as={Link} href="/contact" variant="primary">{t('future.params.contactBtn')}</Button>
+              <Button href="/contact" variant="primary">{t('future.params.contactBtn')}</Button>
             </div>
           </div>
         </div>

--- a/src/components/timecards/TimecardDayEditor.tsx
+++ b/src/components/timecards/TimecardDayEditor.tsx
@@ -16,11 +16,12 @@ import { HourRangePicker } from './HourRangePicker'
 import { TimecardActions } from './TimecardActions'
 
 /**
- * Day view — fine edits for ONE day. Mirrors the month surface exactly: the
- * SAME action set (TimecardActions: fill from plan / structured absences /
- * clear) sits at the top, scoped to this day. Below it, the HourRangePicker
- * (the day-level counterpart to the calendar) is the star for work days;
- * absence days show their label. Category + note round it out.
+ * Day view — fine edits for ONE day. Mirrors the month surface: same open
+ * framing (no card chrome — an open surface like the month grid) and the SAME
+ * action set (TimecardActions: fill from plan / structured absences / clear)
+ * at the top, scoped to this day. Below it, the HourRangePicker (the day-level
+ * counterpart to the calendar grid — same useCellSelection model) is the star
+ * for work days; absence days show their label. Category + note round it out.
  *
  * The date itself lives in the view's nav bar, so it is NOT repeated here.
  */
@@ -44,7 +45,7 @@ export function TimecardDayEditor({
   const isAbsence = hasEntry && isAbsenceCategory(selectedEntry.category)
 
   return (
-    <section className="space-y-5 rounded-lg border border-subtle bg-surface-base p-5">
+    <section className="space-y-5">
       <div className="flex items-baseline justify-between gap-3">
         <p className="font-mono text-xs uppercase tracking-[0.18em] text-text-tertiary">
           {hasEntry

--- a/src/components/timecards/TimecardHeader.tsx
+++ b/src/components/timecards/TimecardHeader.tsx
@@ -30,7 +30,6 @@ export function TimecardHeader({
   syncMessage,
   onSubmit,
   onSave,
-  onFillMonth,
 }: {
   monthLabel: string
   scheduleSummary: string
@@ -45,7 +44,6 @@ export function TimecardHeader({
   syncMessage: string | null
   onSubmit: () => void
   onSave: () => void
-  onFillMonth: () => void
 }) {
   const isSubmitted = status === 'submitted'
   const t = useTranslations('admin.timecards')
@@ -69,16 +67,6 @@ export function TimecardHeader({
             <p className="text-xs text-text-tertiary text-right max-w-xs">{t('submitHint')}</p>
           )}
           <div className="flex items-center gap-2">
-          <Button
-            type="button"
-            variant={hasEntries ? 'ghost' : 'secondary'}
-            onClick={onFillMonth}
-            disabled={isLoadingDraft || isSubmitting}
-            className="text-sm"
-            title={t('fillMonthHint')}
-          >
-            {t('fillMonth')}
-          </Button>
           <Button
             type="button"
             variant="outline"

--- a/src/components/timecards/TimecardsClient.tsx
+++ b/src/components/timecards/TimecardsClient.tsx
@@ -95,7 +95,6 @@ export function TimecardsClient({
         isLoadingDraft={tc.isLoadingDraft}
         errorMessage={tc.errorMessage}
         syncMessage={tc.syncMessage}
-        onFillMonth={tc.fillMonthFromSchedule}
         onSubmit={tc.submitDraft}
         onSave={tc.saveDraft}
       />
@@ -133,10 +132,25 @@ export function TimecardsClient({
 
       {view === 'month' ? (
         <>
-          {/* Quick select entry points — pick a whole batch, then one bulk
-              action ("Alle auswählen" → "Leeren" empties the month). */}
+          {/* Quick select. The 95% case — "fill the whole month from my plan" —
+              leads as the prominent primary action; the two selection helpers
+              ("Ganzer Monat" / "Alle Werktage") follow as quiet ghosts for the
+              batch-then-bulk-bar path. One fill entry point lives here (not the
+              header) so there's a single, obvious place to act. */}
           <div className="flex flex-wrap items-center gap-2">
-            <span className="font-mono text-xs uppercase tracking-[0.16em] text-text-tertiary">
+            <Button
+              type="button"
+              variant="primary"
+              size="sm"
+              onClick={tc.fillMonthFromSchedule}
+              disabled={tc.isLoadingDraft || tc.isSubmitting}
+              title={t('fillMonthHint')}
+              className="gap-1.5"
+            >
+              <CalendarCheck className="h-4 w-4" aria-hidden="true" />
+              {t('fillMonth')}
+            </Button>
+            <span className="ml-1 font-mono text-xs uppercase tracking-[0.16em] text-text-tertiary">
               {t('selectLabel')}
             </span>
             <Button type="button" variant="ghost" size="sm" onClick={tc.selectAll} className="h-auto px-2 py-1 text-sm text-text-secondary hover:text-text-primary">

--- a/src/components/ui/button.tsx
+++ b/src/components/ui/button.tsx
@@ -1,11 +1,14 @@
 'use client'
 
-import { ButtonHTMLAttributes, forwardRef, ElementType } from 'react'
+import { ButtonHTMLAttributes, AnchorHTMLAttributes, forwardRef, ElementType, Ref } from 'react'
 import { cn } from '@/lib/utils'
 import { BUTTONS } from '@/config/ui'
 import { designPrimitive } from '@/lib/design-system'
+import { Link } from '@/i18n/navigation'
 
 interface ButtonProps extends ButtonHTMLAttributes<HTMLButtonElement> {
+  /** @deprecated Pass `href` instead — Button renders the link itself. Passing a
+   *  component via `as` from a Server Component fails RSC serialization. */
   as?: ElementType
   href?: string
   target?: string
@@ -34,21 +37,32 @@ const buttonSizeClass = {
   icon: designPrimitive.buttonSize.icon,
 } as const
 
-const Button = forwardRef<HTMLButtonElement, ButtonProps>(
-  ({ className, as: Tag = 'button', variant = 'default', size = 'default', ...props }, ref) => {
-    return (
-      <Tag
-        className={cn(
-          designPrimitive.buttonBase,
-          designPrimitive.focus,
-          buttonVariantClass[variant],
-          buttonSizeClass[size],
-          className
-        )}
-        ref={ref}
-        {...props}
-      />
+const Button = forwardRef<HTMLElement, ButtonProps>(
+  ({ className, as: Tag, href, variant = 'default', size = 'default', ...props }, ref) => {
+    const classes = cn(
+      designPrimitive.buttonBase,
+      designPrimitive.focus,
+      buttonVariantClass[variant],
+      buttonSizeClass[size],
+      className
     )
+
+    // When given an href, Button renders the link element itself. This keeps it
+    // usable inside Server Components — passing next-intl's <Link> via the `as`
+    // prop there throws "Functions cannot be passed directly to Client Components".
+    if (href) {
+      const isExternal = /^(https?:|mailto:|tel:)/.test(href) || props.target != null
+      // props are typed for a <button>; the anchor/Link branch shares the common
+      // attributes (className, onClick, target, rel, children, aria-*) — cast to
+      // anchor attrs so the spread type-checks.
+      const linkProps = props as unknown as AnchorHTMLAttributes<HTMLAnchorElement>
+      return isExternal
+        ? <a href={href} className={classes} ref={ref as Ref<HTMLAnchorElement>} {...linkProps} />
+        : <Link href={href} className={classes} ref={ref as Ref<HTMLAnchorElement>} {...linkProps} />
+    }
+
+    const Tag2: ElementType = Tag ?? 'button'
+    return <Tag2 className={classes} ref={ref} {...props} />
   }
 )
 


### PR DESCRIPTION
**/space was 500ing** with "Functions cannot be passed directly to Client Components": as a Server Component it used `<Button as={Link}>`, and passing next-intl's `<Link>` (a function) as a prop across the RSC boundary into the client `Button` isn't serializable.

`Button` now renders the link element itself when given `href` (internal → next-intl `<Link>`, external/`target` → `<a>`), so it works from Server Components with a plain `<Button href="…">`. The `as` prop is kept (deprecated) for existing client call sites. Dropped `as={Link}` on /space's two buttons.

This also future-proofs every page: `<Button href>` is now safe in both Server and Client Components.

typecheck clean.