### PR TITLE
feat(timecards): approver opens/views/edits a card from the queue

### DIFF
--- a/src/app/api/admin/timecards/[id]/route.ts
+++ b/src/app/api/admin/timecards/[id]/route.ts
@@ -2,11 +2,53 @@ import { NextRequest } from 'next/server'
 import { withAdmin, type ValidSession } from '@/lib/api/middleware'
 import { apiBadRequest, apiError, apiNotFound, apiSuccess } from '@/lib/api/helpers'
 import { logger } from '@/lib/logger'
-import { timecardReviewActionSchema } from '@/lib/schemas/timecards'
-import { reviewTimecard } from '@/lib/services/timecards'
+import { timecardReviewActionSchema, timecardSaveSchema } from '@/lib/schemas/timecards'
+import { reviewTimecard, getTimecardByIdForReview, saveTimecardEntriesForReview } from '@/lib/services/timecards'
 import { db } from '@/db'
 import { timecards } from '@/db/schema'
 import { eq } from 'drizzle-orm'
+
+// Approver views a single submitted card (with its day entries) before deciding.
+export const GET = withAdmin('timecards', async (
+  _request: NextRequest,
+  session: ValidSession,
+  context,
+) => {
+  try {
+    const id = context?.params?.id
+    if (!id) return apiBadRequest('Zeitkarten-ID ist erforderlich')
+    const card = await getTimecardByIdForReview(id)
+    if (!card) return apiNotFound('Zeitkarte')
+    return apiSuccess(card)
+  } catch (error) {
+    logger.error('Error loading timecard for review', { error, reviewerId: session.user.id })
+    return apiError(error, 'Zeitkarte konnte nicht geladen werden')
+  }
+})
+
+// Approver edits a submitted card's entries (saved to the card's owner, status preserved).
+export const PUT = withAdmin('timecards', async (
+  request: NextRequest,
+  session: ValidSession,
+  context,
+) => {
+  try {
+    const id = context?.params?.id
+    if (!id) return apiBadRequest('Zeitkarten-ID ist erforderlich')
+
+    const body = await request.json()
+    const parsed = timecardSaveSchema.safeParse(body)
+    if (!parsed.success) {
+      return apiBadRequest('Ungültige Eingabedaten', parsed.error.flatten().fieldErrors)
+    }
+
+    const result = await saveTimecardEntriesForReview(id, parsed.data)
+    return apiSuccess(result)
+  } catch (error) {
+    logger.error('Error editing timecard as approver', { error, reviewerId: session.user.id })
+    return apiError(error, 'Zeitkarte konnte nicht gespeichert werden')
+  }
+})
 
 export const PATCH = withAdmin('timecards', async (
   request: NextRequest,

--- a/src/components/admin/timecards/TimecardApprovalsClient.tsx
+++ b/src/components/admin/timecards/TimecardApprovalsClient.tsx
@@ -25,8 +25,10 @@ import {
   XCircle,
   ExternalLink,
   AlertTriangle,
+  Eye,
 } from 'lucide-react'
 import { apiFetch } from '@/lib/api/client'
+import { TimecardReviewDrawer } from './TimecardReviewDrawer'
 import { Avatar } from '@/components/ui/Avatar'
 import { Button } from '@/components/ui/button'
 import { Input } from '@/components/ui/input'
@@ -82,6 +84,7 @@ export function TimecardApprovalsClient() {
   const [isLoading, setIsLoading] = useState(false)
   const [busy, setBusy] = useState(false)
   const [message, setMessage] = useState<string | null>(null)
+  const [openCardId, setOpenCardId] = useState<string | null>(null)
   const [error, setError] = useState<string | null>(null)
 
   const loadQueue = useCallback(async () => {
@@ -338,6 +341,14 @@ export function TimecardApprovalsClient() {
                     <span className={`hidden md:inline-flex items-center px-2 py-0.5 rounded-full text-[10px] font-semibold whitespace-nowrap ${statusColor}`}>
                       {statusLabel}
                     </span>
+                    <Button
+                      variant="outline"
+                      size="sm"
+                      onClick={() => setOpenCardId(row.id)}
+                      className="shrink-0 inline-flex items-center gap-1.5"
+                    >
+                      <Eye className="w-3.5 h-3.5" /> Prüfen
+                    </Button>
                   </li>
                 )
               })}
@@ -345,6 +356,14 @@ export function TimecardApprovalsClient() {
           </>
         )}
       </div>
+
+      {openCardId && (
+        <TimecardReviewDrawer
+          cardId={openCardId}
+          onClose={() => setOpenCardId(null)}
+          onChanged={loadQueue}
+        />
+      )}
     </div>
   )
 }

