### PR TITLE
feat(admin): email diagnostics + test-send tool

### DIFF
--- a/src/app/admin/settings/email/page.tsx
+++ b/src/app/admin/settings/email/page.tsx
@@ -1,0 +1,26 @@
+import { Metadata } from 'next'
+import { Mail } from 'lucide-react'
+import AdminPageWrapper from '@/components/admin/AdminPageWrapper'
+import { requireSection } from '@/lib/admin/guards'
+import { EmailDiagnostics } from '@/components/admin/settings/EmailDiagnostics'
+
+export const metadata: Metadata = {
+  title: 'E-Mail-Diagnose',
+  description: 'E-Mail-Anbieter, Verbindungstest und Test-Versand.',
+}
+
+export default async function EmailDiagnosticsPage() {
+  await requireSection('settings')
+
+  return (
+    <AdminPageWrapper
+      title="E-Mail-Diagnose"
+      description="Aktiver Anbieter, Verbindungstest und Test-Versand — um Zustellprobleme zu finden."
+      icon={Mail}
+      iconColor="blue"
+      backButton={{ href: '/admin/settings', label: 'Einstellungen' }}
+    >
+      <EmailDiagnostics />
+    </AdminPageWrapper>
+  )
+}

--- a/src/app/admin/settings/page.tsx
+++ b/src/app/admin/settings/page.tsx
@@ -1,4 +1,5 @@
 import { Metadata } from 'next'
+import Link from 'next/link'
 import { getTranslations } from 'next-intl/server'
 import { requireSection } from '@/lib/admin/guards'
 import { Settings, Globe, Mail, Shield, Database, Bell } from 'lucide-react'
