### PR TITLE
fix(protocols): unblock audio protocol creation + calmer create form

### DIFF
--- a/scripts/db/migrations/134_drop_protocol_enum_checks.sql
+++ b/scripts/db/migrations/134_drop_protocol_enum_checks.sql
@@ -1,0 +1,49 @@
+-- Migration 134: protocols — guarantee input_method exists, drop legacy enum CHECKs
+--
+-- Prod incident (2026-07-16): creating a protocol with input_method='audio'
+-- failed the INSERT. Root cause: migration 027b used
+-- `ADD COLUMN IF NOT EXISTS input_method ... CHECK (...)`. On databases where
+-- the column already existed, the whole ALTER is a silent no-op — so the CHECK
+-- that includes 'audio' never replaced the older hand-synced value list, and
+-- the DB kept rejecting valid app-level values.
+--
+-- Same failure class as notifications_type_check (dropped in migration 110):
+-- an app-level enum duplicated into a DB CHECK drifts and rejects valid
+-- values. All CHECKs on the protocol tables are enum value lists, validated
+-- at the write boundary:
+--   meeting_type / visibility / input_method → createProtocolSchema /
+--     updateProtocolSchema (zod, derived from src/config/protocols.ts)
+--   status → written only by internal services using config constants
+--   link_type → linkActionSchema (zod)
+-- Neither table has range/money/date-ordering CHECKs, so dropping all CHECK
+-- constraints on them is safe.
+--
+-- Policy (CLAUDE.md): app-level enums = config constant + zod at the write
+-- boundary. DB CHECKs are reserved for true invariants.
+
+-- 1. Guarantee the column exists (no-op where 027b already ran fully).
+ALTER TABLE meeting_protocols
+  ADD COLUMN IF NOT EXISTS input_method TEXT DEFAULT 'transcript';
+
+-- 2. Drop every CHECK constraint on the protocol tables. Constraint names
+--    vary between environments (inline CREATE TABLE vs ALTER-added), so drop
+--    by catalog lookup instead of guessing names.
+DO $$
+DECLARE
+  con RECORD;
+BEGIN
+  FOR con IN
+    SELECT conrelid::regclass AS tbl, conname
+    FROM pg_constraint
+    WHERE contype = 'c'
+      AND conrelid IN (
+        'meeting_protocols'::regclass,
+        'protocol_action_links'::regclass
+      )
+  LOOP
+    EXECUTE format('ALTER TABLE %s DROP CONSTRAINT %I', con.tbl, con.conname);
+  END LOOP;
+END $$;
+
+COMMENT ON COLUMN meeting_protocols.input_method
+  IS 'Pipeline entry point: audio | transcript | notes | tasks — validated in app (src/config/protocols.ts), no DB CHECK (migration 134)';