--- a/src/components/admin/timecards/TimecardReviewDrawer.tsx
+++ b/src/components/admin/timecards/TimecardReviewDrawer.tsx
@@ -1,0 +1,247 @@
+'use client'
+
+import { useEffect, useState } from 'react'
+import { createPortal } from 'react-dom'
+import { X, Check, Ban, Pencil, Save } from 'lucide-react'
+import { Button } from '@/components/ui/button'
+import { Input } from '@/components/ui/input'
+import { Select } from '@/components/ui/select'
+import { useFocusTrap } from '@/hooks/useFocusTrap'
+import { apiFetch } from '@/lib/api/client'
+import {
+  TIMECARD_ENTRY_CATEGORY_OPTIONS,
+  getTimecardEntryCategoryLabel,
+  formatTimecardDuration,
+} from '@/config/timecards'
+
+interface ReviewEntry {
+  id?: string
+  work_date: string
+  duration_minutes: number
+  category: string
+  description?: string | null
+  start_time?: string | null
+  end_time?: string | null
+  break_minutes?: number | null
+  source?: string | null
+}
+interface ReviewCard {
+  id: string
+  user_name?: string | null
+  user_email?: string | null
+  period_type: string
+  period_start: string
+  period_end: string
+  status: string
+  entries: ReviewEntry[]
+}
+
+/**
+ * Approver view of a single submitted timecard. Lets an approver SEE the day
+ * entries before deciding, EDIT them (saved to the card's owner via the admin
+ * PUT, status preserved), and approve / reject (reason optional). Reuses the
+ * overlay focus SSOT (useFocusTrap).
+ */
+export function TimecardReviewDrawer({
+  cardId,
+  onClose,
+  onChanged,
+}: {
+  cardId: string
+  onClose: () => void
+  onChanged: () => void
+}) {
+  const panelRef = useFocusTrap<HTMLDivElement>(true, onClose)
+  const [mounted, setMounted] = useState(false)
+  const [card, setCard] = useState<ReviewCard | null>(null)
+  const [entries, setEntries] = useState<ReviewEntry[]>([])
+  const [editing, setEditing] = useState(false)
+  const [note, setNote] = useState('')
+  const [busy, setBusy] = useState<string | null>(null)
+  const [error, setError] = useState<string | null>(null)
+
+  // eslint-disable-next-line react-hooks/set-state-in-effect -- portal mount guard (SSR-safe)
+  useEffect(() => { setMounted(true) }, [])
+
+  useEffect(() => {
+    let active = true
+    apiFetch<ReviewCard>(`/api/admin/timecards/${cardId}`).then(r => {
+      if (!active) return
+      if (r.success && r.data) { setCard(r.data); setEntries(r.data.entries ?? []) }
+      else setError(r.error || 'Zeitkarte konnte nicht geladen werden.')
+    })
+    return () => { active = false }
+  }, [cardId])
+
+  const total = entries.reduce((s, e) => s + (Number(e.duration_minutes) || 0), 0)
+  const isApproved = card?.status === 'approved'
+
+  const patchEntry = (i: number, patch: Partial<ReviewEntry>) =>
+    setEntries(prev => prev.map((e, idx) => (idx === i ? { ...e, ...patch } : e)))
+
+  const save = async () => {
+    if (!card) return
+    setBusy('save'); setError(null)
+    const r = await apiFetch(`/api/admin/timecards/${cardId}`, {
+      method: 'PUT',
+      body: {
+        period_type: card.period_type,
+        period_start: card.period_start,
+        period_end: card.period_end,
+        entries,
+      },
+    })
+    setBusy(null)
+    if (!r.success) { setError(r.error || 'Speichern fehlgeschlagen.'); return }
+    setEditing(false)
+    onChanged()
+  }
+
+  const review = async (status: 'approved' | 'rejected') => {
+    setBusy(status); setError(null)
+    const r = await apiFetch(`/api/admin/timecards/${cardId}`, {
+      method: 'PATCH',
+      body: { status, review_notes: note.trim() || null },
+    })
+    setBusy(null)
+    if (!r.success) { setError(r.error || 'Aktion fehlgeschlagen.'); return }
+    onChanged()
+    onClose()
+  }
+
+  if (!mounted) return null
+
+  return createPortal(
+    <div className="fixed inset-0 z-50 flex justify-end">
+      <Button
+        variant="ghost"
+        onClick={onClose}
+        aria-label="Schliessen"
+        className="absolute inset-0 h-full w-full rounded-none bg-black/40 p-0 backdrop-blur-xs hover:bg-black/40"
+      />
+      <div
+        ref={panelRef}
+        role="dialog"
+        aria-modal="true"
+        aria-label="Zeitkarte prüfen"
+        className="relative flex h-full w-full max-w-lg flex-col overflow-hidden border-l border-subtle bg-surface-base"
+      >
+        <div className="flex items-center justify-between border-b border-subtle px-5 py-4">
+          <div className="min-w-0">
+            <p className="truncate text-sm font-semibold text-text-primary">
+              {card?.user_name || card?.user_email || 'Zeitkarte'}
+            </p>
+            <p className="text-xs text-text-tertiary">
+              {card ? `${card.period_start} – ${card.period_end} · ${formatTimecardDuration(total)}` : 'Lädt…'}
+              {isApproved && ' · genehmigt'}
+            </p>
+          </div>
+          <Button variant="ghost" size="icon" onClick={onClose} aria-label="Schliessen">
+            <X className="h-4 w-4" />
+          </Button>
+        </div>
+
+        <div className="flex-1 overflow-y-auto px-5 py-4">
+          {error && <p className="mb-3 text-sm text-error-600 dark:text-error-400">{error}</p>}
+          {!card ? (
+            <p className="text-sm text-text-tertiary">Lädt…</p>
+          ) : entries.length === 0 ? (
+            <p className="text-sm text-text-tertiary">Keine Einträge.</p>
+          ) : (
+            <table className="w-full text-sm">
+              <thead>
+                <tr className="text-left text-xs uppercase tracking-wide text-text-tertiary">
+                  <th className="py-1 font-medium">Tag</th>
+                  <th className="py-1 font-medium">Kategorie</th>
+                  <th className="py-1 text-right font-medium">Std.</th>
+                </tr>
+              </thead>
+              <tbody>
+                {entries.map((e, i) => (
+                  <tr key={e.id ?? `${e.work_date}-${i}`} className="border-t border-subtle">
+                    <td className="py-1.5 pr-2 font-mono tabular-nums text-text-secondary">{e.work_date}</td>
+                    <td className="py-1.5 pr-2">
+                      {editing ? (
+                        <Select
+                          value={e.category}
+                          onChange={ev => patchEntry(i, { category: ev.target.value })}
+                          className="w-full text-sm"
+                        >
+                          {TIMECARD_ENTRY_CATEGORY_OPTIONS.map(c => (
+                            <option key={c} value={c}>{getTimecardEntryCategoryLabel(c)}</option>
+                          ))}
+                        </Select>
+                      ) : (
+                        getTimecardEntryCategoryLabel(e.category)
+                      )}
+                    </td>
+                    <td className="py-1.5 text-right tabular-nums">
+                      {editing ? (
+                        <Input
+                          type="number"
+                          step="0.25"
+                          min="0"
+                          max="16"
+                          value={(Number(e.duration_minutes) / 60).toString()}
+                          onChange={ev =>
+                            patchEntry(i, { duration_minutes: Math.round((parseFloat(ev.target.value) || 0) * 60) })
+                          }
+                          className="ml-auto w-20 text-right"
+                        />
+                      ) : (
+                        (Number(e.duration_minutes) / 60).toFixed(2)
+                      )}
+                    </td>
+                  </tr>
+                ))}
+              </tbody>
+            </table>
+          )}
+        </div>
+
+        <div className="space-y-3 border-t border-subtle px-5 py-4">
+          {!editing && (
+            <Input
+              type="text"
+              value={note}
+              onChange={e => setNote(e.target.value)}
+              placeholder="Notiz (optional) — bei Rückweisung erklärt sie, was anzupassen ist"
+              maxLength={1000}
+            />
+          )}
+          <div className="flex flex-wrap gap-2">
+            {editing ? (
+              <>
+                <Button variant="primary" size="sm" onClick={save} disabled={busy !== null} className="inline-flex items-center gap-1.5">
+                  <Save className="h-3.5 w-3.5" /> Speichern
+                </Button>
+                <Button variant="ghost" size="sm" onClick={() => { setEditing(false); setEntries(card?.entries ?? []) }} disabled={busy !== null}>
+                  Abbrechen
+                </Button>
+              </>
+            ) : (
+              <>
+                <Button
+                  variant="primary"
+                  size="sm"
+                  onClick={() => review('approved')}
+                  disabled={busy !== null || isApproved}
+                  className="inline-flex items-center gap-1.5 bg-success-600 text-white hover:bg-success-700"
+                >
+                  <Check className="h-3.5 w-3.5" /> Genehmigen
+                </Button>
+                <Button variant="destructive-outline" size="sm" onClick={() => review('rejected')} disabled={busy !== null} className="inline-flex items-center gap-1.5">
+                  <Ban className="h-3.5 w-3.5" /> Zurückweisen
+                </Button>
+                <Button variant="outline" size="sm" onClick={() => setEditing(true)} disabled={busy !== null || isApproved} className="inline-flex items-center gap-1.5">
+                  <Pencil className="h-3.5 w-3.5" /> Bearbeiten
+                </Button>
+              </>
+            )}
+          </div>
+        </div>
+      </div>
+    </div>,
+    document.body,
+  )
+}

