### PR TITLE
fix: profile save validation (null) + timecard submit (DB constraints, migration 107) + submit UX

### DIFF
--- a/scripts/db/migrations/107_timecard_entries_align_category_duration_checks.sql
+++ b/scripts/db/migrations/107_timecard_entries_align_category_duration_checks.sql
@@ -1,0 +1,28 @@
+-- Migration 107: align timecard_entries CHECK constraints with the config SSOT
+--
+-- Migration 067 constrained timecard_entries.category to worked-time categories only
+-- and duration_minutes > 0. Since then src/config/timecards.ts grew six Swiss absence
+-- categories (ferien/krank/unfall/feiertag/militaer/unbezahlt) and set
+-- MIN_ENTRY_MINUTES = 0 (an unpaid-leave day is a 0-minute labelled marker). The DB
+-- constraints were never updated, so ANY timecard containing a leave entry failed to
+-- INSERT → submitTimecard's transaction rolled back → the card never reached
+-- status='submitted' → the approvals queue ("Zeitkarten-Freigaben") was always empty,
+-- even for a superadmin. (Found during the timecard audit.)
+--
+-- This realigns both constraints with the config. Idempotent (DROP IF EXISTS + re-add).
+-- Keep the category list in sync with TIMECARD_ENTRY_CATEGORIES.
+
+ALTER TABLE timecard_entries DROP CONSTRAINT IF EXISTS timecard_entries_category_check;
+ALTER TABLE timecard_entries ADD CONSTRAINT timecard_entries_category_check CHECK (
+  category IN (
+    -- worked-time
+    'workshop','repair','intake','sales','admin','education','logistics','meeting','volunteering','other',
+    -- absence (Swiss timecard)
+    'ferien','krank','unfall','feiertag','militaer','unbezahlt'
+  )
+);
+
+ALTER TABLE timecard_entries DROP CONSTRAINT IF EXISTS timecard_entries_duration_minutes_check;
+ALTER TABLE timecard_entries ADD CONSTRAINT timecard_entries_duration_minutes_check CHECK (
+  duration_minutes >= 0 AND duration_minutes <= 960
+);

--- a/src/components/timecards/TimecardsClient.tsx
+++ b/src/components/timecards/TimecardsClient.tsx
@@ -258,6 +258,35 @@ export function TimecardsClient({
         onClose={() => setMenuPos(null)}
         header={t('bulkSelected', { count: menuCount })}
       />
+
+      {/* Sticky action bar — keeps Save/Einreichen one tap away right after
+          filling (the fill + leave controls sit mid-page; without this the user
+          had to scroll back up to the header to submit). */}
+      <div className="sticky bottom-0 z-20 -mx-1 flex items-center justify-between gap-3 border-t border-subtle bg-surface-base/95 px-1 py-3 backdrop-blur-sm">
+        <p className="text-sm text-text-tertiary">
+          {tc.periodEntries.length} {t('headerDaysSuffix')} · {formatTimecardDuration(tc.totalMinutes)}
+        </p>
+        <div className="flex items-center gap-2">
+          <Button
+            type="button"
+            variant="outline"
+            size="sm"
+            onClick={tc.saveDraft}
+            disabled={tc.isSaving || tc.isLoadingDraft}
+          >
+            {tc.isSaving ? t('saving') : t('save')}
+          </Button>
+          <Button
+            type="button"
+            variant="primary"
+            size="sm"
+            onClick={tc.submitDraft}
+            disabled={tc.isSubmitting || tc.periodEntries.length === 0 || tc.isLoadingDraft}
+          >
+            {tc.isSubmitting ? t('submitting') : tc.draft.status === 'submitted' ? t('resubmit') : t('submit')}
+          </Button>
+        </div>
+      </div>
     </article>
   )
 }

--- a/src/lib/schemas/__tests__/user-profile-null.test.ts
+++ b/src/lib/schemas/__tests__/user-profile-null.test.ts
@@ -1,0 +1,28 @@
+/** Regression: GET /api/user/profile returns null for empty columns; saving must
+ *  not 400 ("Validierungsfehler") on those nulls. */
+import { UpdateProfileSchema } from '../user'
+
+describe('UpdateProfileSchema — null fields (empty profile save)', () => {
+  it('accepts the null-heavy payload a sparse profile sends back', () => {
+    const r = UpdateProfileSchema.safeParse({
+      first_name: null, last_name: null, company_name: null, avatar_url: null,
+      display_name: null, bio: null, phone: null, mobile: null,
+      address_line1: null, address_line2: null, postal_code: null, city: null,
+      canton: null, country: null, interests: null, website: null,
+      skills: null, expertise_areas: null, service_radius_km: null, availability: null,
+      profile_visibility: null, show_email: null, newsletter_subscribed: null,
+    })
+    expect(r.success).toBe(true)
+  })
+  it('still accepts a normal filled payload', () => {
+    const r = UpdateProfileSchema.safeParse({
+      first_name: 'Georgy', bio: 'Hi', website: 'https://revamp-it.ch',
+      service_radius_km: 50, skills: ['linux'], profile_visibility: 'public',
+    })
+    expect(r.success).toBe(true)
+  })
+  it('still rejects a genuinely invalid website', () => {
+    const r = UpdateProfileSchema.safeParse({ website: 'not-a-url' })
+    expect(r.success).toBe(false)
+  })
+})