--- a/src/app/admin/protocols/new/ProtocolFormClient.tsx
+++ b/src/app/admin/protocols/new/ProtocolFormClient.tsx
@@ -55,23 +55,18 @@ export default function ProtocolFormClient({ teamMembers }: ProtocolFormClientPr
     <div className="max-w-3xl space-y-6">
       {error && <StatusBanner variant="error">{error}</StatusBanner>}
 
-      {/* Inhalt — the hero. Drop a recording, record live, or paste notes;
-          the AI transcribes and structures everything in one pass. This is the
-          one thing the user came here to do, so it leads. */}
+      {/* Inhalt — the hero and the only required step. Hierarchy inside the
+          card mirrors how often each path is used: upload a file (primary),
+          record live (secondary), type notes (tertiary). */}
       <div className="bg-surface-base rounded-lg border p-6 space-y-5">
         <div>
           <Heading level={2} className="text-lg font-semibold text-text-primary">Inhalt</Heading>
           <p className="text-sm text-text-secondary mt-1">
-            Lade Audio, Notizen oder Dateien hoch oder tippe direkt hinein.
-            Die KI strukturiert alles in einem Durchgang und ergänzt Titel, Typ
-            und Teilnehmer selbst.
+            Audio, Dateien oder Notizen — die KI strukturiert alles in einem
+            Durchgang und ergänzt Titel, Typ und Teilnehmer selbst.
           </p>
         </div>
 
-        {/* Record + upload sit side-by-side — same data target. The
-            consent gate is browser-side legal (StGB Art. 179bis); audio
-            recorded without it is a CH criminal offence regardless of
-            our app's policy. */}
         <CaptureControls
           sources={sources}
           setSources={setSources}
@@ -79,25 +74,25 @@ export default function ProtocolFormClient({ teamMembers }: ProtocolFormClientPr
           disabled={loading || processing}
         />
 
-        <CaptureAlternatives />
-
         <FormField label="Notizen / Text einfügen (optional)" htmlFor="content">
           <Textarea
             id="content"
             value={content}
             onChange={(e) => setContent(e.target.value)}
             placeholder="Notizen, Stichpunkte oder eine ganze Mitschrift — die KI macht ein Protokoll daraus..."
-            rows={8}
+            rows={6}
             className="font-mono text-sm"
           />
-          <div className="flex items-center justify-between mt-1">
-            {contentFormat ? (
-              <span className={`text-xs px-2 py-0.5 rounded-full ${contentFormat === 'json' ? 'bg-action-muted text-action' : 'bg-surface-raised text-text-secondary'}`}>
-                {contentFormat === 'json' ? 'JSON erkannt' : 'Freitext'}
-              </span>
-            ) : <span />}
-            <span className="text-xs text-text-tertiary">{content.length} Zeichen</span>
-          </div>
+          {(contentFormat === 'json' || hasTypedText) && (
+            <div className="flex items-center justify-between mt-1">
+              {contentFormat === 'json' ? (
+                <span className="text-xs px-2 py-0.5 rounded-full bg-action-muted text-action">
+                  JSON erkannt
+                </span>
+              ) : <span />}
+              <span className="text-xs text-text-tertiary">{content.length} Zeichen</span>
+            </div>
+          )}
         </FormField>
       </div>
 
@@ -154,17 +149,17 @@ export default function ProtocolFormClient({ teamMembers }: ProtocolFormClientPr
               </FormField>
             </div>
 
-            <FormField label="Titel" htmlFor="title">
-              <Input
-                id="title"
-                type="text"
-                value={title}
-                onChange={(e) => setTitle(e.target.value)}
-                placeholder="z.B. Teamsitzung — 2. April 2026"
-              />
-            </FormField>
-
             <div className="grid grid-cols-1 sm:grid-cols-2 gap-4">
+              <FormField label="Titel" htmlFor="title">
+                <Input
+                  id="title"
+                  type="text"
+                  value={title}
+                  onChange={(e) => setTitle(e.target.value)}
+                  placeholder="z.B. Teamsitzung — 2. April 2026"
+                />
+              </FormField>
+
               <FormField label="Sichtbarkeit" htmlFor="visibility">
                 <Select
                   id="visibility"
@@ -238,60 +233,69 @@ export default function ProtocolFormClient({ teamMembers }: ProtocolFormClientPr
         )}
       </div>
 
-      {/* Submit — its own footer so the primary action reads clearly after
-          content + optional details. */}
-      <div className="bg-surface-base rounded-lg border p-6">
-        <div className="flex items-center justify-between gap-4">
-          <div className="text-sm text-text-tertiary flex items-center gap-2">
-            {hasAudio && (
-              <span className="inline-flex items-center gap-1">
-                <Mic className="w-3 h-3" /> Audio
-              </span>
-            )}
-            {(hasTextFiles || hasTypedText) && (
-              <span className="inline-flex items-center gap-1">
-                <FileText className="w-3 h-3" />
-                {hasTextFiles && hasTypedText
-                  ? 'Notizen + Dateien'
-                  : hasTextFiles
-                    ? `${sources.textFiles.length} Datei${sources.textFiles.length === 1 ? '' : 'en'}`
-                    : 'Notizen'}
-              </span>
-            )}
-            {!hasAudio && !hasTextFiles && !hasTypedText && (
-              <span>Quellen hochladen oder Notizen eingeben</span>
-            )}
-          </div>
-          <Button
-            onClick={handleSubmit}
-            disabled={!canSubmit}
-            variant="primary"
-            size="lg"
-            className="flex items-center gap-2"
-          >
-            {(loading || processing) ? (
-              <>
-                <Loader2 className="w-4 h-4 animate-spin" />
-                {processing ? 'KI verarbeitet...' : 'Erstellt...'}
-              </>
-            ) : (
-              <>
-                <Check className="w-4 h-4" />
-                Protokoll erstellen
-              </>
-            )}
-          </Button>
+      {/* Submit — a plain action row, not another card. Content + optional
+          details above; one clear primary action below. */}
+      <div className="flex items-center justify-between gap-4">
+        <div className="text-sm text-text-tertiary flex items-center gap-2">
+          {hasAudio && (
+            <span className="inline-flex items-center gap-1">
+              <Mic className="w-3 h-3" /> Audio
+            </span>
+          )}
+          {(hasTextFiles || hasTypedText) && (
+            <span className="inline-flex items-center gap-1">
+              <FileText className="w-3 h-3" />
+              {hasTextFiles && hasTypedText
+                ? 'Notizen + Dateien'
+                : hasTextFiles
+                  ? `${sources.textFiles.length} Datei${sources.textFiles.length === 1 ? '' : 'en'}`
+                  : 'Notizen'}
+            </span>
+          )}
+          {!hasAudio && !hasTextFiles && !hasTypedText && (
+            <span>Quellen hochladen oder Notizen eingeben</span>
+          )}
         </div>
+        <Button
+          onClick={handleSubmit}
+          disabled={!canSubmit}
+          variant="primary"
+          size="lg"
+          className="flex items-center gap-2"
+        >
+          {(loading || processing) ? (
+            <>
+              <Loader2 className="w-4 h-4 animate-spin" />
+              {processing ? 'KI verarbeitet...' : 'Erstellt...'}
+            </>
+          ) : (
+            <>
+              <Check className="w-4 h-4" />
+              Protokoll erstellen
+            </>
+          )}
+        </Button>
       </div>
+
+      {/* Fallback help (self-record / self-transcribe / self-structure with
+          open-source tools) — reference material, not part of the flow, so it
+          lives at the very bottom as a collapsed disclosure. */}
+      <CaptureAlternatives />
     </div>
   )
 }
 
 /**
- * CaptureControls — record button + upload zone + consent gate.
+ * CaptureControls — upload zone + record button + consent gate.
  *
- * Keeps consent state local (it's UX, not part of the submitted form),
- * persists "remember me" via ProtocolConsent's localStorage handler.
+ * The drop zone leads (most protocols arrive as an existing recording or
+ * notes file); live recording sits directly below it with the consent
+ * checkbox beside the button it gates. The consent gate is browser-side
+ * legal (StGB Art. 179bis): audio recorded without everyone's consent is
+ * a CH criminal offence regardless of our app's policy.
+ *
+ * Consent state stays local (it's UX, not part of the submitted form);
+ * "remember me" persists via ProtocolConsent's localStorage handler.
  */
 interface CaptureControlsProps {
   sources: ReturnType<typeof useProtocolForm>['sources']
@@ -309,20 +313,17 @@ function CaptureControls({ sources, setSources, setError, disabled }: CaptureCon
 
   return (
     <div className="space-y-4">
-      <ProtocolConsent value={consented} onChange={setConsented} />
-
-      <div className="flex flex-wrap items-center gap-3">
-        <RecordButton onRecorded={handleRecorded} disabled={disabled || !consented} />
-        <span className="text-xs text-text-tertiary">oder</span>
-        <span className="text-xs text-text-tertiary">Datei hochladen / Notizen einfügen ↓</span>
-      </div>
-
       <SourceUploader
         value={sources}
         onChange={setSources}
         onError={setError}
         disabled={disabled}
       />
+
+      <div className="flex flex-wrap items-start gap-x-4 gap-y-2">
+        <RecordButton onRecorded={handleRecorded} disabled={disabled || !consented} />
+        <ProtocolConsent value={consented} onChange={setConsented} />
+      </div>
     </div>
   )
 }

--- a/src/db/schema/protocols.ts
+++ b/src/db/schema/protocols.ts
@@ -7,7 +7,8 @@ import { decisions } from './decisions'
 // MEETING PROTOCOLS
 // =============================================================================
 // Meeting minutes with AI-processed structured notes.
-// Final state includes input_method from migration 027.
+// Final state includes input_method from migration 027; all enum CHECKs
+// dropped in migration 134 (values validated via zod from src/config/protocols.ts).
 
 export const meetingProtocols = pgTable('meeting_protocols', {
   id: uuid('id').primaryKey().defaultRandom(),


### PR DESCRIPTION
## What & why

Creating a protocol from an audio recording failed on prod with `Failed query: INSERT INTO meeting_protocols ...` (`input_method='audio'`). Root cause: migration 027b used `ADD COLUMN IF NOT EXISTS input_method ... CHECK (...)` — when the column already existed, Postgres silently skips the whole clause, so the stale CHECK value list (without `'audio'`) survived on prod and rejected every valid audio insert. Migration `134` guarantees the column exists and drops all CHECK constraints on `meeting_protocols` + `protocol_action_links` by catalog lookup — all of them are hand-synced enum lists already validated at the write boundary via zod schemas derived from `src/config/protocols.ts` (same policy as migration 110 for `notifications.type`).

Second part: `/admin/protocols/new` info-hierarchy cleanup — less noise, clearer flow.

## Approach

- **Migration drops by catalog lookup**, not by guessed constraint names, since inline vs `ALTER`-added CHECKs get different names across environments. Verified in a throwaway Postgres 16 in **both** states: fresh from-zero replay (CI drift job path) and the drifted prod state (old CHECK without `'audio'`) — pre-134 reproduces the exact prod error, post-134 the insert succeeds.
- **Form hierarchy now matches usage**: drop zone first, record button with its consent checkbox directly beside it, notes textarea last. The open-source fallback tool lists (`CaptureAlternatives`) move out of the middle of the hero card to a collapsed disclosure at the page bottom. Submit becomes a plain action row instead of a third card, and the format/char-count meta line only renders once there is text.

## Screenshots / recordings

UI change is layout-only reordering of existing components (no new styles); verified via the existing component tests.

## Checklist

- [x] Tests pass locally (protocol suites: 16 suites / 144 tests; `test:i18n` green)
- [x] `npm run lint` clean (0 errors)
- [x] `npm run typecheck` clean
- [x] Swiss German: no ASCII umlauts (`npm run lint:umlauts`); proper `ä/ö/ü`, `ss` (not `ß`)
- [x] No `console.log` — use `logger` from `@/lib/logger`
- [x] No hardcoded table names — use `TABLE_NAMES` from `@/config/database`
- [x] No hardcoded org data — use `@/config/org`
- [x] Parameterized SQL queries only

## Notes for review

- The deploy pipeline auto-applies `134_drop_protocol_enum_checks.sql` to the prod DB before activating the release.
- `protocol_decision_votes` / `protocol_decision_outcomes` CHECKs were left untouched — their writes aren't part of this incident and weren't audited here.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01QXEBWjhBB9JYsgLSX4jNES

---
_Generated by [Claude Code](https://claude.ai/code/session_01QXEBWjhBB9JYsgLSX4jNES)_