### PR TITLE
refactor(admin): one Freigaben + drop the duplicate timecard editor

### DIFF
--- a/src/app/admin/approvals/page.tsx
+++ b/src/app/admin/approvals/page.tsx
@@ -17,6 +17,7 @@ import { APPROVAL_STATUS, SUBMISSION_CONTENT_TYPE, SUBMISSION_CONTENT_TYPE_LABEL
 import { formatDateShort } from '@/lib/date-formats'
 import { isSuperAdmin } from '@/lib/permissions'
 import { ApprovalActions } from './ApprovalActions'
+import { ApprovalTabs } from '@/components/admin/approvals/ApprovalTabs'
 import { PermissionRequestsManager } from '@/components/admin/PermissionRequestsManager'
 import AdminPageWrapper from '@/components/admin/AdminPageWrapper'
 import Link from 'next/link'
@@ -246,6 +247,7 @@ export default async function ApprovalsPage() {
       icon={CheckSquare}
       iconColor="orange"
     >
+      <ApprovalTabs />
       {/* Hero status — surfaces the actual headline + actionable list below */}
       <ApprovalsHero
         pending={totalPendingAllSources}

--- a/src/app/admin/team/approvals/page.tsx
+++ b/src/app/admin/team/approvals/page.tsx
@@ -18,6 +18,8 @@ import { auth } from '@/auth'
 import AdminPageWrapper from '@/components/admin/AdminPageWrapper'
 import { canAccessSection } from '@/lib/permissions'
 import { TimecardApprovalsClient } from '@/components/admin/timecards/TimecardApprovalsClient'
+import { TimeOffApprovals } from '@/components/admin/timecards/TimeOffApprovals'
+import { ApprovalTabs } from '@/components/admin/approvals/ApprovalTabs'
 
 export const metadata: Metadata = {
   title: 'Freigaben · Zeitkarten',
@@ -44,12 +46,15 @@ export default async function TimecardApprovalsPage() {
   return (
     <AdminPageWrapper
       title="Freigaben"
-      description="Eingereichte Zeitkarten in Bulk prüfen und genehmigen."
+      description="Eingereichte Zeitkarten und Abwesenheiten prüfen und genehmigen."
       icon={CheckSquare}
       iconColor="green"
-      backButton={{ href: '/admin/team', label: 'Team' }}
     >
+      <ApprovalTabs />
       <TimecardApprovalsClient />
+      <div className="mt-10 border-t border-subtle pt-8">
+        <TimeOffApprovals />
+      </div>
     </AdminPageWrapper>
   )
 }

--- a/src/app/admin/timecards/page.tsx
+++ b/src/app/admin/timecards/page.tsx
@@ -1,44 +1,11 @@
-import { Metadata } from 'next'
-import { getTranslations } from 'next-intl/server'
-import { eq } from 'drizzle-orm'
-import { Clock } from 'lucide-react'
-import { db } from '@/db'
-import { teamProfiles } from '@/db/schema'
-import AdminPageWrapper from '@/components/admin/AdminPageWrapper'
-import { requireSection } from '@/lib/admin/guards'
-import { TimecardsClient } from '@/components/timecards/TimecardsClient'
-import { TimeOffApprovals } from '@/components/admin/timecards/TimeOffApprovals'
+import { redirect } from 'next/navigation'
 
-export const metadata: Metadata = {
-  title: 'Zeitkarten',
-  description: 'Arbeitszeiten erfassen und genehmigen.',
-}
-
-export default async function TimecardsPage() {
-  const session = await requireSection('timecards')
-  const t = await getTranslations('admin.timecards')
-
-  const [profile] = await db
-    .select({ workingHours: teamProfiles.workingHours })
-    .from(teamProfiles)
-    .where(eq(teamProfiles.userId, session.user.id))
-    .limit(1)
-
-  return (
-    <AdminPageWrapper
-      title={t('pageTitle')}
-      description={t('pageDescription')}
-      icon={Clock}
-      iconColor="blue"
-    >
-      <TimecardsClient
-        workingHours={profile?.workingHours ?? null}
-        userName={session.user.name || session.user.email || 'Teammitglied'}
-      />
-
-      <div className="mt-10 border-t border-subtle pt-8">
-        <TimeOffApprovals />
-      </div>
-    </AdminPageWrapper>
-  )
+/**
+ * The own-timecard editor lives at /dashboard/timecards (one place to fill your
+ * own card). This admin route used to render a second copy of that same editor
+ * plus the time-off approvals — both now live elsewhere (editor → dashboard,
+ * time-off approvals → /admin/team/approvals). Redirect legacy links there.
+ */
+export default function AdminTimecardsRedirect() {
+  redirect('/dashboard/timecards')
 }

--- a/src/components/admin/approvals/ApprovalTabs.tsx
+++ b/src/components/admin/approvals/ApprovalTabs.tsx
@@ -1,0 +1,42 @@
+'use client'
+
+import Link from 'next/link'
+import { usePathname } from 'next/navigation'
+import { cn } from '@/lib/utils'
+
+/**
+ * One Freigaben, tabbed. The admin used to have separate sidebar entries for
+ * content approvals ("Freigaben") and timecard approvals ("Zeitkarten-Freigaben");
+ * this bar makes them a single approvals area. Add a tab here when a new approval
+ * surface is folded in.
+ */
+const TABS = [
+  { href: '/admin/approvals', label: 'Inhalte' },
+  { href: '/admin/team/approvals', label: 'Zeitkarten & Abwesenheit' },
+] as const
+
+export function ApprovalTabs() {
+  const pathname = usePathname()
+  return (
+    <nav className="mb-6 flex flex-wrap gap-1 border-b border-subtle" aria-label="Freigaben">
+      {TABS.map(tab => {
+        const active = pathname === tab.href
+        return (
+          <Link
+            key={tab.href}
+            href={tab.href}
+            aria-current={active ? 'page' : undefined}
+            className={cn(
+              '-mb-px border-b-2 px-4 py-2.5 text-sm font-medium transition-colors',
+              active
+                ? 'border-primary-600 text-text-primary'
+                : 'border-transparent text-text-tertiary hover:border-subtle hover:text-text-secondary',
+            )}
+          >
+            {tab.label}
+          </Link>
+        )
+      })}
+    </nav>
+  )
+}

--- a/src/config/sections.ts
+++ b/src/config/sections.ts
@@ -930,7 +930,9 @@ export const SECTIONS: Record<string, SectionConfig> = {
       emoji: '⏱️',
       color: 'info',
     },
-    visibility: { admin: true, dashboard: false, requiresStaff: true },
+    // Hidden from the sidebar: this route now redirects to the single
+    // own-timecard editor at /dashboard/timecards ("Meine Zeiterfassung").
+    visibility: { admin: false, dashboard: false, requiresStaff: true },
     priority: 202,
     category: 'management',
     sidebarGroup: 'teamhr',
@@ -946,7 +948,9 @@ export const SECTIONS: Record<string, SectionConfig> = {
       emoji: '✅',
       color: 'success',
     },
-    visibility: { admin: true, dashboard: false, requiresStaff: true },
+    // Hidden from the sidebar: folded into the single "Freigaben" page as a tab
+    // (Zeitkarten & Abwesenheit). Route stays reachable via that tab.
+    visibility: { admin: false, dashboard: false, requiresStaff: true },
     priority: 2,
     category: 'management',
     sidebarGroup: 'uebersicht',


### PR DESCRIPTION
Folds the separate Zeitkarten-Freigaben into a single tabbed Freigaben area (Inhalte · Zeitkarten & Abwesenheit), moves time-off approvals there, and redirects the duplicate /admin/timecards editor to /dashboard/timecards. Sidebar entries for both are hidden (routes stay reachable via tab/redirect). tsc + lint + full suite 531/7691 green.