### PR TITLE
docs: production URLs — revampit.orangecat.ch is the app, www.revamp-it.ch is legacy Joomla

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -50,6 +50,12 @@ hold the line on all of it by default:
 | Search | Meilisearch |
 | Payments | Payrexx |
 
+## Production URL — don't get this wrong
+
+**This codebase runs at https://revampit.orangecat.ch** (self-hosted Hetzner, deployed from `main` by `deploy-selfhost.yml`). Health check: `https://revampit.orangecat.ch/api/health`. Staff time entry (Zeiterfassung): `/admin/zeiterfassung`.
+
+**https://www.revamp-it.ch is the org's LEGACY Joomla site — not this app.** Never verify deploys or smoke-test there. Full URL list: `docs/SHARED_CONTEXT.md` → Access Points.
+
 ---
 
 ## Design System

--- a/docs/SHARED_CONTEXT.md
+++ b/docs/SHARED_CONTEXT.md
@@ -1,7 +1,7 @@
 ---
 created_date: 2026-01-07
-last_modified_date: 2026-06-19
-last_modified_summary: HR talent lifecycle — /karriere, admin vacancies/applications, hire→team_profiles
+last_modified_date: 2026-07-16
+last_modified_summary: Access Points — production URLs (revampit.orangecat.ch) + legacy-Joomla warning
 ---
 
 # Revamp-IT Shared Context (SSOT)
@@ -52,6 +52,17 @@ last_modified_summary: HR talent lifecycle — /karriere, admin vacancies/applic
 ---
 
 ## Access Points
+
+### Production (this codebase)
+
+- **App**: https://revampit.orangecat.ch — self-hosted on the Hetzner box, deployed from `main` via `deploy-selfhost.yml` (systemd `revampit-app`)
+- **Health**: https://revampit.orangecat.ch/api/health (DB + Meilisearch status)
+- **Admin**: https://revampit.orangecat.ch/admin
+- **Zeiterfassung (staff time entry)**: https://revampit.orangecat.ch/admin/zeiterfassung (same shared `TimecardsClient` also at `/dashboard/timecards`)
+
+⚠️ **https://www.revamp-it.ch is NOT this codebase** — that is the organization's legacy Joomla site. Never smoke-test or verify deploys there.
+
+### Local dev
 
 - **Frontend**: http://localhost:3000
 - **Admin Dashboard**: http://localhost:3000/admin


### PR DESCRIPTION
## What & why

A deploy-verification session wasted time probing `www.revamp-it.ch` (the org's old Joomla site) because no doc states where this codebase actually runs. This documents the production access points so agents and contributors verify deploys in the right place.

- **CLAUDE.md** (loaded by every agent session): new "Production URL — don't get this wrong" section — app URL, health endpoint, Zeiterfassung route, and an explicit warning that `www.revamp-it.ch` is the legacy Joomla site.
- **docs/SHARED_CONTEXT.md** → Access Points: split into Production (https://revampit.orangecat.ch, `/api/health`, `/admin`, `/admin/zeiterfassung`) and Local dev; frontmatter bumped.

## Approach

Docs-only; no code changes.

## Screenshots / recordings

n/a (docs)

## Checklist

- [x] Tests pass locally (`npm test`) — unaffected (docs-only)
- [x] `npm run lint` clean — unaffected
- [x] `npm run typecheck` clean — unaffected
- [x] Swiss German: no ASCII umlauts — no German prose added
- [x] No `console.log`
- [x] No hardcoded table names
- [x] No hardcoded org data — URLs documented here are the docs' subject matter
- [x] Parameterized SQL queries only — n/a

## Notes for review

None — follow-up to #215.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01XsjbuSCDfeGYomVXioPpek

---
_Generated by [Claude Code](https://claude.ai/code/session_01XsjbuSCDfeGYomVXioPpek)_