@@ -25,8 +26,9 @@ export default async function SettingsPage() {
     {
       icon: Mail,
       title: 'E-Mail',
-      description: 'SMTP-Konfiguration, Templates',
+      description: 'Anbieter, Verbindungstest, Test-Versand',
       color: 'green',
+      href: '/admin/settings/email',
     },
     {
       icon: Shield,
@@ -67,12 +69,8 @@ export default async function SettingsPage() {
       iconColor="gray"
     >
       <div className="grid md:grid-cols-2 lg:grid-cols-3 gap-4">
-        {settingsSections.map(section => (
-          <div
-            key={section.title}
-            className="p-6 bg-surface-base rounded-xl border border opacity-70"
-            aria-disabled="true"
-          >
+        {settingsSections.map(section => {
+          const inner = (
             <div className="flex items-start gap-4">
               <div className={`w-10 h-10 rounded-lg flex items-center justify-center ${getColorClasses(section.color)}`}>
                 <section.icon className="w-5 h-5" />
@@ -80,15 +78,34 @@ export default async function SettingsPage() {
               <div className="flex-1 min-w-0">
                 <div className="flex items-center gap-2 flex-wrap">
                   <Heading level={3} className="font-semibold text-text-primary">{section.title}</Heading>
-                  <span className="text-xs font-medium px-2 py-0.5 rounded-full bg-surface-raised text-text-secondary">
-                    Demnächst
-                  </span>
+                  {!section.href && (
+                    <span className="text-xs font-medium px-2 py-0.5 rounded-full bg-surface-raised text-text-secondary">
+                      Demnächst
+                    </span>
+                  )}
                 </div>
                 <p className="text-sm text-text-secondary mt-1">{section.description}</p>
               </div>
             </div>
-          </div>
-        ))}
+          )
+          return section.href ? (
+            <Link
+              key={section.title}
+              href={section.href}
+              className="block p-6 bg-surface-base rounded-xl border border hover:border-neutral-300 transition-colors"
+            >
+              {inner}
+            </Link>
+          ) : (
+            <div
+              key={section.title}
+              className="p-6 bg-surface-base rounded-xl border border opacity-70"
+              aria-disabled="true"
+            >
+              {inner}
+            </div>
+          )
+        })}
       </div>
 
       <div className="p-6 bg-surface-raised border border rounded-xl">

--- a/src/app/api/admin/email/diagnostics/route.ts
+++ b/src/app/api/admin/email/diagnostics/route.ts
@@ -1,0 +1,74 @@
+import { NextRequest } from 'next/server'
+import { z } from 'zod'
+import { withAdmin, type ValidSession } from '@/lib/api/middleware'
+import { apiBadRequest, apiError, apiSuccess } from '@/lib/api/helpers'
+import { logger } from '@/lib/logger'
+import { getEmailProvider, EMAIL_CONFIG, LISTMONK_CONFIG } from '@/config/email'
+import {
+  testEmailConfig,
+  testListmonkConnection,
+  sendCustomEmail,
+} from '@/lib/email'
+import { ORG } from '@/config/org'
+
+/**
+ * Admin email diagnostics — determine WHY mail may not be arriving without
+ * exposing secrets. Reports the active provider, which config is present
+ * (booleans, never the passwords), and a live connection test. POST sends a
+ * real test email so an admin can confirm end-to-end delivery.
+ * Super-admin gated via withAdmin('settings').
+ */
+export const GET = withAdmin('settings', async () => {
+  try {
+    const provider = getEmailProvider()
+    const connectionTest =
+      provider === 'listmonk' ? await testListmonkConnection() : await testEmailConfig()
+
+    return apiSuccess({
+      provider,
+      connectionTest,
+      smtp: {
+        host: EMAIL_CONFIG.HOST,
+        port: EMAIL_CONFIG.PORT,
+        secure: EMAIL_CONFIG.SECURE,
+        from: EMAIL_CONFIG.FROM,
+        userSet: Boolean(EMAIL_CONFIG.USER),
+        passSet: Boolean(EMAIL_CONFIG.PASS),
+      },
+      listmonk: {
+        enabled: LISTMONK_CONFIG.ENABLED,
+        url: LISTMONK_CONFIG.URL,
+        fromEmail: LISTMONK_CONFIG.FROM_EMAIL,
+        userSet: Boolean(LISTMONK_CONFIG.USERNAME),
+        passSet: Boolean(LISTMONK_CONFIG.PASSWORD),
+      },
+    })
+  } catch (error) {
+    logger.error('Email diagnostics failed', { error })
+    return apiError(error, 'Diagnose fehlgeschlagen')
+  }
+})
+
+const TestSchema = z.object({ to: z.string().email('Ungültige E-Mail-Adresse') })
+
+export const POST = withAdmin('settings', async (request: NextRequest, session: ValidSession) => {
+  try {
+    const parsed = TestSchema.safeParse(await request.json())
+    if (!parsed.success) {
+      return apiBadRequest('Ungültige Eingabe', parsed.error.flatten().fieldErrors)
+    }
+    const { to } = parsed.data
+    const result = await sendCustomEmail(to, {
+      subject: `${ORG.name} — E-Mail-Test`,
+      html: `<p>Dies ist eine Test-E-Mail von ${ORG.name}. Wenn du sie erhältst, funktioniert der E-Mail-Versand.</p>`,
+      text: `Dies ist eine Test-E-Mail von ${ORG.name}. Wenn du sie erhältst, funktioniert der E-Mail-Versand.`,
+    })
+    logger.info('Email test send', { to, by: session.user.id, success: result.success })
+    // result.success === true means the provider ACCEPTED the message — it does
+    // not guarantee inbox delivery (SPF/DKIM/reputation can still drop it).
+    return apiSuccess({ accepted: result.success, error: result.error ?? null, provider: getEmailProvider() })
+  } catch (error) {
+    logger.error('Email test send failed', { error })
+    return apiError(error, 'Test-E-Mail fehlgeschlagen')
+  }
+})

--- a/src/components/admin/settings/EmailDiagnostics.tsx
+++ b/src/components/admin/settings/EmailDiagnostics.tsx
@@ -1,0 +1,126 @@
+'use client'
+
+import { useEffect, useState } from 'react'
+import { CheckCircle2, XCircle, Mail, Send } from 'lucide-react'
+import { apiFetch } from '@/lib/api/client'
+import { Button } from '@/components/ui/button'
+import { Input } from '@/components/ui/input'
+
+interface Status {
+  provider: 'listmonk' | 'smtp'
+  connectionTest: { success: boolean; error?: string }
+  smtp: { host: string; port: number; secure: boolean; from: string; userSet: boolean; passSet: boolean }
+  listmonk: { enabled: boolean; url: string; fromEmail: string; userSet: boolean; passSet: boolean }
+}
+
+function Flag({ ok, label }: { ok: boolean; label: string }) {
+  return (
+    <span className="inline-flex items-center gap-1.5 text-sm">
+      {ok ? (
+        <CheckCircle2 className="h-4 w-4 text-success-600" />
+      ) : (
+        <XCircle className="h-4 w-4 text-error-500" />
+      )}
+      <span className="text-text-secondary">{label}</span>
+    </span>
+  )
+}
+
+export function EmailDiagnostics() {
+  const [status, setStatus] = useState<Status | null>(null)
+  const [loadError, setLoadError] = useState<string | null>(null)
+  const [to, setTo] = useState('')
+  const [sending, setSending] = useState(false)
+  const [testResult, setTestResult] = useState<{ accepted: boolean; error: string | null } | null>(null)
+
+  useEffect(() => {
+    apiFetch<Status>('/api/admin/email/diagnostics').then(r => {
+      if (r.success && r.data) setStatus(r.data)
+      else setLoadError(r.error || 'Konnte Status nicht laden')
+    })
+  }, [])
+
+  const sendTest = async () => {
+    setSending(true)
+    setTestResult(null)
+    const r = await apiFetch<{ accepted: boolean; error: string | null }>('/api/admin/email/diagnostics', {
+      method: 'POST',
+      body: { to },
+    })
+    setSending(false)
+    if (r.success && r.data) setTestResult(r.data)
+    else setTestResult({ accepted: false, error: r.error || 'Fehler' })
+  }
+
+  if (loadError) return <p className="text-sm text-error-600">{loadError}</p>
+  if (!status) return <p className="text-sm text-text-tertiary">Lädt…</p>
+
+  const active = status.provider === 'listmonk' ? status.listmonk : null
+
+  return (
+    <div className="space-y-6">
+      <div className="rounded-xl border border-subtle bg-surface-base p-5">
+        <div className="mb-3 flex items-center gap-2">
+          <Mail className="h-4 w-4 text-text-tertiary" />
+          <h3 className="text-sm font-semibold text-text-primary">
+            Aktiver Anbieter: <span className="uppercase">{status.provider}</span>
+          </h3>
+        </div>
+        <div className="mb-4">
+          <Flag
+            ok={status.connectionTest.success}
+            label={
+              status.connectionTest.success
+                ? 'Verbindungstest bestanden'
+                : `Verbindungstest fehlgeschlagen: ${status.connectionTest.error ?? 'unbekannt'}`
+            }
+          />
+        </div>
+
+        {status.provider === 'smtp' ? (
+          <dl className="grid gap-x-6 gap-y-2 text-sm sm:grid-cols-2">
+            <div><dt className="text-text-tertiary">Host</dt><dd className="font-mono text-text-primary">{status.smtp.host}:{status.smtp.port}</dd></div>
+            <div><dt className="text-text-tertiary">Absender</dt><dd className="font-mono text-text-primary">{status.smtp.from}</dd></div>
+            <div className="pt-1"><Flag ok={status.smtp.userSet} label="Benutzer gesetzt" /></div>
+            <div className="pt-1"><Flag ok={status.smtp.passSet} label="Passwort gesetzt" /></div>
+          </dl>
+        ) : (
+          <dl className="grid gap-x-6 gap-y-2 text-sm sm:grid-cols-2">
+            <div><dt className="text-text-tertiary">URL</dt><dd className="font-mono text-text-primary">{active?.url}</dd></div>
+            <div><dt className="text-text-tertiary">Absender</dt><dd className="font-mono text-text-primary">{active?.fromEmail}</dd></div>
+            <div className="pt-1"><Flag ok={!!active?.userSet} label="Benutzer gesetzt" /></div>
+            <div className="pt-1"><Flag ok={!!active?.passSet} label="Passwort gesetzt" /></div>
+          </dl>
+        )}
+      </div>
+
+      <div className="rounded-xl border border-subtle bg-surface-base p-5">
+        <h3 className="mb-3 text-sm font-semibold text-text-primary">Test-E-Mail senden</h3>
+        <div className="flex flex-wrap items-center gap-2">
+          <Input
+            type="email"
+            value={to}
+            onChange={e => setTo(e.target.value)}
+            placeholder="empfaenger@example.com"
+            className="w-64"
+          />
+          <Button variant="primary" size="sm" onClick={sendTest} disabled={sending || !to} className="inline-flex items-center gap-1.5">
+            <Send className="h-3.5 w-3.5" /> {sending ? 'Sendet…' : 'Senden'}
+          </Button>
+        </div>
+        {testResult && (
+          <div className="mt-3 text-sm">
+            {testResult.accepted ? (
+              <p className="text-success-700 dark:text-success-400">
+                Vom Anbieter angenommen. Hinweis: Angenommen ≠ zugestellt — prüfe den Posteingang (auch Spam).
+                Bleibt sie aus, liegt es an SPF/DKIM/Reputation der Absenderdomain.
+              </p>
+            ) : (
+              <p className="text-error-600 dark:text-error-400">Fehlgeschlagen: {testResult.error}</p>
+            )}
+          </div>
+        )}
+      </div>
+    </div>
+  )
+}


### PR DESCRIPTION
Mail 'sends' (provider accepts) but may not deliver. This super-admin tool at /admin/settings/email surfaces the truth: active provider, live connection test, which config is present (booleans only), and a test-send that distinguishes 'accepted' from 'delivered'. Needed to diagnose the prod deliverability issue. tsc + lint + full suite 531/7691 green.