### PR TITLE
fix(admin): device summary on intake detail + human working-hours display

### DIFF
--- a/messages/de.json
+++ b/messages/de.json
@@ -10362,7 +10362,13 @@
           "applying": "Ändern…",
           "apply": "Stufe ändern"
         },
-        "timelineHeading": "Verlauf"
+        "timelineHeading": "Verlauf",
+        "device": {
+          "condition": "Zustand",
+          "category": "Kategorie",
+          "price": "Preis",
+          "captured": "Erfasst"
+        }
       },
       "pipeline": {
         "newDevice": "Neues Gerät",

--- a/messages/en.json
+++ b/messages/en.json
@@ -10248,7 +10248,13 @@
           "applying": "Changing…",
           "apply": "Change tier"
         },
-        "timelineHeading": "History"
+        "timelineHeading": "History",
+        "device": {
+          "condition": "Condition",
+          "category": "Category",
+          "price": "Price",
+          "captured": "Captured"
+        }
       },
       "pipeline": {
         "newDevice": "New device",

--- a/messages/es.json
+++ b/messages/es.json
@@ -10296,7 +10296,13 @@
           "applying": "Cambiando…",
           "apply": "Cambiar nivel"
         },
-        "timelineHeading": "Historial"
+        "timelineHeading": "Historial",
+        "device": {
+          "condition": "Estado",
+          "category": "Categoría",
+          "price": "Precio",
+          "captured": "Registrado"
+        }
       },
       "pipeline": {
         "newDevice": "Nuevo dispositivo",

--- a/messages/fr.json
+++ b/messages/fr.json
@@ -10249,7 +10249,13 @@
           "applying": "Changement…",
           "apply": "Changer le niveau"
         },
-        "timelineHeading": "Historique"
+        "timelineHeading": "Historique",
+        "device": {
+          "condition": "État",
+          "category": "Catégorie",
+          "price": "Prix",
+          "captured": "Saisi"
+        }
       },
       "pipeline": {
         "newDevice": "Nouvel appareil",

--- a/messages/it.json
+++ b/messages/it.json
@@ -10296,7 +10296,13 @@
           "applying": "Modifica…",
           "apply": "Cambia livello"
         },
-        "timelineHeading": "Cronologia"
+        "timelineHeading": "Cronologia",
+        "device": {
+          "condition": "Condizione",
+          "category": "Categoria",
+          "price": "Prezzo",
+          "captured": "Registrato"
+        }
       },
       "pipeline": {
         "newDevice": "Nuovo dispositivo",

--- a/messages/ja.json
+++ b/messages/ja.json
@@ -10296,7 +10296,13 @@
           "applying": "変更中…",
           "apply": "段階を変更"
         },
-        "timelineHeading": "履歴"
+        "timelineHeading": "履歴",
+        "device": {
+          "condition": "状態",
+          "category": "カテゴリ",
+          "price": "価格",
+          "captured": "登録日"
+        }
       },
       "pipeline": {
         "newDevice": "新しいデバイス",

--- a/messages/ko.json
+++ b/messages/ko.json
@@ -10296,7 +10296,13 @@
           "applying": "변경 중…",
           "apply": "등급 변경"
         },
-        "timelineHeading": "이력"
+        "timelineHeading": "이력",
+        "device": {
+          "condition": "상태",
+          "category": "카테고리",
+          "price": "가격",
+          "captured": "등록일"
+        }
       },
       "pipeline": {
         "newDevice": "새 기기",

--- a/messages/ru.json
+++ b/messages/ru.json
@@ -10290,7 +10290,13 @@
           "applying": "Изменение…",
           "apply": "Изменить этап"
         },
