### PR TITLE
refactor(admin): all approvals in one Freigaben (Techniker tab) + cache Next build on CI

### DIFF
--- a/.github/workflows/deploy-selfhost.yml
+++ b/.github/workflows/deploy-selfhost.yml
@@ -53,6 +53,19 @@ jobs:
         if: steps.secrets.outputs.configured == 'true'
         run: npm ci
 
+      # Persist Next.js's incremental compiler cache across runs. The build runs
+      # on this ephemeral runner, so without this every build is COLD (full
+      # recompile). restore-keys falls back to the latest cache for the same
+      # lockfile, making subsequent builds incremental (warm).
+      - name: Cache Next.js build
+        if: steps.secrets.outputs.configured == 'true'
+        uses: actions/cache@v4
+        with:
+          path: .next/cache
+          key: nextjs-${{ runner.os }}-${{ hashFiles('package-lock.json') }}-${{ github.sha }}
+          restore-keys: |
+            nextjs-${{ runner.os }}-${{ hashFiles('package-lock.json') }}-
+
       - name: Run ESLint
         if: steps.secrets.outputs.configured == 'true'
         run: npm run lint

--- a/src/app/admin/repairer-applications/page.tsx
+++ b/src/app/admin/repairer-applications/page.tsx
@@ -1,8 +1,7 @@
 'use client'
 
 import { useTranslations } from 'next-intl'
-import { useRouter } from 'next/navigation'
-import { XCircle, FileText, ArrowLeft } from 'lucide-react'
+import { XCircle, FileText } from 'lucide-react'
 import {
   useRepairerApplications,
   ApplicationFilters,
@@ -15,10 +14,10 @@ import {
 import { APPROVAL_STATUS } from '@/config/approval-status'
 import Heading from '@/components/admin/AdminHeading'
 import { Button } from '@/components/ui/button'
+import { ApprovalTabs } from '@/components/admin/approvals/ApprovalTabs'
 
 export default function RepairerApplicationsAdmin() {
   const t = useTranslations('admin.repairer-applications')
-  const router = useRouter()
   const {
     applications,
     loading,
@@ -67,19 +66,9 @@ export default function RepairerApplicationsAdmin() {
 
   return (
     <div className="space-y-6">
+      <ApprovalTabs />
       {/* Header */}
       <div className="flex items-center justify-between">
-        <div className="flex items-center gap-4">
-          <Button
-            variant="ghost"
-            size="sm"
-            onClick={() => router.push('/admin')}
-            className="flex items-center gap-2 text-text-secondary hover:text-text-primary"
-          >
-            <ArrowLeft className="w-5 h-5" />
-            Zurück zum Admin-Bereich
-          </Button>
-        </div>
         <Heading level={1} className="text-2xl font-bold text-text-primary">{t('pageTitle')}</Heading>
       </div>
 

--- a/src/components/admin/approvals/ApprovalTabs.tsx
+++ b/src/components/admin/approvals/ApprovalTabs.tsx
@@ -13,6 +13,7 @@ import { cn } from '@/lib/utils'
 const TABS = [
   { href: '/admin/approvals', label: 'Inhalte' },
   { href: '/admin/team/approvals', label: 'Zeitkarten & Abwesenheit' },
+  { href: '/admin/repairer-applications', label: 'Techniker' },
 ] as const
 
 export function ApprovalTabs() {

--- a/src/config/sections.ts
+++ b/src/config/sections.ts
@@ -621,7 +621,9 @@ export const SECTIONS: Record<string, SectionConfig> = {
       emoji: '🪛',
       color: 'warning',
     },
-    visibility: { admin: true, dashboard: false, requiresStaff: true },
+    // Hidden from the sidebar: folded into the single "Freigaben" page as the
+    // "Techniker" tab. Route stays reachable via that tab.
+    visibility: { admin: false, dashboard: false, requiresStaff: true },
     priority: 100.8,
     category: 'management',
     sidebarGroup: 'angebot',


### PR DESCRIPTION
**One Freigaben, all approvals:** adds a Techniker tab so the single Freigaben page now spans Inhalte · Zeitkarten & Abwesenheit · Techniker; the separate Techniker-Freigaben sidebar entry is hidden (route reachable via the tab). One sidebar entry, three tabs.

**Deploy speed:** caches .next/cache on the GitHub runner. The build runs on the ephemeral runner, so every build was cold (full recompile) — restore-keys now make builds incremental. This deploy seeds the cache; subsequent ones are warmer.

tsc + lint + yaml + full suite 531/7691 green.