--- a/src/lib/services/timecards.ts
+++ b/src/lib/services/timecards.ts
@@ -493,6 +493,31 @@ export async function submitTimecard(userId: string, input: TimecardSaveInput): 
   return submitted
 }
 
+/** Fetch one timecard with its entries for approver review (by card id). */
+export async function getTimecardByIdForReview(timecardId: string): Promise<TimecardWithEntries | null> {
+  return fetchTimecardWithEntries(db, timecardId)
+}
+
+/**
+ * Approver edits a submitted card's entries. Saves to the card's OWNER (not the
+ * approver) and preserves the submitted status — `saveTimecardDraft` only flips
+ * rejected→draft and blocks approved, so a submitted card stays submitted.
+ * Authorization is enforced at the route (withAdmin('timecards')).
+ */
+export async function saveTimecardEntriesForReview(
+  timecardId: string,
+  input: TimecardSaveInput,
+): Promise<TimecardWithEntries> {
+  const rows = await db
+    .select({ userId: timecards.userId })
+    .from(timecards)
+    .where(eq(timecards.id, timecardId))
+    .limit(1)
+  const owner = rows[0]
+  if (!owner) throw new Error('timecard_not_found')
+  return saveTimecardDraft(owner.userId, input)
+}
+
 export async function reviewTimecard(
   reviewerId: string,
   timecardId: string,


### PR DESCRIPTION
Completes the approval-workflow spec. The queue was bulk-only with no way to see a card's entries. Each row now has **Prüfen** → a review drawer that:
- shows the day entries (date, category, hours),
- lets the approver **edit** entries (saved to the card's owner via new admin `PUT /api/admin/timecards/[id]`, status preserved — reuses `saveTimecardDraft`),
- **approve / reject** (reason optional) inline per card.

New `GET`+`PUT` on `/api/admin/timecards/[id]` (withAdmin). Approved cards are read-only (server-enforced too). Reuses useFocusTrap + Select primitive.

typecheck + lint + umlauts + full suite 531/7691 green.