--- a/src/lib/schemas/user.ts
+++ b/src/lib/schemas/user.ts
@@ -1,54 +1,58 @@
 import { z } from 'zod'
 import { swissPostalCodeSchema } from './common'
 
+// NOTE: empty profile columns come back from GET /api/user/profile as `null`, so
+// every optional field must also accept `null` (= "empty/cleared") — otherwise
+// loading a sparse profile and clicking Save fails validation on every null field
+// ("Validierungsfehler"). `.nullish()` = nullable + optional.
 export const UpdateProfileSchema = z.object({
   // Basic info
-  first_name: z.string().max(100).optional(),
-  last_name: z.string().max(100).optional(),
-  company_name: z.string().max(200).optional(),
+  first_name: z.string().max(100).nullish(),
+  last_name: z.string().max(100).nullish(),
+  company_name: z.string().max(200).nullish(),
 
   // Public profile
-  avatar_url: z.string().url('Ungültige URL').optional().or(z.literal('')),
-  display_name: z.string().min(2, 'Anzeigename muss mindestens 2 Zeichen lang sein').max(50).optional(),
-  bio: z.string().max(500, 'Bio darf maximal 500 Zeichen lang sein').optional(),
-  profile_visibility: z.enum(['public', 'private']).optional(),
+  avatar_url: z.string().url('Ungültige URL').or(z.literal('')).nullish(),
+  display_name: z.string().min(2, 'Anzeigename muss mindestens 2 Zeichen lang sein').max(50).or(z.literal('')).nullish(),
+  bio: z.string().max(500, 'Bio darf maximal 500 Zeichen lang sein').nullish(),
+  profile_visibility: z.enum(['public', 'private']).nullish(),
 
   // Contact
-  phone: z.string().optional(),
-  mobile: z.string().optional(),
+  phone: z.string().nullish(),
+  mobile: z.string().nullish(),
 
   // Address
-  address_line1: z.string().max(200).optional(),
-  address_line2: z.string().max(200).optional(),
-  postal_code: swissPostalCodeSchema.optional(),
-  city: z.string().max(100).optional(),
-  canton: z.string().max(50).optional(),
-  country: z.string().max(50).optional(),
+  address_line1: z.string().max(200).nullish(),
+  address_line2: z.string().max(200).nullish(),
+  postal_code: swissPostalCodeSchema.or(z.literal('')).nullish(),
+  city: z.string().max(100).nullish(),
+  canton: z.string().max(50).nullish(),
+  country: z.string().max(50).nullish(),
 
   // Privacy settings
-  show_email: z.boolean().optional(),
-  show_phone: z.boolean().optional(),
+  show_email: z.boolean().nullish(),
+  show_phone: z.boolean().nullish(),
 
   // Notification preferences
-  email_notifications: z.boolean().optional(),
-  sms_notifications: z.boolean().optional(),
-  marketplace_updates: z.boolean().optional(),
-  workshop_reminders: z.boolean().optional(),
+  email_notifications: z.boolean().nullish(),
+  sms_notifications: z.boolean().nullish(),
+  marketplace_updates: z.boolean().nullish(),
+  workshop_reminders: z.boolean().nullish(),
 
   // Legacy preferences
-  preferred_language: z.string().max(10).optional(),
-  newsletter_subscribed: z.boolean().optional(),
-  interests: z.array(z.string()).optional(),
+  preferred_language: z.string().max(10).nullish(),
+  newsletter_subscribed: z.boolean().nullish(),
+  interests: z.array(z.string()).nullish(),
 
   // Service provider fields
-  website: z.string().url('Ungültige URL').optional().or(z.literal('')),
-  skills: z.array(z.string()).optional(),
-  expertise_areas: z.array(z.string()).optional(),
-  service_radius_km: z.number().int().min(0).optional(),
+  website: z.string().url('Ungültige URL').or(z.literal('')).nullish(),
+  skills: z.array(z.string()).nullish(),
+  expertise_areas: z.array(z.string()).nullish(),
+  service_radius_km: z.number().int().min(0).nullish(),
   availability: z.record(z.string(), z.object({
     available: z.boolean(),
     hours: z.string().optional(),
-  })).optional(),
+  })).nullish(),
 })
 
 export type UpdateProfileInput = z.infer<typeof UpdateProfileSchema>


### PR DESCRIPTION
Three reported issues:

1. **Profile 'Validierungsfehler'** — GET returns `null` for empty fields but the save schema only accepted `string|undefined`; saving a sparse profile failed on ~18 null fields. Schema fields now `.nullish()`. Unit-tested (3/3).
2. **Timecards with leave never submitted (migration 107)** — stale `timecard_entries` CHECK constraints (migration 067) rejected the 6 Swiss absence categories + 0-min unpaid days, so any card with leave failed to INSERT → never reached 'submitted' → approvals queue empty even for superadmin. Realigned to the config SSOT.
3. **Submit far from fill controls** — added a sticky bottom Save/Einreichen bar.

typecheck + full suite 531/7691 green. (Dev server is OOM-killed in this env; verified via unit tests + constraint SQL.)