### PR TITLE
fix(mobile-ux): header, checkout address reuse, feedback widget, Erfassung, admin tables

### DIFF
--- a/messages/de.json
+++ b/messages/de.json
@@ -999,7 +999,9 @@
         "city": "Ort",
         "namePlaceholder": "Max Muster",
         "streetPlaceholder": "Musterstrasse 1",
-        "cityPlaceholder": "Zürich"
+        "cityPlaceholder": "Zürich",
+        "prefilledFromProfile": "Adresse aus deinem Profil übernommen",
+        "saveToProfile": "Adresse im Profil speichern – beim nächsten Einkauf vorausgefüllt"
       },
       "payment": {
         "redirect": "Weiterleitung zur Zahlung...",

--- a/messages/en.json
+++ b/messages/en.json
@@ -993,7 +993,9 @@
         "city": "City",
         "namePlaceholder": "John Smith",
         "streetPlaceholder": "Example Street 1",
-        "cityPlaceholder": "Zurich"
+        "cityPlaceholder": "Zurich",
+        "prefilledFromProfile": "Address filled in from your profile",
+        "saveToProfile": "Save address to your profile – prefilled on your next purchase"
       },
       "payment": {
         "redirect": "Redirecting to payment...",

--- a/messages/es.json
+++ b/messages/es.json
@@ -3293,7 +3293,9 @@
         "city": "Ciudad",
         "namePlaceholder": "Juan García",
         "streetPlaceholder": "Calle Ejemplo 1",
-        "cityPlaceholder": "Zúrich"
+        "cityPlaceholder": "Zúrich",
+        "prefilledFromProfile": "Dirección tomada de tu perfil",
+        "saveToProfile": "Guardar la dirección en tu perfil – se rellenará en tu próxima compra"
       },
       "payment": {
         "redirect": "Redirigiendo al pago...",

--- a/messages/fr.json
+++ b/messages/fr.json
@@ -990,7 +990,9 @@
         "city": "Ville",
         "namePlaceholder": "Jean Dupont",
         "streetPlaceholder": "Rue Exemple 1",
-        "cityPlaceholder": "Zurich"
+        "cityPlaceholder": "Zurich",
+        "prefilledFromProfile": "Adresse reprise de votre profil",
+        "saveToProfile": "Enregistrer l'adresse dans votre profil – préremplie lors du prochain achat"
       },
       "payment": {
         "redirect": "Redirection vers le paiement...",

--- a/messages/it.json
+++ b/messages/it.json
@@ -3293,7 +3293,9 @@
         "city": "Città",
         "namePlaceholder": "Mario Rossi",
         "streetPlaceholder": "Via Esempio 1",
-        "cityPlaceholder": "Zurigo"
+        "cityPlaceholder": "Zurigo",
+        "prefilledFromProfile": "Indirizzo ripreso dal tuo profilo",
+        "saveToProfile": "Salva l'indirizzo nel profilo – precompilato al prossimo acquisto"
       },
       "payment": {
         "redirect": "Reindirizzamento al pagamento...",

--- a/messages/ja.json
+++ b/messages/ja.json
@@ -3293,7 +3293,9 @@
         "city": "市区町村",
         "namePlaceholder": "山田 太郎",
         "streetPlaceholder": "例通り1番地",
-        "cityPlaceholder": "チューリッヒ"
+        "cityPlaceholder": "チューリッヒ",
+        "prefilledFromProfile": "プロフィールの住所を自動入力しました",
+        "saveToProfile": "住所をプロフィールに保存する（次回の購入時に自動入力されます）"
       },
       "payment": {
         "redirect": "支払いページに移動中...",

--- a/messages/ko.json
+++ b/messages/ko.json
@@ -3293,7 +3293,9 @@
         "city": "도시",
         "namePlaceholder": "홍 길동",
         "streetPlaceholder": "예시길 1",
-        "cityPlaceholder": "취리히"
+        "cityPlaceholder": "취리히",
+        "prefilledFromProfile": "프로필의 주소를 자동으로 입력했습니다",
+        "saveToProfile": "주소를 프로필에 저장 – 다음 구매 시 자동 입력됩니다"
       },
       "payment": {
         "redirect": "결제 페이지로 이동 중...",

--- a/messages/ru.json
+++ b/messages/ru.json
@@ -1006,7 +1006,9 @@
         "city": "Город",
         "namePlaceholder": "Иван Иванов",
         "streetPlaceholder": "Musterstrasse 1",
-        "cityPlaceholder": "Цюрих"
+        "cityPlaceholder": "Цюрих",
+        "prefilledFromProfile": "Адрес взят из вашего профиля",
+        "saveToProfile": "Сохранить адрес в профиле – будет заполнен при следующей покупке"
       },
       "payment": {
         "redirect": "Переход к оплате...",

--- a/src/app/[locale]/about/press/content.tsx
+++ b/src/app/[locale]/about/press/content.tsx
@@ -137,25 +137,27 @@ export default function PressPageContent() {
       {/* Stats Bar */}
       <section className="py-12 bg-surface-raised">
         <div className="max-w-7xl mx-auto px-4 sm:px-6">
+          {/* Each stat deep-links to the section it counts — numbers are
+              computed from MEDIA_COVERAGE (getMediaStats), never hardcoded. */}
           <div className="flex flex-wrap justify-center gap-8 sm:gap-16">
-            <div className="text-center">
-              <p className="text-3xl sm:text-4xl font-bold text-action">{stats.totalMentions}</p>
-              <p className="text-sm text-text-tertiary mt-1">{t('stats.mediaMentions')}</p>
-            </div>
-            <div className="text-center">
-              <p className="text-3xl sm:text-4xl font-bold text-action">{stats.uniqueSources}</p>
-              <p className="text-sm text-text-tertiary mt-1">{t('stats.uniqueSources')}</p>
-            </div>
-            <div className="text-center">
-              <p className="text-3xl sm:text-4xl font-bold text-action">{stats.partnerships}</p>
-              <p className="text-sm text-text-tertiary mt-1">{t('stats.partnerships')}</p>
-            </div>
+            <a href="#medienbeitraege" className="group text-center">
+              <p className="text-3xl sm:text-4xl font-bold text-action group-hover:underline">{stats.totalMentions}</p>
+              <p className="text-sm text-text-tertiary group-hover:text-text-secondary mt-1">{t('stats.mediaMentions')}</p>
+            </a>
+            <a href="#quellen" className="group text-center">
+              <p className="text-3xl sm:text-4xl font-bold text-action group-hover:underline">{stats.uniqueSources}</p>
+              <p className="text-sm text-text-tertiary group-hover:text-text-secondary mt-1">{t('stats.uniqueSources')}</p>
+            </a>
+            <a href="#partnerschaften" className="group text-center">
+              <p className="text-3xl sm:text-4xl font-bold text-action group-hover:underline">{stats.partnerships}</p>
+              <p className="text-sm text-text-tertiary group-hover:text-text-secondary mt-1">{t('stats.partnerships')}</p>
+            </a>
           </div>
         </div>
       </section>
 
       {/* National Media Highlight */}
-      <section className="py-16 bg-surface-base">
+      <section id="quellen" className="scroll-mt-24 py-16 bg-surface-base">
         <div className="max-w-7xl mx-auto px-4 sm:px-6">
           <div className="flex items-center justify-center gap-2 mb-8">
             <Star className="h-5 w-5 text-warning-500" />
@@ -163,7 +165,7 @@ export default function PressPageContent() {
             <Star className="h-5 w-5 text-warning-500" />
           </div>
 
-          <div className="grid sm:grid-cols-2 lg:grid-cols-4 gap-4 max-w-4xl mx-auto mb-12">
+          <div className="grid grid-cols-1 sm:grid-cols-2 lg:grid-cols-4 gap-4 max-w-4xl mx-auto mb-12">
             {tier1Sources.map((mention) => (
               <FeaturedSourceBadge key={mention.id} mention={mention} />
             ))}
@@ -172,13 +174,13 @@ export default function PressPageContent() {
       </section>
 
       {/* Featured Articles */}
-      <section className="py-16 bg-surface-raised">
+      <section id="medienbeitraege" className="scroll-mt-24 py-16 bg-surface-raised">
         <div className="max-w-7xl mx-auto px-4 sm:px-6">
           <Heading level={2} className="text-text-primary mb-8 text-center">
             {t('featuredArticles')}
           </Heading>
 
-          <div className="grid md:grid-cols-2 lg:grid-cols-3 gap-6">
+          <div className="grid grid-cols-1 md:grid-cols-2 lg:grid-cols-3 gap-6">
             {featuredMedia.map((mention) => (
               <MediaCard key={mention.id} mention={mention} readArticleLabel={t('readArticle')} />
             ))}
@@ -187,14 +189,18 @@ export default function PressPageContent() {
       </section>
 
       {/* Other Mentions */}
-      <section className="py-16 bg-surface-base">
+      <section id="partnerschaften" className="scroll-mt-24 py-16 bg-surface-base">
         <div className="max-w-7xl mx-auto px-4 sm:px-6">
           <Heading level={2} className="text-text-primary mb-8 text-center">
             {t('otherMentions')}
           </Heading>
 
           <div className="bg-surface-raised rounded-2xl border p-8">
-            <div className="grid sm:grid-cols-2 lg:grid-cols-3 gap-4">
+            {/* grid-cols-1 is load-bearing: without an explicit minmax(0,1fr)
+                base track, the nowrap `truncate` titles blow the implicit
+                auto column out past the viewport and the whole page scrolls
+                horizontally on phones. */}
+            <div className="grid grid-cols-1 sm:grid-cols-2 lg:grid-cols-3 gap-4">
               {otherMedia.map((mention) => (
                 <a
                   key={mention.id}

--- a/src/app/[locale]/marketplace/cart/CartPageClient.tsx
+++ b/src/app/[locale]/marketplace/cart/CartPageClient.tsx
@@ -6,12 +6,13 @@ import { useTranslations } from 'next-intl'
 import { Trash2, ShoppingCart, Loader2, MapPin, ArrowLeft, ShieldCheck, LockKeyhole, Store, Truck } from 'lucide-react'
 import { toast } from 'sonner'
 import { Button } from '@/components/ui/button'
-import { Input } from '@/components/ui/input'
 import { Link, useRouter } from '@/i18n/navigation'
 import Heading from '@/components/ui/Heading'
 import { ListingImage } from '@/components/marketplace/ListingImage'
 import { PaymentReturnBanner } from '@/components/payments/PaymentReturnBanner'
+import { ShippingAddressFields } from '@/components/marketplace/checkout/ShippingAddressFields'
 import { useCart } from '@/components/marketplace/cart/CartProvider'
+import { useShippingAddress } from '@/hooks/useShippingAddress'
 import { apiFetch } from '@/lib/api/client'
 import { formatCHF, REVAMPIT_LISTING_DELIVERY } from '@/config/marketplace'
 import { LOCATIONS, OPENING_HOURS } from '@/config/org'
@@ -25,25 +26,25 @@ export function CartPageClient() {
   const [checkingOut, setCheckingOut] = useState(false)
   const [reviewing, setReviewing] = useState(false)
   const [deliveryMethod, setDeliveryMethod] = useState<'pickup' | 'shipping'>('pickup')
-  const [shippingAddress, setShippingAddress] = useState({
-    name: '',
-    street: '',
-    postal_code: '',
-    city: '',
-    country: 'CH',
-  })
+  // Shared address state — prefilled from the buyer's saved profile address
+  // and optionally written back on order creation (see useShippingAddress).
+  const {
+    shippingAddress,
+    setShippingAddress,
+    prefilled: addressPrefilled,
+    postalCodeValid,
+    addressComplete,
+    canOfferSave,
+    saveToProfile,
+    setSaveToProfile,
+    persistAddressIfRequested,
+  } = useShippingAddress()
 
   const shippingCost = deliveryMethod === 'shipping' && REVAMPIT_LISTING_DELIVERY.shippingCostChf
     ? Number(REVAMPIT_LISTING_DELIVERY.shippingCostChf)
     : 0
   const orderTotal = total + shippingCost
-  const postalCodeValid = /^\d{4}$/.test(shippingAddress.postal_code)
-  const shippingFormValid = deliveryMethod !== 'shipping' || (
-    shippingAddress.name.trim() !== '' &&
-    shippingAddress.street.trim() !== '' &&
-    shippingAddress.city.trim() !== '' &&
-    postalCodeValid
-  )
+  const shippingFormValid = deliveryMethod !== 'shipping' || addressComplete
 
   if (!hydrated) {
     return (
@@ -64,6 +65,9 @@ export function CartPageClient() {
       return
     }
     setCheckingOut(true)
+    if (deliveryMethod === 'shipping') {
+      await persistAddressIfRequested()
+    }
     const res = await apiFetch<{ orderId: string; paymentUrl: string }>('/api/marketplace/cart/checkout', {
       method: 'POST',
       body: {
@@ -198,45 +202,16 @@ export function CartPageClient() {
                 </div>
 
                 {deliveryMethod === 'shipping' && (
-                  <div className="mt-5 grid gap-4 sm:grid-cols-2">
-                    <div className="sm:col-span-2">
-                      <label className="mb-1 block text-sm font-medium text-text-secondary">{tCheckout('address.name')}</label>
-                      <Input
-                        value={shippingAddress.name}
-                        onChange={(e) => setShippingAddress(prev => ({ ...prev, name: e.target.value }))}
-                        autoComplete="name"
-                        placeholder={tCheckout('address.namePlaceholder')}
-                      />
-                    </div>
-                    <div className="sm:col-span-2">
-                      <label className="mb-1 block text-sm font-medium text-text-secondary">{tCheckout('address.street')}</label>
-                      <Input
-                        value={shippingAddress.street}
-                        onChange={(e) => setShippingAddress(prev => ({ ...prev, street: e.target.value }))}
-                        autoComplete="street-address"
-                        placeholder={tCheckout('address.streetPlaceholder')}
-                      />
-                    </div>
-                    <div>
-                      <label className="mb-1 block text-sm font-medium text-text-secondary">{tCheckout('address.postalCode')}</label>
-                      <Input
-                        value={shippingAddress.postal_code}
-                        onChange={(e) => setShippingAddress(prev => ({ ...prev, postal_code: e.target.value.replace(/\D/g, '').slice(0, 4) }))}
-                        inputMode="numeric"
-                        autoComplete="postal-code"
-                        placeholder="8000"
-                        className={shippingAddress.postal_code && !postalCodeValid ? 'border-error-500' : ''}
-                      />
-                    </div>
-                    <div>
-                      <label className="mb-1 block text-sm font-medium text-text-secondary">{tCheckout('address.city')}</label>
-                      <Input
-                        value={shippingAddress.city}
-                        onChange={(e) => setShippingAddress(prev => ({ ...prev, city: e.target.value }))}
-                        autoComplete="address-level2"
-                        placeholder={tCheckout('address.cityPlaceholder')}
-                      />
-                    </div>
+                  <div className="mt-5">
+                    <ShippingAddressFields
+                      address={shippingAddress}
+                      onChange={setShippingAddress}
+                      postalCodeValid={postalCodeValid}
+                      prefilled={addressPrefilled}
+                      canOfferSave={canOfferSave}
+                      saveToProfile={saveToProfile}
+                      onSaveToggle={setSaveToProfile}
+                    />
                   </div>
                 )}
               </section>

--- a/src/app/[locale]/marketplace/checkout/[listingId]/CheckoutPageClient.tsx
+++ b/src/app/[locale]/marketplace/checkout/[listingId]/CheckoutPageClient.tsx
@@ -12,7 +12,7 @@ import {
 } from 'lucide-react'
 import { ListingImage } from '@/components/marketplace/ListingImage'
 import Heading from '@/components/ui/Heading'
-import { Input } from '@/components/ui/input'
+import { ShippingAddressFields } from '@/components/marketplace/checkout/ShippingAddressFields'
 import { formatCHF, COMMISSION_RATE } from '@/config/marketplace'
 import { useTranslations } from 'next-intl'
 import { useCheckout, type ListingForCheckout } from '@/hooks/useCheckout'
@@ -42,6 +42,10 @@ export function CheckoutPageClient({
     canSelectDelivery,
     postalCodeValid,
     shippingFormValid,
+    addressPrefilled,
+    canOfferSave,
+    saveToProfile,
+    setSaveToProfile,
     setDeliveryMethod,
     setShippingAddress,
     handleCreateOrder,
@@ -148,57 +152,15 @@ export function CheckoutPageClient({
           {deliveryMethod === 'shipping' && (
             <div className="card-shell p-6">
               <Heading level={2} className="text-lg text-text-primary mb-4">{t('address.title')}</Heading>
-              <div className="space-y-4">
-                <div>
-                  <label className="block text-sm font-medium text-text-secondary mb-1">{t('address.name')}</label>
-                  <Input
-                    type="text"
-                    autoComplete="name"
-                    value={shippingAddress.name}
-                    onChange={(e) => setShippingAddress(prev => ({ ...prev, name: e.target.value }))}
-                    placeholder={t('address.namePlaceholder')}
-                  />
-                </div>
-                <div>
-                  <label className="block text-sm font-medium text-text-secondary mb-1">{t('address.street')}</label>
-                  <Input
-                    type="text"
-                    autoComplete="street-address"
-                    value={shippingAddress.street}
-                    onChange={(e) => setShippingAddress(prev => ({ ...prev, street: e.target.value }))}
-                    placeholder={t('address.streetPlaceholder')}
-                  />
-                </div>
-                <div className="grid grid-cols-1 gap-4 sm:grid-cols-3">
-                  <div>
-                    <label className="block text-sm font-medium text-text-secondary mb-1">{t('address.postalCode')}</label>
-                    <Input
-                      type="text"
-                      inputMode="numeric"
-                      autoComplete="postal-code"
-                      pattern="[0-9]{4}"
-                      value={shippingAddress.postal_code}
-                      onChange={(e) => setShippingAddress(prev => ({ ...prev, postal_code: e.target.value }))}
-                      maxLength={4}
-                      className={shippingAddress.postal_code && !postalCodeValid ? 'border-error-500' : ''}
-                      placeholder="8000"
-                    />
-                    {shippingAddress.postal_code && !postalCodeValid && (
-                      <p className="text-xs text-error-500 mt-1">{t('address.postalCodeError')}</p>
-                    )}
-                  </div>
-                  <div className="sm:col-span-2">
-                    <label className="block text-sm font-medium text-text-secondary mb-1">{t('address.city')}</label>
-                    <Input
-                      type="text"
-                      autoComplete="address-level2"
-                      value={shippingAddress.city}
-                      onChange={(e) => setShippingAddress(prev => ({ ...prev, city: e.target.value }))}
-                      placeholder={t('address.cityPlaceholder')}
-                    />
-                  </div>
-                </div>
-              </div>
+              <ShippingAddressFields
+                address={shippingAddress}
+                onChange={setShippingAddress}
+                postalCodeValid={postalCodeValid}
+                prefilled={addressPrefilled}
+                canOfferSave={canOfferSave}
+                saveToProfile={saveToProfile}
+                onSaveToggle={setSaveToProfile}
+              />
             </div>
           )}
 

--- a/src/app/admin/appointments/page.tsx
+++ b/src/app/admin/appointments/page.tsx
@@ -16,6 +16,7 @@ import { ADMIN_CONTENT } from '@/config/admin-content'
 import {
   BOOKING_STATUS,
   BOOKING_STATUS_BADGES,
+  CANONICAL_BOOKING_STATUSES,
   getBookingStatusBadge,
   getUrgencyBadge,
 } from '@/config/booking-status'
@@ -32,7 +33,10 @@ export const metadata: Metadata = {
 
 const FILTER_OPTIONS: { value: string; label: string }[] = [
   { value: '', label: 'Alle' },
-  ...Object.entries(BOOKING_STATUS_BADGES).map(([value, { label }]) => ({ value, label })),
+  ...CANONICAL_BOOKING_STATUSES.map((value) => ({
+    value,
+    label: BOOKING_STATUS_BADGES[value].label,
+  })),
 ]
 
 interface PageProps {

--- a/src/app/admin/erfassung/page.tsx
+++ b/src/app/admin/erfassung/page.tsx
@@ -177,7 +177,9 @@ function ErfassungContent() {
   const isBulkSaving = bulkProducts.some(p => p._status === 'processing')
 
   return (
-    <div className="space-y-4 sm:space-y-6 max-w-5xl mx-auto pb-24 sm:pb-6">
+    // pb-44 clears the fixed mobile submit bar (~84px) stacked above the
+    // admin bottom nav (56px + safe area).
+    <div className="space-y-4 sm:space-y-6 max-w-5xl mx-auto pb-44 sm:pb-6">
       {/* Pipeline progress — shown when entering from Geräte-Eingang */}
       {isIntakePipeline && (
         <div className="bg-surface-base border border-default rounded-lg px-4 py-3">

--- a/src/app/admin/it-hilfe/ITHilfeAdminClient.tsx
+++ b/src/app/admin/it-hilfe/ITHilfeAdminClient.tsx
@@ -47,8 +47,9 @@ export default function ITHilfeAdminClient() {
       {/* Hero status — single clear next action per state */}
       {stats && <HeroStatus stats={stats} onJumpToRequests={() => switchTab('requests')} t={t} />}
 
-      {/* Tab Navigation + per-tab primary CTA */}
-      <div className="flex items-center justify-between gap-4 border-b border">
+      {/* Tab Navigation + per-tab primary CTA. flex-wrap: on phones the CTA
+          drops onto its own line instead of overlapping the tabs. */}
+      <div className="flex flex-wrap items-center justify-between gap-x-4 gap-y-2 border-b border">
         <div className="flex gap-1">
           {TABS.map(tabDef => (
             <Button

--- a/src/app/admin/workshops/page.tsx
+++ b/src/app/admin/workshops/page.tsx
@@ -277,15 +277,34 @@ export default function AdminWorkshopsPage() {
             <div className="px-6 py-12 text-center">
               <GraduationCap className="w-12 h-12 text-text-muted mx-auto mb-4" />
               <Heading level={3} className="text-lg font-medium text-text-primary mb-2">
-                Keine Workshop-Vorschläge gefunden
+                {filters.status === PROPOSAL_STATUS.PENDING && !searchTerm.trim()
+                  ? 'Alles erledigt'
+                  : 'Keine Workshop-Vorschläge gefunden'}
               </Heading>
-              <p className="text-text-secondary mb-4">
+              <p className="text-text-secondary mb-6">
                 {searchTerm.trim()
                   ? STRINGS.EMPTY_SEARCH(searchTerm)
                   : filters.status === PROPOSAL_STATUS.PENDING
                   ? STRINGS.EMPTY_PENDING
                   : STRINGS.EMPTY_STATUS(filters.status)}
               </p>
+              {/* Never a dead end: offer the two next actions that make
+                  sense from here instead of a blank wall. */}
+              <div className="flex flex-wrap justify-center gap-3">
+                {filters.status !== 'all' && !searchTerm.trim() && (
+                  <Button
+                    variant="outline"
+                    size="sm"
+                    onClick={() => setFilters(prev => ({ ...prev, status: 'all' }))}
+                  >
+                    Alle Vorschläge anzeigen
+                  </Button>
+                )}
+                <Button as={Link} href={ROUTES.admin.workshopsInstances} variant="primary" size="sm">
+                  <Calendar className="w-4 h-4 mr-2" />
+                  Termine verwalten
+                </Button>
+              </div>
             </div>
           )}
         </div>

--- a/src/app/api/admin/erfassung/route.ts
+++ b/src/app/api/admin/erfassung/route.ts
@@ -88,6 +88,9 @@ export const POST = withAdmin('products', async (request, session) => {
 
   } catch (error) {
     logger.error('Erfassung failed', { error })
-    return apiError(error, 'Fehler beim Erfassen des Produkts')
+    // Staff-only endpoint: include the underlying cause so the team can act
+    // on failures directly instead of guessing from a blanket message.
+    const detail = error instanceof Error && error.message ? ` – ${error.message}` : ''
+    return apiError(error, `Fehler beim Erfassen des Produkts${detail}`)
   }
 })

--- a/src/app/dashboard/profile/components/PersonalInfoSection.tsx
+++ b/src/app/dashboard/profile/components/PersonalInfoSection.tsx
@@ -1,6 +1,6 @@
 'use client'
 
-import { User, Building2 } from 'lucide-react'
+import { User, Building2, MapPin } from 'lucide-react'
 import { useTranslations } from 'next-intl'
 import Heading from '@/components/ui/Heading'
 import { Input } from '@/components/ui/input'
@@ -64,6 +64,62 @@ export function PersonalInfoSection({ profile, handleChange }: PersonalInfoSecti
               onChange={(e) => handleChange('company_name', e.target.value)}
               className="pl-11"
               placeholder="Firma AG"
+            />
+          </div>
+        </div>
+      </div>
+
+      {/* Address — the saved address prefills the marketplace checkout, so
+          buyers only ever type it once. */}
+      <div className="mt-8 border-t border-subtle pt-6">
+        <div className="mb-4 flex items-center gap-3">
+          <div className="flex h-10 w-10 items-center justify-center rounded-lg bg-surface-raised">
+            <MapPin className="h-5 w-5 text-text-secondary" />
+          </div>
+          <div>
+            <Heading level={3} className="text-base font-semibold text-text-primary">
+              {tAddr('heading')}
+            </Heading>
+            <p className="text-sm text-text-tertiary">{tAddr('subtitle')}</p>
+          </div>
+        </div>
+        <div className="grid grid-cols-1 md:grid-cols-3 gap-4">
+          <div className="md:col-span-3">
+            <label className="block text-sm font-medium text-text-secondary mb-1">
+              {tAddr('streetLabel')}
+            </label>
+            <Input
+              type="text"
+              autoComplete="street-address"
+              value={profile.address_line1}
+              onChange={(e) => handleChange('address_line1', e.target.value)}
+              placeholder={tAddr('streetPlaceholder')}
+            />
+          </div>
+          <div>
+            <label className="block text-sm font-medium text-text-secondary mb-1">
+              {tAddr('plzLabel')}
+            </label>
+            <Input
+              type="text"
+              inputMode="numeric"
+              autoComplete="postal-code"
+              maxLength={4}
+              value={profile.postal_code}
+              onChange={(e) => handleChange('postal_code', e.target.value.replace(/\D/g, '').slice(0, 4))}
+              placeholder="8000"
+            />
+          </div>
+          <div className="md:col-span-2">
+            <label className="block text-sm font-medium text-text-secondary mb-1">
+              {tAddr('cityLabel')}
+            </label>
+            <Input
+              type="text"
+              autoComplete="address-level2"
+              value={profile.city}
+              onChange={(e) => handleChange('city', e.target.value)}
+              placeholder={tAddr('cityPlaceholder')}
             />
           </div>
         </div>

--- a/src/app/globals.css
+++ b/src/app/globals.css
@@ -211,6 +211,21 @@
   min-width: 44px;
 }
 
+@utility safe-area-inset-bottom {
+  /* iOS/Android gesture-bar clearance for fixed bottom bars. */
+  padding-bottom: env(safe-area-inset-bottom, 0px);
+}
+
+@utility scrollbar-hide {
+  /* Hide the scrollbar of horizontal chip/tab rows (content still scrolls).
+     Used by AboutSubNav and other edge-bleed scroll rows. */
+  scrollbar-width: none;
+  -ms-overflow-style: none;
+  &::-webkit-scrollbar {
+    display: none;
+  }
+}
+
 @utility grid-cols-responsive {
   grid-template-columns: repeat(auto-fit, minmax(200px, 1fr));
 }

--- a/src/components/admin/AdminTable.tsx
+++ b/src/components/admin/AdminTable.tsx
@@ -12,6 +12,11 @@ import { adminTable, adminSurface, adminInteractive } from '@/lib/admin-ui'
  * structure once; callers supply columns (render-prop cells for full freedom:
  * links, badges, action selects) + a stable row key.
  *
+ * Below md each row renders as a stacked card instead of a table row — a
+ * seven-column table on a phone was a blind horizontal scroll. The first
+ * column is treated as the row's identity (card title); the rest render as
+ * label/value lines.
+ *
  * Pure render (no hooks) → usable from both Server and Client components.
  */
 export interface AdminTableColumn<T> {
@@ -39,9 +44,34 @@ const alignClass = (align?: 'left' | 'right' | 'center') =>
   align === 'right' ? 'text-right' : align === 'center' ? 'text-center' : ''
 
 export function AdminTable<T>({ columns, rows, rowKey, isSelected, className }: AdminTableProps<T>) {
+  const [identityColumn, ...detailColumns] = columns
+
   return (
     <div className={cn(adminSurface.table, className)}>
-      <div className="overflow-x-auto">
+      {/* Phones/small tablets: stacked cards, no horizontal scrolling. */}
+      <ul className="divide-y divide-subtle md:hidden">
+        {rows.map((row) => (
+          <li
+            key={rowKey(row)}
+            className={cn('space-y-2 p-4', isSelected?.(row) && adminInteractive.rowSelected)}
+          >
+            <div className="text-sm font-medium text-text-primary">
+              {identityColumn.cell(row)}
+            </div>
+            <dl className="space-y-1.5">
+              {detailColumns.map((col, i) => (
+                <div key={i} className="flex items-start justify-between gap-3 text-sm">
+                  <dt className="shrink-0 text-text-tertiary">{col.header}</dt>
+                  <dd className="min-w-0 text-right text-text-secondary">{col.cell(row)}</dd>
+                </div>
+              ))}
+            </dl>
+          </li>
+        ))}
+      </ul>
+
+      {/* md and up: the classic table. */}
+      <div className="hidden overflow-x-auto md:block">
         <table className="w-full text-sm">
           <thead className={adminTable.thead}>
             <tr>

--- a/src/components/admin/MobileBottomNav.tsx
+++ b/src/components/admin/MobileBottomNav.tsx
@@ -27,7 +27,7 @@ export function MobileBottomNav({ accessibleSections, onMenuClick }: MobileBotto
 
   return (
     <nav
-      className="fixed bottom-0 left-0 right-0 z-50 flex border-t border bg-surface-base lg:hidden"
+      className="fixed bottom-0 left-0 right-0 z-50 flex border-t border bg-surface-base safe-area-inset-bottom lg:hidden"
       aria-label={t('navAria')}
     >
       {items.map(section => {

--- a/src/components/admin/NotificationBell.tsx
+++ b/src/components/admin/NotificationBell.tsx
@@ -52,6 +52,10 @@ export function NotificationBell() {
   const [loading, setLoading] = useState(false)
   const [error, setError] = useState<string | null>(null)
   const [markingAll, setMarkingAll] = useState(false)
+  // How far (px) the panel must shift right of the bell so it stays inside
+  // the viewport. The bell sits mid-cluster in both headers, so a plain
+  // `right-0` panel runs off the left edge of narrow phone screens.
+  const [panelShift, setPanelShift] = useState(0)
   const panelRef = useRef<HTMLDivElement>(null)
   const router = useRouter()
 
@@ -96,6 +100,15 @@ export function NotificationBell() {
   }, [open])
 
   const handleOpen = () => {
+    if (!open && panelRef.current) {
+      const rect = panelRef.current.getBoundingClientRect()
+      const margin = 8
+      const width = Math.min(320, window.innerWidth - 2 * margin)
+      const overhang = margin - (rect.right - width)
+      setPanelShift(overhang > 0
+        ? Math.min(overhang, window.innerWidth - margin - rect.right)
+        : 0)
+    }
     setOpen(o => !o)
     if (!open) void fetchNotifications()
   }
@@ -149,7 +162,10 @@ export function NotificationBell() {
       </Button>
 
       {open && (
-        <div className="absolute right-0 top-full z-50 mt-2 w-80 overflow-hidden rounded-xl border border bg-surface-base shadow-xs">
+        <div
+          className="absolute top-full z-50 mt-2 w-80 max-w-[calc(100vw-1rem)] overflow-hidden rounded-xl border border bg-surface-base shadow-xs"
+          style={{ right: -panelShift }}
+        >
           {/* Header */}
           <div className="flex items-center justify-between border-b border-subtle px-4 py-3 dark:border-white/6">
             <span className="font-semibold text-sm text-text-primary">

--- a/src/components/auth/UserMenu.tsx
+++ b/src/components/auth/UserMenu.tsx
@@ -136,11 +136,12 @@ export function UserMenu() {
         variant="ghost"
         onClick={() => setIsOpen(!isOpen)}
         className={cn(
-          "flex items-center gap-2 p-1.5 rounded-full h-auto",
-          "ring-2 ring-primary-100 dark:ring-action/20",
+          // No always-on ring halo — on phones the pale ring read as a large
+          // green blob next to the compact icon buttons. Feedback on hover/open.
+          "flex items-center gap-2 p-1 rounded-full h-auto",
           isOpen
-            ? "bg-action-muted/10 ring-action/20 dark:ring-action/30"
-            : "hover:bg-action-muted/10 hover:ring-action/20 dark:hover:ring-action/30"
+            ? "bg-action-muted/10 ring-2 ring-action/20 dark:ring-action/30"
+            : "hover:bg-action-muted/10 hover:ring-2 hover:ring-action/20 dark:hover:ring-action/30"
         )}
         aria-expanded={isOpen}
         aria-haspopup="true"
@@ -172,7 +173,7 @@ export function UserMenu() {
       {/* Dropdown Menu */}
       <div
         className={cn(
-          "absolute right-0 mt-2 w-72",
+          "absolute right-0 mt-2 w-72 max-w-[calc(100vw-1rem)]",
           "transition-all duration-200 ease-out origin-top-right",
           isOpen 
             ? "opacity-100 scale-100 pointer-events-auto" 

--- a/src/components/erfassung/BulkActionBar.tsx
+++ b/src/components/erfassung/BulkActionBar.tsx
@@ -31,8 +31,10 @@ export function BulkActionBar({
 }: BulkActionBarProps) {
   const t = useTranslations('components.erfassung.bulkActionBar')
 
+  // Below lg the admin bottom nav (h-14, fixed bottom-0) is visible —
+  // offset above it so the bulk actions are never covered.
   return (
-    <div className="fixed bottom-0 left-0 right-0 bg-surface-base border-t border px-4 py-3 z-30 safe-area-inset-bottom shadow-xs">
+    <div className="fixed bottom-[calc(3.5rem+env(safe-area-inset-bottom))] lg:bottom-0 left-0 right-0 bg-surface-base border-t border px-4 py-3 z-40 lg:safe-area-inset-bottom shadow-xs">
       <div className="max-w-5xl mx-auto flex items-center justify-between gap-4">
         {/* Left: selection info */}
         <div className="flex items-center gap-3">

--- a/src/components/erfassung/ErfassungSubmitBar.tsx
+++ b/src/components/erfassung/ErfassungSubmitBar.tsx
@@ -81,8 +81,11 @@ export function ErfassungSubmitBar({ isEditMode, isLoading, onSubmit }: Props) {
         </div>
       </div>
 
-      {/* Mobile Sticky Bottom Bar */}
-      <div className="sm:hidden fixed bottom-0 left-0 right-0 bg-surface-base border-t border p-4 z-50 safe-area-inset-bottom">
+      {/* Mobile Sticky Bottom Bar — sits ABOVE the admin bottom nav (h-14 +
+          safe area), which is also fixed at bottom-0 with the same z-index;
+          anchored at 0 the two bars stacked on top of each other and the
+          submit buttons were half-covered. */}
+      <div className="sm:hidden fixed bottom-[calc(3.5rem+env(safe-area-inset-bottom))] left-0 right-0 bg-surface-base border-t border p-4 z-40">
         {isEditMode ? (
           <Button
             type="button"

--- a/src/components/feedback/FeedbackScopeSelector.tsx
+++ b/src/components/feedback/FeedbackScopeSelector.tsx
@@ -47,7 +47,7 @@ export function FeedbackScopeSelector({
                 }
               }}
               className={cn(
-                "w-full px-3 py-2.5 text-xs rounded-lg border-2 transition-all duration-200",
+                "w-full h-auto whitespace-normal px-3 py-2.5 text-xs rounded-lg border-2 transition-all duration-200",
                 isActive
                   ? `${config.bgColor} ${config.borderColor} ${config.textColor} transform scale-[1.02]`
                   : "bg-surface-base border text-text-secondary hover:bg-surface-raised hover:border-strong"

--- a/src/components/feedback/QuickSuggestions.tsx
+++ b/src/components/feedback/QuickSuggestions.tsx
@@ -20,7 +20,9 @@ export function QuickSuggestions({ feedbackScope, selectedElements, onSuggestion
       <label className="block text-xs font-medium text-text-secondary">
         Schnellvorschläge
       </label>
-      <div className="grid grid-cols-2 gap-1">
+      {/* Wrapping pills — a fixed 2-column grid clipped/overlapped the long
+          German labels on narrow screens; pills size to their text instead. */}
+      <div className="flex flex-wrap gap-1.5">
         {suggestions.map((suggestion, index) => (
           <Button
             key={index}
@@ -29,7 +31,7 @@ export function QuickSuggestions({ feedbackScope, selectedElements, onSuggestion
             size="sm"
             onClick={() => onSuggestionClick(suggestion)}
             className={cn(
-              "px-2 py-1 text-xs rounded border transition-colors text-left",
+              "h-auto whitespace-normal px-2.5 py-1.5 text-xs rounded-full border transition-colors text-left",
               `${config.hoverBg} ${config.borderColor} hover:${config.textColor}`
             )}
             disabled={feedbackScope === 'element' && selectedElements.length === 0 && suggestion !== "Element auswählen"}

--- a/src/components/feedback/SuggestionButton.tsx
+++ b/src/components/feedback/SuggestionButton.tsx
@@ -162,11 +162,10 @@ export default function SuggestionButton() {
           </div>
         )}
 
-        {/* Side Panel */}
-        <div
-          className="fixed z-[70] sm:right-4 sm:top-20 bottom-4 left-1/2 -translate-x-1/2 sm:left-auto sm:translate-x-0 sm:bottom-auto"
-          style={{ maxHeight: 'calc(100vh - 5rem)' }}
-        >
+        {/* Panel — bottom sheet on phones, side panel from sm up. The former
+            centered-translate wrapper had no width of its own, so the panel's
+            percentage width collapsed into a broken narrow column on mobile. */}
+        <div className="fixed z-[70] inset-x-0 bottom-0 sm:inset-x-auto sm:bottom-auto sm:right-4 sm:top-20">
           <div
             ref={panelRef}
             role="dialog"
@@ -174,8 +173,10 @@ export default function SuggestionButton() {
             aria-labelledby="suggestion-panel-title"
             data-suggestion-panel
             className={cn(
-              "card-shell rounded-2xl sm:rounded-l-2xl overflow-hidden flex flex-col max-h-[calc(100vh-8rem)] sm:max-h-[70vh] h-auto",
-              "w-[calc(100%-2rem)] max-w-sm sm:w-80 md:w-96",
+              "card-shell overflow-hidden flex flex-col h-auto",
+              "w-full max-h-[85dvh] rounded-t-2xl rounded-b-none",
+              "sm:w-96 sm:max-h-[70vh] sm:rounded-2xl",
+              "pb-[env(safe-area-inset-bottom)] sm:pb-0",
               isElementSelectionMode && "ring-2 ring-action ring-opacity-50 pointer-events-auto"
             )}
             style={{ pointerEvents: 'auto' }}
@@ -315,18 +316,18 @@ export default function SuggestionButton() {
               </div>
             </div>
 
-            {/* Footer */}
-            <div className="border-t border-subtle px-4 py-3 bg-surface-raised flex-shrink-0">
-            </div>
           </div>
         </div>
       </>
     )
   }
 
-  // Floating Button (collapsed state)
+  // Floating Button (collapsed state) — on phones it stacks above the Hirn
+  // FAB in the bottom-right corner so the bottom-left of the screen (and any
+  // full-width primary CTA there) stays uncovered. From sm up it sits at the
+  // right edge, vertically centered.
   return (
-    <div className="fixed z-40 left-4 bottom-4 sm:left-auto sm:bottom-auto sm:right-4 sm:top-1/2 sm:-translate-y-1/2">
+    <div className="fixed z-40 right-4 bottom-[4.5rem] sm:bottom-auto sm:top-1/2 sm:-translate-y-1/2">
       <Button
         variant="primary"
         size="icon"

--- a/src/components/hirn/HirnPublicFab.tsx
+++ b/src/components/hirn/HirnPublicFab.tsx
@@ -52,7 +52,8 @@ export function HirnPublicFab() {
     <>
       {/* Proactive suggestion chip */}
       {showChip && !isOpen && (
-        <div className="fixed bottom-20 right-4 sm:bottom-24 sm:right-6 z-40 max-w-xs">
+        // Sits above BOTH stacked FABs on phones (brain + feedback pencil).
+        <div className="fixed bottom-32 right-4 sm:bottom-24 sm:right-6 z-40 max-w-[calc(100vw-2rem)] sm:max-w-xs">
           <div className="flex items-start gap-2 bg-surface-base border border-strong rounded-xl px-3 py-2 text-sm text-text-primary">
             <Button
               type="button"
@@ -84,9 +85,9 @@ export function HirnPublicFab() {
         aria-label={t('open')}
         aria-haspopup="dialog"
         aria-expanded={isOpen}
-        className="fixed bottom-4 right-4 sm:bottom-6 sm:right-6 z-40 w-14 h-14 rounded-full shadow-xs hover:scale-105"
+        className="fixed bottom-4 right-4 sm:bottom-6 sm:right-6 z-40 w-12 h-12 sm:w-14 sm:h-14 rounded-full shadow-xs hover:scale-105"
       >
-        <Brain className="w-6 h-6 text-white" aria-hidden="true" />
+        <Brain className="w-5 h-5 sm:w-6 sm:h-6 text-white" aria-hidden="true" />
       </Button>
 
       <HirnChatPanel

--- a/src/components/layout/MobileMenu.tsx
+++ b/src/components/layout/MobileMenu.tsx
@@ -12,6 +12,7 @@ import { ORG } from '@/config/org'
 import { Button } from '@/components/ui/button'
 import { Logo } from '@/components/ui/Logo'
 import { LocaleSwitcher } from '@/components/ui/LocaleSwitcher'
+import { ThemeToggle } from '@/components/ui/ThemeToggle'
 import { useSession } from 'next-auth/react'
 import { cn } from '@/lib/utils'
 import { ROUTES } from '@/config/routes'
@@ -38,6 +39,7 @@ export function MobileMenu({
   const t = useTranslations('nav')
   const tBadge = useTranslations('nav.badge')
   const tAccessibility = useTranslations('accessibility')
+  const tTheme = useTranslations('accessibility.theme')
 
   // navigation config uses `badge: 'new'` (i18n key, not literal). Map
   // here so consumers below stay simple.
@@ -146,7 +148,7 @@ export function MobileMenu({
             <span>
               {t('experimentalBanner')} –
               <a
-                href={ORG.website}
+                href={ORG.websiteLegacy}
                 target="_blank"
                 rel="noopener noreferrer"
                 className="font-medium text-warning-800 dark:text-warning-300 hover:text-warning-900 dark:hover:text-warning-200 underline ml-1"
@@ -308,12 +310,19 @@ export function MobileMenu({
           )}
         </nav>
 
-        {/* Footer - Language pills (one-tap) + Auth Actions. The theme toggle
-            lives on the top bar itself (one-tap, always visible) — not here. */}
+        {/* Footer - Language pills (one-tap) + theme toggle + Auth Actions.
+            On phones the theme toggle lives here (the top bar hides it below
+            sm to keep the scarce header width for account actions). */}
         <div className="border-t border-subtle dark:border-white/6 px-6 pt-3 pb-1 space-y-3">
-          <div>
-            <p className="text-xs font-medium text-text-tertiary mb-2">{t('language')}</p>
-            <LocaleSwitcher inline />
+          <div className="flex items-end justify-between gap-4">
+            <div>
+              <p className="text-xs font-medium text-text-tertiary mb-2">{t('language')}</p>
+              <LocaleSwitcher inline />
+            </div>
+            <div className="sm:hidden">
+              <p className="text-xs font-medium text-text-tertiary mb-2">{tTheme('label')}</p>
+              <ThemeToggle />
+            </div>
           </div>
         </div>
         <div className="px-6 pb-4">

--- a/src/components/layout/header/Header.tsx
+++ b/src/components/layout/header/Header.tsx
@@ -82,14 +82,21 @@ export function Header() {
   // Publish the current header offset as a CSS custom property on the
   // document root so any sub-nav (sticky strip below the header) can
   // follow the smart-hide state. When the header is visible the offset
-  // is its own height (h-16 → 4rem). When hidden the offset is 0, which
-  // lets sticky sub-navs slide up into the freed space instead of leaving
-  // a 64-px gap above themselves. CSS transition on the consumer side
+  // is its measured height (h-14 on phones, h-16 from sm up — measured,
+  // not hardcoded, so the two stay in sync). When hidden the offset is 0,
+  // which lets sticky sub-navs slide up into the freed space instead of
+  // leaving a gap above themselves. CSS transition on the consumer side
   // animates the change smoothly.
   useEffect(() => {
     const root = document.documentElement
-    root.style.setProperty('--header-offset', effectivelyHidden ? '0px' : '4rem')
+    const publish = () => {
+      const height = headerRef.current?.offsetHeight ?? 64
+      root.style.setProperty('--header-offset', effectivelyHidden ? '0px' : `${height}px`)
+    }
+    publish()
+    window.addEventListener('resize', publish)
     return () => {
+      window.removeEventListener('resize', publish)
       // Reset on unmount so downstream consumers don't see a stale offset.
       root.style.removeProperty('--header-offset')
     }
@@ -128,12 +135,12 @@ export function Header() {
         )}
       >
         <div className="max-w-7xl mx-auto">
-          <nav className="flex items-center justify-between gap-3 sm:gap-6 h-16 px-3 sm:px-6 lg:px-8">
+          <nav className="flex items-center justify-between gap-3 sm:gap-6 h-14 sm:h-16 px-3 sm:px-6 lg:px-8">
             {/* Logo — the ONE flexible item in the row (min-w-0, no shrink-0).
                 On narrow phones it scales down so the action cluster — most
                 importantly the menu button — is never pushed off-screen. */}
             <div className="min-w-0">
-              <Logo className="h-10" />
+              <Logo className="h-9 sm:h-10" />
             </div>
 
             {/* Primary Navigation — inline only at xl+ (below xl the hamburger menu
@@ -182,9 +189,10 @@ export function Header() {
             {/* Compact Right Side — phones, tablets and laptops below xl. Account
                 actions (bell + avatar / login) stay visible; full nav is in the menu. */}
             <div className="xl:hidden flex shrink-0 items-center gap-1.5 ml-auto">
-              {/* One-tap theme toggle — visible for everyone (incl. logged-out)
-                  on every screen, not buried in the hamburger menu. */}
-              <ThemeToggle />
+              {/* One-tap theme toggle from sm up. On phones the top bar is the
+                  scarcest surface on the site — the toggle lives in the mobile
+                  menu footer instead (next to the language switcher). */}
+              <ThemeToggle className="hidden sm:inline-flex" />
               <CommandPaletteTrigger />
               <UserMenu />
               {/* Mobile Menu Button */}
@@ -196,7 +204,8 @@ export function Header() {
                 className={cn(
                   // Boxed like the theme toggle — the bare ghost icon was easy
                   // to miss on phones (thin faint lines at the screen edge).
-                  "relative rounded-lg border border-subtle bg-surface-raised",
+                  // h-9 w-9 matches every other icon control in the bar.
+                  "relative h-9 w-9 rounded-lg border border-subtle bg-surface-raised",
                   "text-text-primary hover:border-strong hover:bg-surface-raised"
                 )}
                 onClick={() => setMobileMenuOpen(true)}
@@ -215,8 +224,8 @@ export function Header() {
         </div>
       </header>
 
-      {/* Spacer for fixed header */}
-      <div className="h-16" />
+      {/* Spacer for fixed header — must mirror the nav's responsive height */}
+      <div className="h-14 sm:h-16" />
 
       <MobileMenu
         isOpen={mobileMenuOpen}

--- a/src/components/marketplace/checkout/ShippingAddressFields.tsx
+++ b/src/components/marketplace/checkout/ShippingAddressFields.tsx
@@ -1,0 +1,109 @@
+'use client'
+
+/**
+ * ShippingAddressFields — the one shipping-address form used by both
+ * checkout flows (single-item checkout + RevampIT cart). Renders the
+ * Swiss-format fields, the "prefilled from profile" hint and the optional
+ * "save to profile for next time" opt-in.
+ */
+
+import { CheckCircle2 } from 'lucide-react'
+import { useTranslations } from 'next-intl'
+import { Input } from '@/components/ui/input'
+import type { ShippingAddress } from '@/hooks/useShippingAddress'
+
+interface ShippingAddressFieldsProps {
+  address: ShippingAddress
+  onChange: (updater: (prev: ShippingAddress) => ShippingAddress) => void
+  postalCodeValid: boolean
+  prefilled: boolean
+  canOfferSave: boolean
+  saveToProfile: boolean
+  onSaveToggle: (save: boolean) => void
+}
+
+export function ShippingAddressFields({
+  address,
+  onChange,
+  postalCodeValid,
+  prefilled,
+  canOfferSave,
+  saveToProfile,
+  onSaveToggle,
+}: ShippingAddressFieldsProps) {
+  const t = useTranslations('marketplace.checkout.address')
+
+  return (
+    <div className="space-y-4">
+      {prefilled && (
+        <p className="flex items-center gap-2 rounded-lg bg-action-muted px-3 py-2 text-sm text-action">
+          <CheckCircle2 className="h-4 w-4 shrink-0" aria-hidden="true" />
+          {t('prefilledFromProfile')}
+        </p>
+      )}
+      <div>
+        <label htmlFor="shipping-name" className="mb-1 block text-sm font-medium text-text-secondary">{t('name')}</label>
+        <Input
+          id="shipping-name"
+          type="text"
+          autoComplete="name"
+          value={address.name}
+          onChange={(e) => onChange(prev => ({ ...prev, name: e.target.value }))}
+          placeholder={t('namePlaceholder')}
+        />
+      </div>
+      <div>
+        <label htmlFor="shipping-street" className="mb-1 block text-sm font-medium text-text-secondary">{t('street')}</label>
+        <Input
+          id="shipping-street"
+          type="text"
+          autoComplete="street-address"
+          value={address.street}
+          onChange={(e) => onChange(prev => ({ ...prev, street: e.target.value }))}
+          placeholder={t('streetPlaceholder')}
+        />
+      </div>
+      <div className="grid grid-cols-1 gap-4 sm:grid-cols-3">
+        <div>
+          <label htmlFor="shipping-plz" className="mb-1 block text-sm font-medium text-text-secondary">{t('postalCode')}</label>
+          <Input
+            id="shipping-plz"
+            type="text"
+            inputMode="numeric"
+            autoComplete="postal-code"
+            value={address.postal_code}
+            onChange={(e) => onChange(prev => ({ ...prev, postal_code: e.target.value.replace(/\D/g, '').slice(0, 4) }))}
+            maxLength={4}
+            className={address.postal_code && !postalCodeValid ? 'border-error-500' : ''}
+            placeholder="8000"
+          />
+          {address.postal_code && !postalCodeValid && (
+            <p className="mt-1 text-xs text-error-500">{t('postalCodeError')}</p>
+          )}
+        </div>
+        <div className="sm:col-span-2">
+          <label htmlFor="shipping-city" className="mb-1 block text-sm font-medium text-text-secondary">{t('city')}</label>
+          <Input
+            id="shipping-city"
+            type="text"
+            autoComplete="address-level2"
+            value={address.city}
+            onChange={(e) => onChange(prev => ({ ...prev, city: e.target.value }))}
+            placeholder={t('cityPlaceholder')}
+          />
+        </div>
+      </div>
+      {canOfferSave && (
+        <label className="flex cursor-pointer items-start gap-2 text-sm text-text-secondary">
+          <input
+            type="checkbox"
+            checked={saveToProfile}
+            onChange={(e) => onSaveToggle(e.target.checked)}
+            className="mt-0.5 rounded border-strong text-action focus:ring-action"
+          />
+          {t('saveToProfile')}
+        </label>
+      )}
+    </div>
+  )
+}

--- a/src/components/search/CommandPaletteTrigger.tsx
+++ b/src/components/search/CommandPaletteTrigger.tsx
@@ -22,7 +22,7 @@ export function CommandPaletteTrigger({ className }: { className?: string }) {
       onClick={openCommandPalette}
       aria-label="Suche öffnen (⌘K)"
       className={cn(
-        'flex h-9 w-9 items-center justify-center rounded-md p-0 text-text-tertiary hover:bg-surface-raised sm:w-auto sm:gap-2 sm:px-3',
+        'flex h-9 w-9 items-center justify-center rounded-lg p-0 text-text-tertiary hover:bg-surface-raised sm:w-auto sm:gap-2 sm:px-3',
         className,
       )}
     >

--- a/src/components/ui/ThemeToggle.tsx
+++ b/src/components/ui/ThemeToggle.tsx
@@ -35,7 +35,7 @@ export function ThemeToggle({ className }: ThemeToggleProps) {
       onClick={() => setTheme(next)}
       suppressHydrationWarning
       className={cn(
-        'inline-flex h-9 w-9 items-center justify-center rounded-md border border-subtle bg-surface-raised text-text-tertiary transition-colors hover:border-strong hover:text-text-primary',
+        'inline-flex h-9 w-9 items-center justify-center rounded-lg border border-subtle bg-surface-raised text-text-tertiary transition-colors hover:border-strong hover:text-text-primary',
         className,
       )}
     >

--- a/src/config/booking-status.ts
+++ b/src/config/booking-status.ts
@@ -34,6 +34,24 @@ export const BOOKING_STATUS = {
 
 export type BookingStatus = typeof BOOKING_STATUS[keyof typeof BOOKING_STATUS]
 
+/**
+ * Lifecycle statuses an appointment row can actually carry in the DB.
+ * Excludes the repairer-view aliases (pending/confirmed) — those are
+ * display-only synonyms; offering them as filters produced duplicate
+ * "Bestätigt"/"Ausstehend" chips that never matched any row.
+ */
+export const CANONICAL_BOOKING_STATUSES: readonly BookingStatus[] = [
+  BOOKING_STATUS.REQUESTED,
+  BOOKING_STATUS.ACCEPTED,
+  BOOKING_STATUS.QUOTED,
+  BOOKING_STATUS.QUOTE_APPROVED,
+  BOOKING_STATUS.QUOTE_REJECTED,
+  BOOKING_STATUS.IN_PROGRESS,
+  BOOKING_STATUS.COMPLETED,
+  BOOKING_STATUS.REJECTED,
+  BOOKING_STATUS.CANCELLED,
+]
+
 // ============================================================================
 // Appointment Transitions (SSOT) — who can do what, from which state
 // ============================================================================

--- a/src/config/org.ts
+++ b/src/config/org.ts
@@ -35,6 +35,8 @@ export const ORG = {
   description: 'Wir machen Technologie nachhaltig und für alle zugänglich.',
   /** Current production app URL. revamp-it.ch still serves the legacy Joomla site. */
   website: 'https://revampit.orangecat.ch',
+  /** Legacy public site (Joomla) — target of the "zur aktuellen Site" banner link. */
+  websiteLegacy: 'https://revamp-it.ch',
   /** Email domain */
   emailDomain: 'revamp-it.ch',
   /**

--- a/src/hooks/useCheckout.ts
+++ b/src/hooks/useCheckout.ts
@@ -4,6 +4,9 @@ import { useState } from 'react'
 import { apiFetch } from '@/lib/api/client'
 import { logger } from '@/lib/logger'
 import { COMMISSION_RATE } from '@/config/marketplace'
+import { useShippingAddress, type ShippingAddress } from '@/hooks/useShippingAddress'
+
+export type { ShippingAddress }
 
 export interface ListingForCheckout {
   id: string
@@ -17,14 +20,6 @@ export interface ListingForCheckout {
   seller_name: string
   seller_id: string
   is_revampit: boolean
-}
-
-export interface ShippingAddress {
-  name: string
-  street: string
-  city: string
-  postal_code: string
-  country: string
 }
 
 interface CheckoutErrors {
@@ -41,13 +36,19 @@ export function useCheckout(
   const [deliveryMethod, setDeliveryMethod] = useState<'pickup' | 'shipping'>(() =>
     initialListing.delivery_options === 'shipping' ? 'shipping' : 'pickup',
   )
-  const [shippingAddress, setShippingAddress] = useState<ShippingAddress>({
-    name: '',
-    street: '',
-    city: '',
-    postal_code: '',
-    country: 'CH',
-  })
+  // Shared address state — prefilled from the buyer's saved profile address
+  // and optionally written back on order creation (see useShippingAddress).
+  const {
+    shippingAddress,
+    setShippingAddress,
+    prefilled: addressPrefilled,
+    postalCodeValid,
+    addressComplete,
+    canOfferSave,
+    saveToProfile,
+    setSaveToProfile,
+    persistAddressIfRequested,
+  } = useShippingAddress()
   const [creatingOrder, setCreatingOrder] = useState(false)
 
   const handleCreateOrder = async () => {
@@ -56,6 +57,9 @@ export function useCheckout(
     setError(null)
 
     try {
+      if (deliveryMethod === 'shipping') {
+        await persistAddressIfRequested()
+      }
       const result = await apiFetch<{ paymentUrl?: string }>('/api/marketplace/orders', {
         method: 'POST',
         body: {
@@ -83,13 +87,7 @@ export function useCheckout(
   const totalAmount = listing.price_chf + shippingCost
   const commission = Math.round(totalAmount * COMMISSION_RATE * 100) / 100
   const canSelectDelivery = listing.delivery_options === 'both'
-  const postalCodeValid = /^\d{4}$/.test(shippingAddress.postal_code)
-  const shippingFormValid = deliveryMethod !== 'shipping' || (
-    shippingAddress.name.trim() !== '' &&
-    shippingAddress.street.trim() !== '' &&
-    shippingAddress.city.trim() !== '' &&
-    postalCodeValid
-  )
+  const shippingFormValid = deliveryMethod !== 'shipping' || addressComplete
 
   return {
     listing,
@@ -103,6 +101,10 @@ export function useCheckout(
     canSelectDelivery,
     postalCodeValid,
     shippingFormValid,
+    addressPrefilled,
+    canOfferSave,
+    saveToProfile,
+    setSaveToProfile,
     setDeliveryMethod,
     setShippingAddress,
     handleCreateOrder,

--- a/src/hooks/useShippingAddress.ts
+++ b/src/hooks/useShippingAddress.ts
@@ -1,0 +1,139 @@
+'use client'
+
+/**
+ * useShippingAddress — SSOT for the checkout shipping-address form.
+ *
+ * Used by BOTH checkout flows (single-item /marketplace/checkout/[listingId]
+ * and the RevampIT cart). Owns the address state, prefills it once from the
+ * logged-in user's saved profile address (user_profiles), validates it, and
+ * optionally writes it back to the profile ("für das nächste Mal speichern")
+ * when an order is placed — so returning buyers never retype their address.
+ */
+
+import { useEffect, useRef, useState } from 'react'
+import { useSession } from 'next-auth/react'
+import { apiFetch } from '@/lib/api/client'
+import { logger } from '@/lib/logger'
+
+export interface ShippingAddress {
+  name: string
+  street: string
+  city: string
+  postal_code: string
+  country: string
+}
+
+interface ProfileAddressResponse {
+  profile?: {
+    first_name?: string | null
+    last_name?: string | null
+    address_line1?: string | null
+    postal_code?: string | null
+    city?: string | null
+  }
+}
+
+export const EMPTY_SHIPPING_ADDRESS: ShippingAddress = {
+  name: '',
+  street: '',
+  city: '',
+  postal_code: '',
+  country: 'CH',
+}
+
+function isUntouched(address: ShippingAddress): boolean {
+  return !address.name && !address.street && !address.city && !address.postal_code
+}
+
+export function useShippingAddress() {
+  const { data: session, status } = useSession()
+  const [shippingAddress, setShippingAddress] = useState<ShippingAddress>(EMPTY_SHIPPING_ADDRESS)
+  const [prefilled, setPrefilled] = useState(false)
+  const [saveToProfile, setSaveToProfile] = useState(false)
+  // The profile address as loaded, to know whether saving back is meaningful.
+  // State (not a ref) — it's read during render to compute canOfferSave.
+  const [loadedProfileAddress, setLoadedProfileAddress] = useState<
+    { street: string; postal_code: string; city: string } | null
+  >(null)
+  const attemptedPrefill = useRef(false)
+
+  useEffect(() => {
+    if (status !== 'authenticated' || attemptedPrefill.current) return
+    attemptedPrefill.current = true
+    let cancelled = false
+    async function prefill() {
+      const result = await apiFetch<ProfileAddressResponse>('/api/user/profile')
+      if (cancelled || !result.success || !result.data?.profile) return
+      const p = result.data.profile
+      setLoadedProfileAddress({
+        street: p.address_line1 ?? '',
+        postal_code: p.postal_code ?? '',
+        city: p.city ?? '',
+      })
+      const fullName = [p.first_name, p.last_name].filter(Boolean).join(' ')
+        || session?.user?.name
+        || ''
+      if (!p.address_line1 || !p.postal_code || !p.city) return
+      setShippingAddress(prev => {
+        // Never overwrite anything the user already typed.
+        if (!isUntouched(prev)) return prev
+        setPrefilled(true)
+        return {
+          name: fullName,
+          street: p.address_line1 ?? '',
+          city: p.city ?? '',
+          postal_code: p.postal_code ?? '',
+          country: 'CH',
+        }
+      })
+    }
+    void prefill()
+    return () => { cancelled = true }
+  }, [status, session?.user?.name])
+
+  const postalCodeValid = /^\d{4}$/.test(shippingAddress.postal_code)
+  const addressComplete =
+    shippingAddress.name.trim() !== '' &&
+    shippingAddress.street.trim() !== '' &&
+    shippingAddress.city.trim() !== '' &&
+    postalCodeValid
+
+  // Whether offering "save to profile" makes sense: logged in, and the typed
+  // address differs from what the profile already has.
+  const addressDiffersFromProfile =
+    shippingAddress.street.trim() !== (loadedProfileAddress?.street ?? '').trim() ||
+    shippingAddress.postal_code !== (loadedProfileAddress?.postal_code ?? '') ||
+    shippingAddress.city.trim() !== (loadedProfileAddress?.city ?? '').trim()
+  const canOfferSave = status === 'authenticated' && addressDiffersFromProfile
+
+  /**
+   * Persist the address to the user's profile if the user opted in.
+   * Fire-and-forget semantics: a failed save must never block the order.
+   */
+  const persistAddressIfRequested = async () => {
+    if (!saveToProfile || !canOfferSave || !addressComplete) return
+    const result = await apiFetch<void>('/api/user/profile', {
+      method: 'PUT',
+      body: {
+        address_line1: shippingAddress.street.trim(),
+        postal_code: shippingAddress.postal_code,
+        city: shippingAddress.city.trim(),
+      },
+    })
+    if (!result.success) {
+      logger.warn('Saving checkout address to profile failed', { error: result.error })
+    }
+  }
+
+  return {
+    shippingAddress,
+    setShippingAddress,
+    prefilled,
+    postalCodeValid,
+    addressComplete,
+    canOfferSave,
+    saveToProfile,
+    setSaveToProfile,
+    persistAddressIfRequested,
+  }
+}

--- a/src/lib/api/client.ts
+++ b/src/lib/api/client.ts
@@ -47,9 +47,18 @@ export async function apiFetch<T = unknown>(
     const data = await response.json().catch(() => ({}))
 
     if (!response.ok || !data.success) {
+      // Validation failures (apiBadRequest) carry per-field messages in
+      // `errors` — surface them, otherwise users only see the generic
+      // "Ungültige Eingabedaten" with no clue which field is wrong.
+      const fieldMessages = data.errors && typeof data.errors === 'object'
+        ? Object.values(data.errors as Record<string, string[]>).flat().filter(Boolean)
+        : []
+      const baseError = data.error || `Anfrage fehlgeschlagen (${response.status})`
       return {
         success: false,
-        error: data.error || `Anfrage fehlgeschlagen (${response.status})`,
+        error: fieldMessages.length > 0
+          ? `${baseError}: ${fieldMessages.join(' · ')}`
+          : baseError,
       }
     }
 


### PR DESCRIPTION
## What & why

Site-wide mobile UX overhaul driven by production phone screenshots. Fixes: the oversized/crowded mobile header and the "Experimentelle Site" banner linking back to the app itself instead of revamp-it.ch; the notifications panel running off the left edge of phone screens; page-level horizontal scrolling on `/about/press`; non-clickable stats; checkout asking for the address even when the user has one saved; the feedback widget rendering as a broken narrow column with overlapping chips on mobile; Erfassung's submit buttons hidden under the admin bottom nav and its opaque "Fehler beim Erfassen des Produkts" error; duplicate "Bestätigt"/"Ausstehend" filter chips on Termine; blind horizontal-scroll admin tables on phones; and dead-end empty states.

## Approach

- **Press-page overflow root cause:** the mention grids had no base `grid-cols-1`, so the implicit `auto` track sized to the nowrap `truncate` titles (571px) and mobile browsers zoomed out to fit. One class fixes it; verified with a Playwright overflow sweep across all main public pages (`scrollWidth === 390` everywhere now).
- **Checkout address reuse (Amazon-style):** new `useShippingAddress` hook is the SSOT for both checkout flows — prefills from the saved `user_profiles` address, offers "save for next time", and writes back on order creation. A shared `ShippingAddressFields` component replaces the duplicated form markup in the single-item checkout and the cart. The profile page finally gets address inputs (columns + API already existed end-to-end; only the UI was missing). Payment method selection stays on the Payrexx hosted page — storing card data ourselves is not PCI-feasible; Payrexx tokenization would be the follow-up for one-click payments.
- **Two silent no-op utility classes** (`scrollbar-hide`, `safe-area-inset-bottom`) were used across the codebase but never defined — now defined in `globals.css`.
- **AdminTable** (SSOT for ~23 admin tables) renders stacked label/value cards below `md` instead of horizontal scroll — every admin table gets a usable phone view from one change.
- **Termine duplicate chips:** the filter iterated the whole `BOOKING_STATUS_BADGES` map, which merges the lifecycle statuses with the repairer-view aliases (`pending`/`confirmed`). New `CANONICAL_BOOKING_STATUSES` excludes display-only aliases.
- **Erfassung diagnosability:** `apiFetch` now surfaces zod per-field messages, and the staff-only erfassung route includes the underlying cause in its 500 message instead of a blanket string.

## Screenshots / recordings

Verified locally at 390×844 with Playwright: compact header, mobile menu with theme toggle + banner linking to `https://revamp-it.ch`, feedback bottom sheet with wrapping suggestion pills, stacked FABs bottom-right, zero horizontal overflow on `/`, `/about/*`, `/marketplace`, `/workshops`, `/services`, `/blog`, `/it-hilfe`, `/contact`.

## Checklist

- [x] Tests pass locally (`npm test` — i18n suites; full suite unchanged areas)
- [x] `npm run lint` clean (0 errors; 51 pre-existing warnings)
- [x] `npm run typecheck` clean
- [x] Swiss German: no ASCII umlauts (`npm run lint:umlauts`); proper `ä/ö/ü`, `ss` (not `ß`)
- [x] No `console.log` — use `logger` from `@/lib/logger`
- [x] No hardcoded table names — use `TABLE_NAMES` from `@/config/database`
- [x] No hardcoded org data — use `@/config/org` (new `ORG.websiteLegacy` constant)
- [x] Parameterized SQL queries only (no SQL touched)

## Notes for review

- `compliance:i18n` fails on pre-existing missing `soFunktioniert.*` keys (fails on a clean checkout too; not part of the deploy CI gate).
- The prod "Fehler beim Erfassen des Produkts" root cause needs one real submission after deploy — the error will now carry the underlying cause so it can be fixed precisely.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_0165sASEr12yCd78JkNCfRDY

---
_Generated by [Claude Code](https://claude.ai/code/session_0165sASEr12yCd78JkNCfRDY)_