### PR TITLE
feat(protocols/tasks): manual task add, clearer people mapping, AI task help

### DIFF
--- a/src/app/admin/protocols/[id]/ProtocolDetailClient.tsx
+++ b/src/app/admin/protocols/[id]/ProtocolDetailClient.tsx
@@ -74,6 +74,8 @@ export default function ProtocolDetailClient(props: ProtocolDetailProps) {
     bulkCreatingTasks,
     bulkTaskErrors,
     handleCreateAllTasks,
+    addingCustomTask,
+    handleAddCustomTask,
     finalizing,
     showFinalizeDialog,
     setShowFinalizeDialog,
@@ -224,13 +226,16 @@ export default function ProtocolDetailClient(props: ProtocolDetailProps) {
                 <div className="flex-1 min-w-0">
                   <h3 className="text-sm font-semibold mb-1 text-text-primary">
                     {allMapped
-                      ? 'Alle Personen zugeordnet'
-                      : `Erkannte Personen (${unmappedAttendees.length} noch offen)`
+                      ? 'Wer war dabei? — alle zugeordnet'
+                      : `Wer war dabei? (${unmappedAttendees.length} ${unmappedAttendees.length === 1 ? 'Name' : 'Namen'} noch offen)`
                     }
                   </h3>
                   {!allMapped && (
                     <p className="text-xs text-text-tertiary mb-3">
-                      Optional. Zuordnung erlaubt automatische Aufgaben­zuweisung; sonst manuell.
+                      Die KI hat diese Namen im Gespräch gehört. Wähle das passende
+                      Team-Konto: die Person wird als Teilnehmer gespeichert und ihre
+                      Aufgaben werden ihr direkt zugewiesen. Unklare Namen kannst du
+                      offen lassen.
                     </p>
                   )}
                   <div className="space-y-2">
@@ -294,8 +299,11 @@ export default function ProtocolDetailClient(props: ProtocolDetailProps) {
             protocolDecisions={protocolDecisions}
             currentUserId={currentUserId}
             isProtocolCreator={isProtocolCreator}
+            teamMembers={teamMembers}
+            addingCustomTask={addingCustomTask}
             onCreateTask={handleCreateTask}
             onCreateAllTasks={handleCreateAllTasks}
+            onAddCustomTask={handleAddCustomTask}
             onRefresh={() => router.refresh()}
           />
 

--- a/src/app/admin/protocols/[id]/__tests__/ProtocolDetailClient.test.tsx
+++ b/src/app/admin/protocols/[id]/__tests__/ProtocolDetailClient.test.tsx
@@ -178,6 +178,8 @@ describe('ProtocolDetailClient', () => {
     )
 
     expect(screen.getByText('Keine Aktionen erkannt')).toBeInTheDocument()
-    expect(screen.getByText(/Überarbeite den Inhalt oben/i)).toBeInTheDocument()
+    // Empty state is actionable: manual add is offered alongside reprocessing.
+    expect(screen.getByText(/Ergänze Aufgaben unten von Hand/i)).toBeInTheDocument()
+    expect(screen.getByRole('button', { name: /Aufgabe ergänzen/i })).toBeInTheDocument()
   })
 })

--- a/src/app/admin/tasks/[id]/TaskAIChat.tsx
+++ b/src/app/admin/tasks/[id]/TaskAIChat.tsx
@@ -1,0 +1,47 @@
+'use client'
+
+import { AIAdvisorChat } from '@/components/ai/AIAdvisorChat'
+
+/**
+ * TaskAIChat — "ask the AI for help" on a task, complementing the human
+ * "Um Hilfe bitten" flow in TaskActionsClient. Practical help: how to
+ * proceed, break the work down, spot blockers, draft a message.
+ */
+interface TaskAIChatProps {
+  title: string
+  description: string | null
+  instructions: string | null
+  status: string
+  priority: string
+  dueDate: string | null
+  protocolTitle: string | null
+}
+
+const QUICK_QUESTIONS = [
+  { label: 'Wie gehe ich vor?', question: 'Wie gehe ich bei dieser Aufgabe am besten vor? Gib mir konkrete Schritte.' },
+  { label: 'In Schritte zerlegen', question: 'Zerlege diese Aufgabe in kleine, abhakbare Teilschritte.' },
+  { label: 'Was könnte blockieren?', question: 'Welche Hindernisse oder offenen Fragen könnten diese Aufgabe blockieren, und wie räume ich sie aus?' },
+  { label: 'Nachricht entwerfen', question: 'Entwirf eine kurze Nachricht an das Team, mit der ich für diese Aufgabe um Unterstützung bitte.' },
+]
+
+export function TaskAIChat(props: TaskAIChatProps) {
+  return (
+    <AIAdvisorChat
+      heading="KI um Hilfe bitten — Frag die KI zu dieser Aufgabe"
+      endpoint="/api/ai/task-advisor"
+      quickQuestions={QUICK_QUESTIONS}
+      placeholder="Stelle eine eigene Frage zu dieser Aufgabe..."
+      hint="Die KI kennt nur Titel, Beschreibung und Anleitung dieser Aufgabe — prüfe Vorschläge, bevor du sie umsetzt."
+      buildBody={(question) => ({
+        title: props.title,
+        description: props.description,
+        instructions: props.instructions,
+        status: props.status,
+        priority: props.priority,
+        dueDate: props.dueDate,
+        protocolTitle: props.protocolTitle,
+        question,
+      })}
+    />
+  )
+}

