### PR TITLE
feat(timecards): reopen — superadmin can un-approve a locked card

### DIFF
--- a/messages/de.json
+++ b/messages/de.json
@@ -9766,6 +9766,7 @@
       "submitting": "Sende…",
       "resubmit": "Erneut einreichen",
       "lockedApproved": "Genehmigt und gesperrt",
+      "reopen2": "Wieder öffnen (Admin)",
       "submitSuccess": "Zur Prüfung gesendet — Freigabe-Team wird benachrichtigt.",
       "submitHint": "Entwurf speichern hält deine Eingaben; «Zur Prüfung einreichen» sendet an Freigabe.",
       "submitError": "Zeitkarte konnte nicht eingereicht werden.",

--- a/src/app/api/admin/timecards/[id]/reopen/route.ts
+++ b/src/app/api/admin/timecards/[id]/reopen/route.ts
@@ -1,0 +1,23 @@
+import { NextRequest } from 'next/server'
+import { withAdmin, type ValidSession } from '@/lib/api/middleware'
+import { apiBadRequest, apiError, apiSuccess } from '@/lib/api/helpers'
+import { logger } from '@/lib/logger'
+import { reopenTimecard } from '@/lib/services/timecards'
+
+// Reopen a reviewed/locked timecard back to draft (e.g. approved by mistake).
+export const POST = withAdmin('timecards', async (
+  _request: NextRequest,
+  session: ValidSession,
+  context,
+) => {
+  try {
+    const id = context?.params?.id
+    if (!id) return apiBadRequest('Zeitkarten-ID ist erforderlich')
+    const result = await reopenTimecard(id)
+    logger.info('Timecard reopened', { timecardId: id, by: session.user.id })
+    return apiSuccess(result)
+  } catch (error) {
+    logger.error('Error reopening timecard', { error, reviewerId: session.user.id })
+    return apiError(error, 'Zeitkarte konnte nicht wieder geöffnet werden')
+  }
+})

--- a/src/app/dashboard/timecards/page.tsx
+++ b/src/app/dashboard/timecards/page.tsx
@@ -24,6 +24,7 @@ import { Metadata } from 'next'
 import { redirect } from 'next/navigation'
 import { eq, desc } from 'drizzle-orm'
 import { auth } from '@/auth'
+import { isSuperAdmin } from '@/lib/permissions'
 import { db } from '@/db'
 import { teamProfiles, timecards as timecardsTable } from '@/db/schema'
 import Heading from '@/components/ui/Heading'