-        "timelineHeading": "История"
+        "timelineHeading": "История",
+        "device": {
+          "condition": "Состояние",
+          "category": "Категория",
+          "price": "Цена",
+          "captured": "Зарегистрировано"
+        }
       },
       "pipeline": {
         "newDevice": "Новое устройство",

--- a/src/app/admin/intake/IntakeDetailView.tsx
+++ b/src/app/admin/intake/IntakeDetailView.tsx
@@ -9,7 +9,10 @@ import { Input } from '@/components/ui/input'
 import {
   Check, RefreshCw, ExternalLink,
   AlertCircle, ArrowDownUp, Clock, CheckCheck, ClipboardList,
+  Image as ImageIcon,
 } from 'lucide-react'
+import { KATEGORIEN, getConditionLabel } from '@/config/erfassung'
+import { formatDateShort } from '@/lib/date-formats'
 import {
   INTAKE_TIERS,
   INTAKE_TIER_LABELS,
@@ -142,6 +145,53 @@ export function IntakeDetailView({
             </>
           )}
         </div>
+      </div>
+
+      {/* Device summary — what IS this thing (image, condition, price, …).
+          Without it the detail page was a floating publish box in a void. */}
+      <div className="bg-surface-base border rounded-lg p-4">
+        <div className="flex gap-4">
+          <div className="h-24 w-24 shrink-0 overflow-hidden rounded-lg border border-subtle bg-surface-raised">
+            {detail.image_url ? (
+               
+              <img src={detail.image_url} alt={`${detail.brand} ${detail.product_name}`} className="h-full w-full object-cover" />
+            ) : (
+              <div className="flex h-full w-full items-center justify-center">
+                <ImageIcon className="h-8 w-8 text-text-muted" aria-hidden="true" />
+              </div>
+            )}
+          </div>
+          <dl className="grid flex-1 grid-cols-2 gap-x-4 gap-y-2 text-sm sm:grid-cols-3">
+            <div>
+              <dt className="text-xs text-text-tertiary">{t('device.condition')}</dt>
+              <dd className="font-medium text-text-primary">{getConditionLabel(detail.condition)}</dd>
+            </div>
+            <div>
+              <dt className="text-xs text-text-tertiary">{t('device.category')}</dt>
+              <dd className="font-medium text-text-primary">
+                {KATEGORIEN.find(k => k.value === detail.category)?.label || '—'}
+              </dd>
+            </div>
+            <div>
+              <dt className="text-xs text-text-tertiary">{t('device.price')}</dt>
+              <dd className="font-medium text-text-primary tabular-nums">
+                {detail.selling_price_chf != null ? `CHF ${Number(detail.selling_price_chf).toFixed(2)}` : '—'}
+              </dd>
+            </div>
+            <div className="col-span-2 sm:col-span-3">
+              <dt className="text-xs text-text-tertiary">{t('device.captured')}</dt>
+              <dd className="text-text-secondary">
+                {formatDateShort(detail.created_at)}
+                {detail.created_by_name ? ` · ${detail.created_by_name}` : ''}
+              </dd>
+            </div>
+          </dl>
+        </div>
+        {detail.short_description && (
+          <p className="mt-3 border-t border-subtle pt-3 text-sm text-text-secondary">
+            {detail.short_description}
+          </p>
+        )}
       </div>
 
       {/* Progress Bar — annahme items only; quick captures have no checklist */}

--- a/src/app/admin/intake/types.ts
+++ b/src/app/admin/intake/types.ts
@@ -59,6 +59,7 @@ export interface DetailData {
   short_description: string | null
   condition: string
   category: string | null
+  image_url: string | null
   /** NULL for quick-captured devices (Schnellerfassung — no checklist). */
   intake_tier: IntakeTier | null
   marketplace_status: string

--- a/src/app/api/admin/intake/[id]/__tests__/route.test.ts
+++ b/src/app/api/admin/intake/[id]/__tests__/route.test.ts
@@ -49,6 +49,7 @@ const mockFrom = jest.fn()
 const mockInnerJoin = jest.fn()
 const mockLeftJoin = jest.fn()
 const mockWhere = jest.fn()
+const mockLimit = jest.fn()
 
 // Drizzle update chain
 const mockUpdate = jest.fn()
@@ -67,6 +68,7 @@ jest.mock('@/db/schema', () => ({
   aiExtractedProducts: { id: 'aep_id', itemUuid: 'aep_itemUuid', productName: 'aep_name', brand: 'aep_brand', shortDescription: 'aep_shortDesc', condition: 'aep_condition', category: 'aep_category', subcategory: 'aep_subcategory', estimatedPriceChf: 'aep_price', createdBy: 'aep_createdBy', updatedAt: 'aep_updatedAt' },
   users: { id: 'u_id', name: 'u_name', email: 'u_email' },
   donations: { id: 'd_id', donorName: 'd_donorName', donorEmail: 'd_donorEmail', notes: 'd_notes', status: 'd_status' },
+  productImages: { productId: 'pi_productId', isPrimary: 'pi_isPrimary', filePath: 'pi_filePath' },
 }))
 
 jest.mock('drizzle-orm', () => ({
@@ -185,11 +187,17 @@ beforeEach(() => {
   mockAuth.mockResolvedValue(MOCK_SESSION)
 
   // GET: select().from().innerJoin().leftJoin().leftJoin().where()
+  //      + image lookup: select().from(productImages).where().limit(1)
   // PATCH existence check: select().from(inventoryItems).where() (no joins)
   mockFrom.mockReturnValue({ innerJoin: mockInnerJoin, where: mockWhere })
   mockInnerJoin.mockReturnValue({ leftJoin: mockLeftJoin })
   mockLeftJoin.mockReturnValue({ leftJoin: mockLeftJoin, where: mockWhere })
-  mockWhere.mockResolvedValue([MOCK_ROW])
+  // The where() result is awaited directly (detail row) OR chained with
+  // .limit(1) (image lookup) — return a promise that also carries .limit.
+  mockWhere.mockImplementation(() =>
+    Object.assign(Promise.resolve([MOCK_ROW]), { limit: mockLimit })
+  )
+  mockLimit.mockResolvedValue([])
 
   // PATCH: select().from().where() for existence check
   // (uses same mockFrom chain, but different terminal)

--- a/src/app/api/admin/intake/[id]/route.ts
+++ b/src/app/api/admin/intake/[id]/route.ts
@@ -7,8 +7,8 @@
 
 import { withAdmin } from '@/lib/api/middleware'
 import { db } from '@/db'
-import { inventoryItems, aiExtractedProducts, users, donations } from '@/db/schema'
-import { eq, and, isNotNull, sql } from 'drizzle-orm'
+import { inventoryItems, aiExtractedProducts, users, donations, productImages } from '@/db/schema'
+import { eq, and, sql } from 'drizzle-orm'
 import { apiError, apiSuccess, apiNotFound, apiBadRequest } from '@/lib/api/helpers'
 import { ERROR_MESSAGES } from '@/config/error-messages'
 import { validateBody } from '@/lib/schemas'
@@ -72,6 +72,18 @@ export const GET = withAdmin<{ id: string }>('intake', async (_request, _session
     }
 
     const row = rows[0]
+
+    // Primary product image — the detail page shows the device, not just text.
+    let imageUrl: string | null = null
+    if (row.ai_product_id) {
+      const [img] = await db
+        .select({ filePath: productImages.filePath })
+        .from(productImages)
+        .where(and(eq(productImages.productId, row.ai_product_id), eq(productImages.isPrimary, true)))
+        .limit(1)
+      imageUrl = img?.filePath ?? null
+    }
+
     const tier = row.intake_tier as IntakeTier | null
     const checklist = (row.intake_checklist || {}) as ChecklistState
     const cat = row.category
@@ -99,6 +111,7 @@ export const GET = withAdmin<{ id: string }>('intake', async (_request, _session
 
     return apiSuccess({
       ...row,
+      image_url: imageUrl,
       checklist_complete: complete,
       checklist_progress: progress,
       checklist_items: checklistWithState,
@@ -125,11 +138,11 @@ export const PATCH = withAdmin<{ id: string }>('intake', async (request, session
     if (!validation.success) return validation.error
     const data = validation.data
 
-    // Check exists
+    // Check exists — quick-captured devices (tier NULL) are editable too.
     const [existing] = await db
       .select({ id: inventoryItems.id, aiProductId: inventoryItems.aiProductId })
       .from(inventoryItems)
-      .where(and(eq(inventoryItems.id, id), isNotNull(inventoryItems.intakeTier)))
+      .where(eq(inventoryItems.id, id))
 
     if (!existing) {
       return apiNotFound(ERROR_MESSAGES.INTAKE_ITEM_NOT_FOUND)

--- a/src/components/admin/team/TeamProfileTabs.tsx
+++ b/src/components/admin/team/TeamProfileTabs.tsx
@@ -177,7 +177,7 @@ export function TeamProfileTabs({ profile, isSuperAdmin }: Props) {
 
       {/* Tab bar */}
       <div className="flex items-center justify-between gap-3 border-b border">
-        <nav className="flex -mb-px overflow-x-auto" role="tablist" aria-label="Profilbereiche">
+        <nav className="flex -mb-px overflow-x-auto scrollbar-hide" role="tablist" aria-label="Profilbereiche">
           {TAB_KEYS.map((key) => {
             const meta = tabMeta[key]
             const Icon = meta.icon

--- a/src/components/admin/team/TeamProfileView.tsx
+++ b/src/components/admin/team/TeamProfileView.tsx
@@ -28,6 +28,7 @@ import {
   type EmergencyRelation,
 } from '@/config/team'
 import { CurrentFocusInput } from './activity/CurrentFocusInput'
+import { WorkingHoursDisplay } from './WorkingHoursDisplay'
 import { formatDateShort } from '@/lib/date-formats'
 import type { TeamProfileViewProps } from './types'
 import { ROUTES } from '@/config/routes'
@@ -179,12 +180,10 @@ export function TeamProfileView({
             <div className="space-y-3">
               {profile.working_hours && (
                 <div>
-                  <Heading level={3} className="text-sm text-text-secondary">
+                  <Heading level={3} className="text-sm text-text-secondary mb-1">
                     {t('workingHours')}
                   </Heading>
-                  <p className="text-text-secondary text-sm">
-                    {profile.working_hours}
-                  </p>
+                  <WorkingHoursDisplay value={profile.working_hours} />
                 </div>
               )}
 

--- a/src/components/admin/team/WorkingHoursDisplay.tsx
+++ b/src/components/admin/team/WorkingHoursDisplay.tsx
@@ -1,0 +1,52 @@
+'use client'
+
+/**
+ * Read-only rendering of a team member's working hours.
+ *
+ * `working_hours` stores the serialized WeeklySchedule JSON (see
+ * lib/team/schedule.ts). This renders it as a human weekly plan — the raw
+ * JSON used to be printed verbatim on the profile page. Legacy free-text
+ * values (pre-schedule era) are shown as-is.
+ */
+
+import {
+  parseWeeklySchedule,
+  summarizeWeeklySchedule,
+  WEEKDAY_IDS,
+  WEEKDAY_LABELS,
+} from '@/lib/team/schedule'
+
+export function WorkingHoursDisplay({ value }: { value: string }) {
+  const looksStructured = value.trim().startsWith('{')
+  if (!looksStructured) {
+    return <p className="text-text-secondary text-sm whitespace-pre-wrap">{value}</p>
+  }
+
+  const schedule = parseWeeklySchedule(value)
+  const enabledDays = WEEKDAY_IDS.filter(day => schedule.days[day].enabled)
+
+  if (enabledDays.length === 0) {
+    return <p className="text-text-muted text-sm">Kein Standardschedule hinterlegt</p>
+  }
+
+  return (
+    <div className="space-y-1.5">
+      <dl className="space-y-0.5">
+        {WEEKDAY_IDS.map(day => {
+          const d = schedule.days[day]
+          return (
+            <div key={day} className="flex items-baseline gap-3 text-sm">
+              <dt className="w-7 shrink-0 font-medium text-text-secondary">{WEEKDAY_LABELS[day]}</dt>
+              <dd className={d.enabled ? 'text-text-secondary tabular-nums' : 'text-text-muted'}>
+                {d.enabled
+                  ? `${d.start}–${d.end}${d.break_minutes > 0 ? ` · ${d.break_minutes} Min. Pause` : ''}`
+                  : '—'}
+              </dd>
+            </div>
+          )
+        })}
+      </dl>
+      <p className="text-xs text-text-tertiary">{summarizeWeeklySchedule(schedule)}</p>
+    </div>
+  )
+}


### PR DESCRIPTION
## What & why

Follow-up polish on two pages flagged as unusable on mobile: the intake device detail (for quick-captured devices it was a lone publish box in a void — no photo, no condition, no price) and the team member profile, which printed the **raw WeeklySchedule JSON** as "Arbeitszeiten" (overflowing the viewport).

## Approach

- Intake detail gets a device summary card — primary photo, Zustand (via `getConditionLabel`), Kategorie (from `KATEGORIEN`), Preis, Erfassungsdatum + Erfasser, Kurzbeschreibung. The detail API now returns the primary product image; PATCH no longer rejects quick-captured (tier NULL) devices.
- New `WorkingHoursDisplay` renders the stored schedule via the existing `lib/team/schedule.ts` SSOT as a Mo–So plan (times, breaks, weekly total); legacy free-text values still render as-is.
- Team profile tab row gets `scrollbar-hide` (the visible scrollbar strip is gone).

## Screenshots / recordings

Admin pages are auth-gated; verified via typecheck, lint, 60 passing intake/team unit tests (detail-route test extended for the image lookup), and a full production build.

## Checklist

- [x] Tests pass locally (60 intake/team tests)
- [x] `npm run lint` clean (0 errors)
- [x] `npm run typecheck` clean
- [x] Swiss German: no ASCII umlauts; proper `ä/ö/ü`, `ss` (not `ß`)
- [x] No `console.log`
- [x] No hardcoded table names
- [x] No hardcoded org data
- [x] Parameterized SQL queries only

## Notes for review

Device-card labels are i18n keys (`admin.intake.detail.device.*`) added to all 8 locales.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_0165sASEr12yCd78JkNCfRDY

---
_Generated by [Claude Code](https://claude.ai/code/session_0165sASEr12yCd78JkNCfRDY)_