--- a/src/app/admin/tasks/[id]/page.tsx
+++ b/src/app/admin/tasks/[id]/page.tsx
@@ -40,6 +40,7 @@ import {
   FileText,
 } from 'lucide-react'
 import TaskActionsClient from './TaskActionsClient'
+import { TaskAIChat } from './TaskAIChat'
 import { TaskRequestResponseButtons } from './TaskRequestResponseButtons'
 import Heading from '@/components/admin/AdminHeading'
 import { ROUTES } from '@/config/routes'
@@ -326,6 +327,17 @@ export default async function TaskDetailPage({
 
           {/* Actions */}
           <TaskActionsClient taskId={task.id} taskTitle={task.title} isArchived={task.is_archived} />
+
+          {/* AI helper — complements "Um Hilfe bitten": teammates OR the AI */}
+          <TaskAIChat
+            title={task.title}
+            description={task.description}
+            instructions={task.instructions}
+            status={TASK_STATUS_LABELS[task.current_status] || task.current_status}
+            priority={TASK_PRIORITY_LABELS[task.priority] || task.priority}
+            dueDate={task.due_date ? formatDateShort(task.due_date) : null}
+            protocolTitle={protocolSource?.protocolTitle ?? null}
+          />
 
           {/* Completion History */}
           <div className="bg-surface-base rounded-lg border p-6">

--- a/src/app/api/ai/task-advisor/route.ts
+++ b/src/app/api/ai/task-advisor/route.ts
@@ -1,0 +1,94 @@
+/**
+ * Task Advisor API
+ *
+ * POST /api/ai/task-advisor
+ *
+ * "Ask the AI for help" on a task: unlike the protocol advisor (which stays
+ * strictly within the document), this one gives PRACTICAL help — how to
+ * approach the task, break it into steps, spot blockers, draft messages.
+ *
+ * Auth required — staff only.
+ */
+
+import { NextRequest, NextResponse } from 'next/server'
+import { z } from 'zod'
+import { auth } from '@/auth'
+import { logger } from '@/lib/logger'
+import { callWithFallback } from '@/lib/ai/providers'
+import { apiSuccess, apiError, apiBadRequest, apiUnauthorized } from '@/lib/api/helpers'
+import { ERROR_MESSAGES } from '@/config/error-messages'
+
+const requestSchema = z.object({
+  title: z.string().min(1).max(300),
+  description: z.string().max(4000).nullable().optional(),
+  instructions: z.string().max(4000).nullable().optional(),
+  status: z.string().max(50).optional(),
+  priority: z.string().max(50).optional(),
+  dueDate: z.string().max(50).nullable().optional(),
+  protocolTitle: z.string().max(300).nullable().optional(),
+  question: z.string().min(1).max(500),
+})
+
+const SYSTEM_PROMPT = `Du bist ein praktischer Assistent für Aufgaben bei RevampIT
+(Schweizer Non-Profit: gebrauchte Computer reparieren und weitergeben).
+Du hilfst Teammitgliedern, ihre Aufgaben tatsächlich zu erledigen.
+
+Regeln:
+- Antworte praktisch und konkret auf Deutsch (Schweizer Schreibweise, ss statt ß)
+- Gib umsetzbare Schritte, keine Allgemeinplätze
+- Wenn dir Kontext fehlt, sage was du wissen müsstest — erfinde nichts
+- Halte Antworten unter 250 Wörtern — knapp und klar`
+
+export async function POST(request: NextRequest) {
+  try {
+    const session = await auth()
+    if (!session?.user?.email) return apiUnauthorized()
+
+    let body: unknown
+    try {
+      body = await request.json()
+    } catch {
+      return apiBadRequest('Ungültiger JSON-Body')
+    }
+
+    const parsed = requestSchema.safeParse(body)
+    if (!parsed.success) {
+      return apiBadRequest(ERROR_MESSAGES.INVALID_REQUEST, parsed.error.flatten().fieldErrors)
+    }
+
+    const { title, description, instructions, status, priority, dueDate, protocolTitle, question } = parsed.data
+
+    const userPrompt = `AUFGABE: ${title}
+
+BESCHREIBUNG:
+${description || '(Keine Beschreibung)'}
+${instructions ? `\nANLEITUNG:\n${instructions}` : ''}
+STATUS: ${status || 'unbekannt'} · PRIORITÄT: ${priority || 'normal'}${dueDate ? ` · FÄLLIG: ${dueDate}` : ''}${protocolTitle ? `\nSTAMMT AUS PROTOKOLL: ${protocolTitle}` : ''}
+
+FRAGE:
+${question}
+
+Hilf konkret weiter. Knapp und klar, unter 250 Wörtern.`
+
+    logger.info('Task advisor requested', { questionLength: question.length })
+
+    const result = await callWithFallback({
+      systemPrompt: SYSTEM_PROMPT,
+      userPrompt,
+      maxTokens: 500,
+      temperature: 0.3,
+      timeoutMs: 10_000,
+    })
+
+    if (!result) {
+      return NextResponse.json(
+        { success: false, error: 'KI-Dienst vorübergehend nicht verfügbar. Bitte versuche es später erneut.' },
+        { status: 503 }
+      )
+    }
+
+    return apiSuccess({ analysis: result.text })
+  } catch (error) {
+    return apiError(error, 'Fehler beim Erstellen der Analyse')
+  }
+}

--- a/src/components/admin/protocols/ProtocolAIChat.tsx
+++ b/src/components/admin/protocols/ProtocolAIChat.tsx
@@ -1,10 +1,6 @@
 'use client'
 
-import { useState } from 'react'
-import { Sparkles, Loader2, AlertCircle, ChevronDown, ChevronUp, Send } from 'lucide-react'
-import { apiFetch } from '@/lib/api/client'
-import { Textarea } from '@/components/ui/textarea'
-import { Button } from '@/components/ui/button'
+import { AIAdvisorChat } from '@/components/ai/AIAdvisorChat'
 import type { StructuredNotes } from '@/lib/schemas/protocols'
 
 interface ProtocolAIChatProps {
@@ -21,21 +17,15 @@ const QUICK_QUESTIONS = [
 ]
 
 export function ProtocolAIChat({ title, notes, defaultExpanded = false }: ProtocolAIChatProps) {
-  const [expanded, setExpanded] = useState(defaultExpanded)
-  const [question, setQuestion] = useState('')
-  const [loading, setLoading] = useState(false)
-  const [error, setError] = useState('')
-  const [analysis, setAnalysis] = useState('')
-
-  async function ask(q: string) {
-    if (!q.trim() || loading) return
-    setLoading(true)
-    setError('')
-    setAnalysis('')
-
-    const result = await apiFetch<{ analysis: string }>('/api/ai/protocol-advisor', {
-      method: 'POST',
-      body: {
+  return (
+    <AIAdvisorChat
+      heading="KI-Assistent — Frag die KI zu diesem Protokoll"
+      endpoint="/api/ai/protocol-advisor"
+      quickQuestions={QUICK_QUESTIONS}
+      placeholder="Stelle eine eigene Frage zu diesem Protokoll..."
+      hint="Die KI antwortet basierend auf dem Protokollinhalt — prüfe wichtige Punkte immer im Protokoll selbst."
+      defaultExpanded={defaultExpanded}
+      buildBody={(question) => ({
         title,
         summary: notes.summary,
         topics: notes.topics?.map(t => ({
@@ -48,110 +38,8 @@ export function ProtocolAIChat({ title, notes, defaultExpanded = false }: Protoc
           assigned_to_name: a.assigned_to_name,
           item_type: a.item_type,
         })),
-        question: q.trim(),
-      },
-    })
-
-    if (!result.success || !result.data) {
-      setError(result.error || 'Fehler bei der KI-Analyse')
-    } else {
-      setAnalysis(result.data.analysis)
-      setQuestion('')
-    }
-    setLoading(false)
-  }
-
-  function handleKeyDown(e: React.KeyboardEvent<HTMLTextAreaElement>) {
-    if (e.key === 'Enter' && !e.shiftKey) {
-      e.preventDefault()
-      ask(question)
-    }
-  }
-
-  return (
-    <div className="rounded-lg border border-info-200 bg-info-50 dark:border-info-500/20 dark:bg-info-500/6">
-      <Button
-        type="button"
-        onClick={() => setExpanded(!expanded)}
-        variant="ghost"
-        className="w-full flex items-center justify-between px-4 py-3 text-left"
-        aria-expanded={expanded}
-      >
-        <span className="flex items-center gap-2 text-sm font-semibold text-info-900 dark:text-info-200">
-          <Sparkles className="w-4 h-4 text-info-600 dark:text-info-400 shrink-0" />
-          KI-Assistent — Frag die KI zu diesem Protokoll
-        </span>
-        {expanded
-          ? <ChevronUp className="w-4 h-4 text-info-500 shrink-0" />
-          : <ChevronDown className="w-4 h-4 text-info-500 shrink-0" />
-        }
-      </Button>
-
-      {expanded && (
-        <div className="px-4 pb-4 space-y-3">
-          <div className="flex flex-wrap gap-1.5">
-            {QUICK_QUESTIONS.map((q) => (
-              <Button
-                key={q.label}
-                type="button"
-                onClick={() => ask(q.question)}
-                disabled={loading}
-                variant="ghost"
-                size="sm"
-                className="px-2.5 py-1.5 rounded-full bg-info-100 dark:bg-info-500/12 text-info-700 dark:text-info-300 text-xs font-medium hover:bg-info-200 dark:hover:bg-info-500/18 disabled:opacity-50 transition-colors touch-manipulation"
-              >
-                {q.label}
-              </Button>
-            ))}
-          </div>
-
-          <div className="flex gap-2">
-            <Textarea
-              value={question}
-              onChange={(e) => setQuestion(e.target.value)}
-              onKeyDown={handleKeyDown}
-              placeholder="Stelle eine eigene Frage zu diesem Protokoll..."
-              rows={2}
-              disabled={loading}
-              className="flex-1 resize-none"
-            />
-            <Button
-              type="button"
-              onClick={() => ask(question)}
-              disabled={loading || !question.trim()}
-              variant="primary"
-              className="px-3 py-2 bg-info-600 hover:bg-info-700 disabled:bg-info-300 dark:disabled:bg-info-500/30 text-white rounded-lg transition-colors self-end touch-manipulation"
-              aria-label="Frage stellen"
-            >
-              {loading
-                ? <Loader2 className="w-4 h-4 animate-spin" />
-                : <Send className="w-4 h-4" />
-              }
-            </Button>
-          </div>
-
-          {error && (
-            <div className="flex items-start gap-2 bg-error-50 dark:bg-error-900/20 border border-error-200 dark:border-error-800 text-error-700 dark:text-error-400 px-3 py-2 rounded-lg text-sm">
-              <AlertCircle className="w-4 h-4 shrink-0 mt-0.5" />
-              <span>{error}</span>
-            </div>
-          )}
-
-          {analysis && (
-            <div className="bg-surface-base border border-info-200 dark:border-info-500/20 rounded-lg px-4 py-3 text-sm text-text-primary whitespace-pre-wrap leading-relaxed">
-              <div className="flex items-center gap-1.5 text-xs text-info-600 dark:text-info-400 font-medium mb-2">
-                <Sparkles className="w-3 h-3" />
-                KI-Antwort
-              </div>
-              {analysis}
-            </div>
-          )}
-
-          <p className="text-xs text-info-500 dark:text-info-400/70">
-            Die KI antwortet basierend auf dem Protokollinhalt — prüfe wichtige Punkte immer im Protokoll selbst.
-          </p>
-        </div>
-      )}
-    </div>
+        question,
+      })}
+    />
   )
 }

--- a/src/components/admin/protocols/ProtocolActionItemsList.tsx
+++ b/src/components/admin/protocols/ProtocolActionItemsList.tsx
@@ -1,3 +1,6 @@
+'use client'
+
+import { useState } from 'react'
 import { Link } from '@/i18n/navigation'
 import {
   Loader2,
@@ -7,8 +10,11 @@ import {
   Vote,
   HelpCircle,
   Sparkles,
+  Plus,
 } from 'lucide-react'
 import { Button } from '@/components/ui/button'
+import { Input } from '@/components/ui/input'
+import { Select } from '@/components/ui/select'
 import {
   PRIORITY_HINT_LABELS,
   ACTION_ITEM_TYPE_LABELS,
@@ -36,8 +42,12 @@ interface Props {
   protocolDecisions: ProtocolDecisionSummary[]
   currentUserId: string
   isProtocolCreator: boolean
+  /** For the manual add-task assignee select. */
+  teamMembers: Array<{ id: string; name: string }>
+  addingCustomTask: boolean
   onCreateTask: (actionItem: StructuredNotes['action_items'][0]) => void
   onCreateAllTasks: () => void
+  onAddCustomTask: (description: string, assignee: { id: string; name: string } | null) => Promise<boolean>
   onRefresh: () => void
 }
 
@@ -78,8 +88,11 @@ export function ProtocolActionItemsList({
   protocolDecisions,
   currentUserId,
   isProtocolCreator,
+  teamMembers,
+  addingCustomTask,
   onCreateTask,
   onCreateAllTasks,
+  onAddCustomTask,
   onRefresh,
 }: Props) {
   // Quick lookup: actionItemId → linked standalone decision (if any).
@@ -90,13 +103,25 @@ export function ProtocolActionItemsList({
   // show which structured-note topic it came from (raw → notes → item chain).
   const topicTitleById = new Map((notes.topics ?? []).map((t) => [t.id, t.title]))
 
+  const canAct = isReview || isFinalized
+
   if (!notes.action_items || notes.action_items.length === 0) {
     return (
-      <div className="bg-surface-raised border border-default rounded-lg p-4">
-        <h3 className="text-sm font-semibold text-text-primary mb-1">Keine Aktionen erkannt</h3>
-        <p className="text-sm text-text-secondary">
-          Die KI hat keine konkreten Aufgaben oder Entscheidungen extrahiert. Überarbeite den Inhalt oben und starte die Verarbeitung erneut.
-        </p>
+      <div className="bg-surface-raised border border-default rounded-lg p-4 space-y-3">
+        <div>
+          <h3 className="text-sm font-semibold text-text-primary mb-1">Keine Aktionen erkannt</h3>
+          <p className="text-sm text-text-secondary">
+            Die KI hat keine konkreten Aufgaben oder Entscheidungen extrahiert.
+            Ergänze Aufgaben unten von Hand oder überarbeite den Inhalt und starte die Verarbeitung erneut.
+          </p>
+        </div>
+        {isReview && (
+          <AddCustomTaskRow
+            teamMembers={teamMembers}
+            adding={addingCustomTask}
+            onAdd={onAddCustomTask}
+          />
+        )}
       </div>
     )
   }
@@ -108,8 +133,6 @@ export function ProtocolActionItemsList({
     const linked = decisionsByActionItem.get(d.id)
     return !linked || !linked.isClosed
   }).length
-
-  const canAct = isReview || isFinalized
 
   return (
     <div className="bg-surface-base rounded-lg border border-default overflow-hidden">
@@ -262,6 +285,107 @@ export function ProtocolActionItemsList({
           </div>
         </div>
       )}
+
+      {/* Manual add — the AI doesn't catch everything. Anything discussed in
+          the meeting can be added as a task here, with the same link
+          mechanics and provenance as the recognized items. */}
+      {isReview && (
+        <div className="border-t border-subtle px-4 py-3">
+          <AddCustomTaskRow
+            teamMembers={teamMembers}
+            adding={addingCustomTask}
+            onAdd={onAddCustomTask}
+          />
+        </div>
+      )}
+    </div>
+  )
+}
+
+// =============================================================================
+// AddCustomTaskRow — manual "the AI missed this" task entry
+// =============================================================================
+
+interface AddCustomTaskRowProps {
+  teamMembers: Array<{ id: string; name: string }>
+  adding: boolean
+  onAdd: (description: string, assignee: { id: string; name: string } | null) => Promise<boolean>
+}
+
+function AddCustomTaskRow({ teamMembers, adding, onAdd }: AddCustomTaskRowProps) {
+  const [open, setOpen] = useState(false)
+  const [description, setDescription] = useState('')
+  const [assigneeId, setAssigneeId] = useState('')
+
+  const submit = async () => {
+    const member = teamMembers.find((m) => m.id === assigneeId)
+    const ok = await onAdd(description, member ? { id: member.id, name: member.name } : null)
+    if (ok) {
+      setDescription('')
+      setAssigneeId('')
+      setOpen(false)
+    }
+  }
+
+  if (!open) {
+    return (
+      <Button
+        variant="ghost"
+        size="sm"
+        onClick={() => setOpen(true)}
+        className="inline-flex items-center gap-1.5 text-sm text-action hover:text-action h-auto px-0 bg-transparent hover:bg-transparent"
+      >
+        <Plus className="w-4 h-4" />
+        Aufgabe ergänzen — etwas wurde nicht erkannt?
+      </Button>
+    )
+  }
+
+  return (
+    <div className="space-y-2">
+      <div className="flex flex-col sm:flex-row gap-2">
+        <Input
+          value={description}
+          onChange={(e) => setDescription(e.target.value)}
+          onKeyDown={(e) => {
+            if (e.key === 'Enter' && description.trim() && !adding) submit()
+          }}
+          placeholder="Was ist zu tun?"
+          className="flex-1"
+          autoFocus
+        />
+        <Select
+          value={assigneeId}
+          onChange={(e) => setAssigneeId(e.target.value)}
+          className="sm:w-48"
+          aria-label="Zuständige Person"
+        >
+          <option value="">— Niemand zugewiesen —</option>
+          {teamMembers.map((m) => (
+            <option key={m.id} value={m.id}>{m.name}</option>
+          ))}
+        </Select>
+      </div>
+      <div className="flex items-center gap-2">
+        <Button
+          variant="primary"
+          size="sm"
+          onClick={submit}
+          disabled={adding || !description.trim()}
+          className="gap-1.5"
+        >
+          {adding ? <Loader2 className="w-3.5 h-3.5 animate-spin" /> : <Plus className="w-3.5 h-3.5" />}
+          Aufgabe erstellen
+        </Button>
+        <Button
+          variant="ghost"
+          size="sm"
+          onClick={() => setOpen(false)}
+          className="text-text-tertiary"
+        >
+          Abbrechen
+        </Button>
+      </div>
     </div>
   )
 }

--- a/src/components/admin/protocols/ProtocolAttendeesCard.tsx
+++ b/src/components/admin/protocols/ProtocolAttendeesCard.tsx
@@ -110,7 +110,11 @@ export function ProtocolAttendeesCard({
                   {attendeeNames[uid] || 'Unbekannt'}
                 </span>
               ))
-            : <p className="text-xs text-text-muted">Keine Teilnehmer eingetragen</p>
+            : (
+              <p className="text-xs text-text-muted">
+                Keine Teilnehmer eingetragen{isReview ? ' — Personen, die du unter «Wer war dabei?» zuordnest, erscheinen hier automatisch.' : ''}
+              </p>
+            )
           }
         </div>
       )}

--- a/src/components/admin/protocols/useProtocolDetail.ts
+++ b/src/components/admin/protocols/useProtocolDetail.ts
@@ -76,9 +76,14 @@ export function useProtocolDetail({ protocol, actionLinks, initialProcessingErro
         }),
       }
 
+      // Mapped people ARE the meeting's attendees — one save keeps both in
+      // sync, so nobody has to maintain a second "Teilnehmer" list by hand.
+      const mappedIds = Object.values(attendeeMapping).filter(Boolean)
+      const attendees = Array.from(new Set([...(protocol.attendees || []), ...mappedIds]))
+
       const result = await apiFetch<void>(`/api/protocols/${protocol.id}`, {
         method: 'PATCH',
-        body: { structured_notes: updatedNotes },
+        body: { structured_notes: updatedNotes, attendees },
       })
       if (!result.success) throw new Error(result.error || 'Fehler beim Speichern')
       setMappingDirty(false)
@@ -190,6 +195,71 @@ export function useProtocolDetail({ protocol, actionLinks, initialProcessingErro
       setError(getErrorMessage(err))
     } finally {
       setCreatingTask(null)
+    }
+  }
+
+  /**
+   * Add a task the AI did NOT recognize from the transcript.
+   *
+   * Two steps so the protocol stays the SSOT: the new item is first
+   * appended to structured_notes.action_items (provenance: it belongs to
+   * this meeting), then created + linked as a real task via the same
+   * /actions endpoint the recognized items use.
+   */
+  const [addingCustomTask, setAddingCustomTask] = useState(false)
+  const handleAddCustomTask = async (
+    description: string,
+    assignee: { id: string; name: string } | null,
+  ): Promise<boolean> => {
+    const trimmed = description.trim()
+    if (!trimmed || !notes) return false
+    setAddingCustomTask(true)
+    setError(null)
+
+    try {
+      const newItem: StructuredNotes['action_items'][0] = {
+        id: `custom-${crypto.randomUUID()}`,
+        description: trimmed,
+        assigned_to_name: assignee?.name ?? null,
+        assigned_to_id: assignee?.id ?? null,
+        due_hint: null,
+        item_type: 'task',
+        topic_id: null,
+        priority_hint: null,
+      }
+
+      const patchResult = await apiFetch<void>(`/api/protocols/${protocol.id}`, {
+        method: 'PATCH',
+        body: {
+          structured_notes: { ...notes, action_items: [...notes.action_items, newItem] },
+        },
+      })
+      if (!patchResult.success) throw new Error(patchResult.error || 'Fehler beim Speichern')
+
+      const linkResult = await apiFetch<void>(`/api/protocols/${protocol.id}/actions`, {
+        method: 'POST',
+        body: {
+          action_item_id: newItem.id,
+          link_type: 'task',
+          task_data: {
+            title: trimmed,
+            description: `Aus Protokoll: ${protocol.title} (${formatDateShort(protocol.meeting_date)}) — manuell ergänzt`,
+            task_type: 'one_time',
+            category: 'admin',
+            priority: TASK_PRIORITIES.NORMAL,
+            assigned_to: assignee?.id ?? null,
+          },
+        },
+      })
+      if (!linkResult.success) throw new Error(linkResult.error || 'Fehler beim Erstellen der Aufgabe')
+
+      router.refresh()
+      return true
+    } catch (err) {
+      setError(getErrorMessage(err))
+      return false
+    } finally {
+      setAddingCustomTask(false)
     }
   }
 
@@ -312,6 +382,8 @@ export function useProtocolDetail({ protocol, actionLinks, initialProcessingErro
     bulkCreatingTasks,
     bulkTaskErrors,
     handleCreateAllTasks,
+    addingCustomTask,
+    handleAddCustomTask,
     // Finalize
     finalizing,
     showFinalizeDialog,

--- a/src/components/ai/AIAdvisorChat.tsx
+++ b/src/components/ai/AIAdvisorChat.tsx
@@ -1,0 +1,165 @@
+'use client'
+
+/**
+ * AIAdvisorChat — shared collapsed "ask the AI about this thing" card.
+ *
+ * One component for every advisor surface (protocols, tasks, …): quick
+ * question chips, a free-text question, one answer at a time. The caller
+ * provides the endpoint and the context body; the endpoint returns
+ * { analysis: string } (see /api/ai/protocol-advisor, /api/ai/task-advisor).
+ */
+
+import { useState } from 'react'
+import { Sparkles, Loader2, AlertCircle, ChevronDown, ChevronUp, Send } from 'lucide-react'
+import { apiFetch } from '@/lib/api/client'
+import { Textarea } from '@/components/ui/textarea'
+import { Button } from '@/components/ui/button'
+
+export interface AIQuickQuestion {
+  label: string
+  question: string
+}
+
+interface AIAdvisorChatProps {
+  /** Header line, e.g. "KI-Assistent — Frag die KI zu diesem Protokoll". */
+  heading: string
+  /** POST endpoint returning { analysis: string }. */
+  endpoint: string
+  /** Context fields merged into the request body alongside { question }. */
+  buildBody: (question: string) => Record<string, unknown>
+  quickQuestions: AIQuickQuestion[]
+  placeholder: string
+  /** Small-print reminder under the answer area. */
+  hint: string
+  defaultExpanded?: boolean
+}
+
+export function AIAdvisorChat({
+  heading,
+  endpoint,
+  buildBody,
+  quickQuestions,
+  placeholder,
+  hint,
+  defaultExpanded = false,
+}: AIAdvisorChatProps) {
+  const [expanded, setExpanded] = useState(defaultExpanded)
+  const [question, setQuestion] = useState('')
+  const [loading, setLoading] = useState(false)
+  const [error, setError] = useState('')
+  const [analysis, setAnalysis] = useState('')
+
+  async function ask(q: string) {
+    if (!q.trim() || loading) return
+    setLoading(true)
+    setError('')
+    setAnalysis('')
+
+    const result = await apiFetch<{ analysis: string }>(endpoint, {
+      method: 'POST',
+      body: buildBody(q.trim()),
+    })
+
+    if (!result.success || !result.data) {
+      setError(result.error || 'Fehler bei der KI-Analyse')
+    } else {
+      setAnalysis(result.data.analysis)
+      setQuestion('')
+    }
+    setLoading(false)
+  }
+
+  function handleKeyDown(e: React.KeyboardEvent<HTMLTextAreaElement>) {
+    if (e.key === 'Enter' && !e.shiftKey) {
+      e.preventDefault()
+      ask(question)
+    }
+  }
+
+  return (
+    <div className="rounded-lg border border-info-200 bg-info-50 dark:border-info-500/20 dark:bg-info-500/6">
+      <Button
+        type="button"
+        onClick={() => setExpanded(!expanded)}
+        variant="ghost"
+        className="w-full flex items-center justify-between px-4 py-3 text-left"
+        aria-expanded={expanded}
+      >
+        <span className="flex items-center gap-2 text-sm font-semibold text-info-900 dark:text-info-200">
+          <Sparkles className="w-4 h-4 text-info-600 dark:text-info-400 shrink-0" />
+          {heading}
+        </span>
+        {expanded
+          ? <ChevronUp className="w-4 h-4 text-info-500 shrink-0" />
+          : <ChevronDown className="w-4 h-4 text-info-500 shrink-0" />
+        }
+      </Button>
+
+      {expanded && (
+        <div className="px-4 pb-4 space-y-3">
+          <div className="flex flex-wrap gap-1.5">
+            {quickQuestions.map((q) => (
+              <Button
+                key={q.label}
+                type="button"
+                onClick={() => ask(q.question)}
+                disabled={loading}
+                variant="ghost"
+                size="sm"
+                className="px-2.5 py-1.5 rounded-full bg-info-100 dark:bg-info-500/12 text-info-700 dark:text-info-300 text-xs font-medium hover:bg-info-200 dark:hover:bg-info-500/18 disabled:opacity-50 transition-colors touch-manipulation"
+              >
+                {q.label}
+              </Button>
+            ))}
+          </div>
+
+          <div className="flex gap-2">
+            <Textarea
+              value={question}
+              onChange={(e) => setQuestion(e.target.value)}
+              onKeyDown={handleKeyDown}
+              placeholder={placeholder}
+              rows={2}
+              disabled={loading}
+              className="flex-1 resize-none"
+            />
+            <Button
+              type="button"
+              onClick={() => ask(question)}
+              disabled={loading || !question.trim()}
+              variant="primary"
+              className="px-3 py-2 bg-info-600 hover:bg-info-700 disabled:bg-info-300 dark:disabled:bg-info-500/30 text-white rounded-lg transition-colors self-end touch-manipulation"
+              aria-label="Frage stellen"
+            >
+              {loading
+                ? <Loader2 className="w-4 h-4 animate-spin" />
+                : <Send className="w-4 h-4" />
+              }
+            </Button>
+          </div>
+
+          {error && (
+            <div className="flex items-start gap-2 bg-error-50 dark:bg-error-900/20 border border-error-200 dark:border-error-800 text-error-700 dark:text-error-400 px-3 py-2 rounded-lg text-sm">
+              <AlertCircle className="w-4 h-4 shrink-0 mt-0.5" />
+              <span>{error}</span>
+            </div>
+          )}
+
+          {analysis && (
+            <div className="bg-surface-base border border-info-200 dark:border-info-500/20 rounded-lg px-4 py-3 text-sm text-text-primary whitespace-pre-wrap leading-relaxed">
+              <div className="flex items-center gap-1.5 text-xs text-info-600 dark:text-info-400 font-medium mb-2">
+                <Sparkles className="w-3 h-3" />
+                KI-Antwort
+              </div>
+              {analysis}
+            </div>
+          )}
+
+          <p className="text-xs text-info-500 dark:text-info-400/70">
+            {hint}
+          </p>
+        </div>
+      )}
+    </div>
+  )
+}


### PR DESCRIPTION
## What & why

Three staff-reported gaps in the protocol → tasks flow:

1. **The people element made no sense** — the "Erkannte Personen" mapping (main column) and the sidebar "Teilnehmer (0)" card read as two competing attendee editors. They are now one concept: the card asks **"Wer war dabei?"**, explains in plain words what mapping does, and saving a mapping also stores the mapped people as the protocol's **attendees** — the sidebar card fills automatically and says so when empty.
2. **The AI doesn't catch every task** — new **"Aufgabe ergänzen"** row in *Aktionen & Entscheidungen* (and in the empty state) lets staff add tasks the transcript missed, with an optional assignee. The item is appended to `structured_notes` (same provenance as recognized items) and created + linked through the same `/actions` endpoint.
3. **Help on a task was humans-only** — new **"KI um Hilfe bitten"** card on `/admin/tasks/[id]` alongside "Um Hilfe bitten": quick prompts (Vorgehen, Teilschritte, Blocker, Nachricht entwerfen) plus free questions, backed by a new `/api/ai/task-advisor` route (practical-help prompt, existing provider cascade Groq → OpenRouter → Ollama).

## Approach

- `AIAdvisorChat` extracted as a shared component; `ProtocolAIChat` and the new `TaskAIChat` are thin wrappers instead of duplicated chat UIs.
- Custom tasks keep the protocol as SSOT: PATCH `structured_notes` first, then the standard create+link call — no parallel task-creation path.
- Attendee sync is a union merge (existing attendees + newly mapped users) in the existing save-mapping PATCH; no schema change.

## Screenshots / recordings

Copy/layout recomposition of existing primitives (`Card`, `Button`, `Input`, `Select`); no new styles or hex values.

## Checklist

- [x] Tests pass locally (protocol/task suites: 58 tests incl. updated empty-state expectations)
- [x] `npm run lint` clean (0 errors)
- [x] `npm run typecheck` clean
- [x] Swiss German: no ASCII umlauts (`npm run lint:umlauts`); proper `ä/ö/ü`, `ss` (not `ß`)
- [x] No `console.log` — use `logger` from `@/lib/logger`
- [x] No hardcoded table names — use `TABLE_NAMES` from `@/config/database`
- [x] No hardcoded org data — use `@/config/org`
- [x] Parameterized SQL queries only

## Notes for review

- The task advisor deliberately allows practical recommendations (unlike the protocol advisor, which stays within the document) — different system prompt, same infrastructure.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01QXEBWjhBB9JYsgLSX4jNES

---
_Generated by [Claude Code](https://claude.ai/code/session_01QXEBWjhBB9JYsgLSX4jNES)_