@@ -42,6 +43,13 @@ export default async function DashboardTimecardsPage() {
   if (!session?.user) {
     redirect('/auth/login?callbackUrl=/dashboard/timecards')
   }
+
+  // Approvers (superadmins / timecard-permission staff) can reopen a card that
+  // was reviewed/approved by mistake — see the "Wieder öffnen" action.
+  const u = session.user as typeof session.user & { isSuperAdmin?: boolean; staffPermissions?: string[] }
+  const canApprove =
+    isSuperAdmin(u.email, u.isSuperAdmin) ||
+    (u.staffPermissions ?? []).some(p => ['timecards', 'timecard-approvals', '*'].includes(p))
 
   // Pull workingHours so the TimecardsClient can prefill entries from the
   // user's regular schedule. Returns null if there's no team profile yet —
@@ -87,6 +95,7 @@ export default async function DashboardTimecardsPage() {
           <TimecardsClient
             workingHours={profile?.workingHours ?? null}
             userName={session.user.name || session.user.email || 'Du'}
+            canApprove={canApprove}
           />
         </div>
         <aside className="min-w-0 lg:sticky lg:top-20 lg:self-start">

--- a/src/components/timecards/TimecardsClient.tsx
+++ b/src/components/timecards/TimecardsClient.tsx
@@ -8,6 +8,7 @@ import { Textarea } from '@/components/ui/textarea'
 import { Button } from '@/components/ui/button'
 import { ContextMenu, type ContextMenuItem, type ContextMenuPosition } from '@/components/ui/context-menu'
 import { cn } from '@/lib/utils'
+import { apiFetch } from '@/lib/api/client'
 import { formatTimecardDuration, TIMECARD_ABSENCE_TYPES } from '@/config/timecards'
 import { getDisplayDate } from '@/lib/team/timecard-utils'
 import { NoScheduleNotice } from './NoScheduleNotice'
@@ -36,9 +37,12 @@ import type { TimecardAIResult } from './types'
 export function TimecardsClient({
   workingHours,
   userName,
+  canApprove = false,
 }: {
   workingHours: string | null
   userName: string
+  /** Approvers can reopen a card that was reviewed/approved by mistake. */
+  canApprove?: boolean
 }) {
   const tc = useTimecardDraft({ workingHours })
   const [extrasOpen, setExtrasOpen] = useState(false)
@@ -269,6 +273,19 @@ export function TimecardsClient({
             : `${tc.periodEntries.length} ${t('headerDaysSuffix')} · ${formatTimecardDuration(tc.totalMinutes)}`}
         </p>
         <div className="flex items-center gap-2">
+          {canApprove && tc.draft.status === 'approved' && tc.draft.id && (
+            <Button
+              type="button"
+              variant="outline"
+              size="sm"
+              onClick={async () => {
+                const r = await apiFetch(`/api/admin/timecards/${tc.draft.id}/reopen`, { method: 'POST' })
+                if (r.success) window.location.reload()
+              }}
+            >
+              {t('reopen2')}
+            </Button>
+          )}
           <Button
             type="button"
             variant="outline"

--- a/src/components/timecards/draft-utils.ts
+++ b/src/components/timecards/draft-utils.ts
@@ -12,6 +12,7 @@ import type { DraftState } from './types'
 
 export function createDraft(entries: TimecardEntryInput[], selectedDate: string): DraftState {
   return {
+    id: null,
     entries,
     notes: '',
     status: TIMECARD_STATUSES.DRAFT,
@@ -21,6 +22,7 @@ export function createDraft(entries: TimecardEntryInput[], selectedDate: string)
 
 export function toDraftState(timecard: Timecard, fallbackSelectedDate: string): DraftState {
   return {
+    id: timecard.id ?? null,
     entries: timecard.entries.map(entry => normalizeEntry(entry)),
     notes: timecard.notes ?? '',
     status: timecard.status as DraftState['status'],

--- a/src/components/timecards/types.ts
+++ b/src/components/timecards/types.ts
@@ -14,6 +14,8 @@ export interface TimecardAIResult {
 }
 
 export interface DraftState {
+  /** Persisted card id once saved/loaded (null for a fresh, never-saved draft). */
+  id: string | null
   entries: TimecardEntryInput[]
   notes: string
   status: TimecardStatus

--- a/src/lib/services/timecards.ts
+++ b/src/lib/services/timecards.ts
@@ -518,6 +518,31 @@ export async function saveTimecardEntriesForReview(
   return saveTimecardDraft(owner.userId, input)
 }
 
+/**
+ * Reopen a reviewed/locked timecard back to draft so it can be edited again
+ * (e.g. a card approved by mistake — like an approved-empty month). Clears the
+ * review + submission metadata. Authorization is enforced at the route
+ * (withAdmin('timecards')).
+ */
+export async function reopenTimecard(timecardId: string): Promise<TimecardWithEntries> {
+  const rows = await db
+    .update(timecards)
+    .set({
+      status: TIMECARD_STATUSES.DRAFT,
+      reviewedBy: null,
+      reviewedAt: null,
+      reviewNotes: null,
+      submittedAt: null,
+      updatedAt: sql`NOW()`,
+    })
+    .where(eq(timecards.id, timecardId))
+    .returning({ id: timecards.id })
+  if (!rows[0]) throw new Error('timecard_not_found')
+  const result = await fetchTimecardWithEntries(db, timecardId)
+  if (!result) throw new Error('timecard_not_found')
+  return result
+}
+
 export async function reviewTimecard(
   reviewerId: string,
   timecardId: string,


### PR DESCRIPTION
An approved card is locked, but one approved by mistake (e.g. the approved-empty June month that's blocking submit) had no way back. Approvers can now reopen it to draft.

- `reopenTimecard` service + `POST /api/admin/timecards/[id]/reopen` (withAdmin).
- Editor shows "Wieder öffnen (Admin)" on an approved card for approvers (superadmin / timecards permission) → reopen → reload.

typecheck + lint + umlauts + full suite 531/7691 green.