### PR TITLE
feat(timecards): submitter confirmation email + optional reject reason + approved-lock

### DIFF
--- a/messages/de.json
+++ b/messages/de.json
@@ -9765,6 +9765,7 @@
       "submit": "Zur Prüfung einreichen",
       "submitting": "Sende…",
       "resubmit": "Erneut einreichen",
+      "lockedApproved": "Genehmigt und gesperrt",
       "submitSuccess": "Zur Prüfung gesendet — Freigabe-Team wird benachrichtigt.",
       "submitHint": "Entwurf speichern hält deine Eingaben; «Zur Prüfung einreichen» sendet an Freigabe.",
       "submitError": "Zeitkarte konnte nicht eingereicht werden.",

--- a/src/components/admin/timecards/TimecardApprovalsClient.tsx
+++ b/src/components/admin/timecards/TimecardApprovalsClient.tsx
@@ -135,10 +135,8 @@ export function TimecardApprovalsClient() {
 
   const runBulk = async (status: 'approved' | 'rejected') => {
     if (selected.size === 0) return
-    if (status === 'rejected' && !sharedNote.trim()) {
-      setError('Eine Begründung ist nötig, wenn Karten zurückgewiesen werden.')
-      return
-    }
+    // A rejection reason is optional — it's sent when provided so the submitter
+    // knows what to change, but isn't required.
     setBusy(true)
     setError(null)
     setMessage(null)
@@ -216,7 +214,7 @@ export function TimecardApprovalsClient() {
               type="text"
               value={sharedNote}
               onChange={e => setSharedNote(e.target.value)}
-              placeholder="Notiz (optional bei Genehmigung, Pflicht bei Rückweisung)"
+              placeholder="Notiz (optional) — bei Rückweisung erklärt sie dem Team, was anzupassen ist"
               className="flex-1 min-w-0"
               maxLength={1000}
             />
@@ -233,9 +231,8 @@ export function TimecardApprovalsClient() {
               <Button
                 variant="destructive-outline"
                 onClick={() => runBulk('rejected')}
-                disabled={busy || !sharedNote.trim()}
+                disabled={busy}
                 className="inline-flex items-center gap-1.5 text-sm font-semibold"
-                title={!sharedNote.trim() ? 'Notiz erforderlich für Rückweisung' : undefined}
               >
                 <XCircle className="w-4 h-4" />
                 Zurückweisen

--- a/src/components/timecards/TimecardsClient.tsx
+++ b/src/components/timecards/TimecardsClient.tsx
@@ -261,10 +261,12 @@ export function TimecardsClient({
 
       {/* Sticky action bar — keeps Save/Einreichen one tap away right after
           filling (the fill + leave controls sit mid-page; without this the user
-          had to scroll back up to the header to submit). */}
+          had to scroll back up to the header to submit). Locked once approved. */}
       <div className="sticky bottom-0 z-20 -mx-1 flex items-center justify-between gap-3 border-t border-subtle bg-surface-base/95 px-1 py-3 backdrop-blur-sm">
         <p className="text-sm text-text-tertiary">
-          {tc.periodEntries.length} {t('headerDaysSuffix')} · {formatTimecardDuration(tc.totalMinutes)}
+          {tc.draft.status === 'approved'
+            ? t('lockedApproved')
+            : `${tc.periodEntries.length} ${t('headerDaysSuffix')} · ${formatTimecardDuration(tc.totalMinutes)}`}
         </p>
         <div className="flex items-center gap-2">
           <Button
@@ -272,7 +274,7 @@ export function TimecardsClient({
             variant="outline"
             size="sm"
             onClick={tc.saveDraft}
-            disabled={tc.isSaving || tc.isLoadingDraft}
+            disabled={tc.isSaving || tc.isLoadingDraft || tc.draft.status === 'approved'}
           >
             {tc.isSaving ? t('saving') : t('save')}
           </Button>
@@ -281,7 +283,7 @@ export function TimecardsClient({
             variant="primary"
             size="sm"
             onClick={tc.submitDraft}
-            disabled={tc.isSubmitting || tc.periodEntries.length === 0 || tc.isLoadingDraft}
+            disabled={tc.isSubmitting || tc.periodEntries.length === 0 || tc.isLoadingDraft || tc.draft.status === 'approved'}
           >
             {tc.isSubmitting ? t('submitting') : tc.draft.status === 'submitted' ? t('resubmit') : t('submit')}
           </Button>

--- a/src/lib/services/timecards.ts
+++ b/src/lib/services/timecards.ts
@@ -476,6 +476,20 @@ export async function submitTimecard(userId: string, input: TimecardSaveInput): 
     logger.warn('Failed to notify timecard approvers', { error, timecardId: saved.id })
   }
 
+  // Confirm to the submitter that their card is in review (in-app + email, gated
+  // on their email_notifications pref — same path as the approver notification).
+  try {
+    await notifyUsers([userId], {
+      type: NOTIFICATION_TYPES.TIMECARD_SUBMITTED,
+      title: 'Zeitkarte eingereicht',
+      content: `Deine Zeitkarte für ${submitted.period_start} – ${submitted.period_end} wurde zur Prüfung eingereicht. Du wirst benachrichtigt, sobald sie geprüft wurde.`,
+      related_type: RELATED_TYPES.TIMECARD,
+      related_id: submitted.id,
+    })
+  } catch (error) {
+    logger.warn('Failed to send timecard submission confirmation', { error, timecardId: saved.id })
+  }
+
   return submitted
 }
 


### PR DESCRIPTION
Closes the workflow gaps from the spec (most already existed — status model, transitions, approver resolution, approve/reject with optional reason, email to approvers on submit + submitter on review):

- **Submitter confirmation on submit** (in-app + email via the notification path) — previously only approvers were notified.
- **Reject reason now optional in the approvals UI** — schema/service already allowed it; the UI was forcing it. Still sent when provided.
- **Approved cards visually locked** in the editor (server already enforced).

Remaining (larger UI, needs a stable dev env to build+test): approver opens/edits a card + per-card view in the queue. The reject→notify→edit→resubmit loop already covers corrections.

typecheck + umlauts + full suite 531/7691 green.