### PR TITLE
fix(protocols): flow is always visible and never stuck

### DIFF
--- a/src/app/admin/protocols/[id]/ProtocolDetailClient.tsx
+++ b/src/app/admin/protocols/[id]/ProtocolDetailClient.tsx
@@ -16,7 +16,7 @@
  *   9. Erneut verarbeiten / Abschliessen / Löschen
  */
 
-import { useState, useMemo } from 'react'
+import { useEffect, useMemo } from 'react'
 import { Loader2, CheckCircle2, FileText, Trash2, AlertCircle, UserCheck } from 'lucide-react'
 import { Button } from '@/components/ui/button'
 import { ConfirmDialog } from '@/components/ui/ConfirmDialog'
@@ -129,6 +129,15 @@ export default function ProtocolDetailClient(props: ProtocolDetailProps) {
 
   const allMapped = unmappedAttendees.length === 0 && (notes?.detected_attendees?.length ?? 0) > 0
 
+  // While the AI runs, refresh until the status flips — the user should never
+  // have to reload by hand to see their structured notes appear.
+  const isProcessing = protocol.status === PROTOCOL_STATUSES.PROCESSING
+  useEffect(() => {
+    if (!isProcessing) return
+    const timer = setInterval(() => router.refresh(), 5000)
+    return () => clearInterval(timer)
+  }, [isProcessing, router])
+
   return (
     <div className="space-y-4">
       {/* Error Banner */}
@@ -146,18 +155,18 @@ export default function ProtocolDetailClient(props: ProtocolDetailProps) {
         </div>
       )}
 
-      {/* Progress Strip — replaces the old wall-of-cards checklist */}
-      {(isReview || isFinalized) && (
-        <ProtocolProgressStrip items={reviewChecklist} />
-      )}
+      {/* Progress Strip — the whole pipeline (Input → Struktur → Personen →
+          Entscheide → Aufgaben → Abschluss), visible in EVERY state so the
+          user always knows where the protocol stands and what comes next. */}
+      <ProtocolProgressStrip items={reviewChecklist} />
 
       {/* Processing Spinner */}
-      {protocol.status === PROTOCOL_STATUSES.PROCESSING && (
+      {isProcessing && (
         <div className="bg-warning-50 dark:bg-warning-900/20 border border-warning-200 dark:border-warning-800 rounded-lg p-8 text-center">
           <Loader2 className="w-8 h-8 animate-spin text-warning-500 mx-auto mb-3" />
           <p className="font-medium text-warning-800 dark:text-warning-300">Wird verarbeitet…</p>
           <p className="text-sm text-warning-700 dark:text-warning-400 mt-1">
-            Die KI strukturiert das Transkript. Dies dauert einige Sekunden.
+            Die KI strukturiert das Transkript. Die Seite aktualisiert sich automatisch.
           </p>
         </div>
       )}
@@ -166,6 +175,7 @@ export default function ProtocolDetailClient(props: ProtocolDetailProps) {
       {isDraft && !notes && (
         <ProtocolDraftInput
           allowAudio={usesUnifiedPipeline}
+          hasTranscript={Boolean(protocol.raw_transcript)}
           transcript={transcript}
           audioFile={audioFile}
           processing={processing}
@@ -177,9 +187,30 @@ export default function ProtocolDetailClient(props: ProtocolDetailProps) {
         />
       )}
 
+      {/* Quelle — Rohtranskript. Rendered whenever a transcript exists (also
+          without structured notes: while processing runs or after a failed
+          structuring the source must stay visible). Collapsed when the
+          structured view exists; expanded when it is the only content. */}
+      {protocol.raw_transcript && !(isDraft && !notes) && (
+        <details
+          className="bg-surface-base rounded-lg border border-default"
+          open={!notes}
+        >
+          <summary className="flex items-center gap-2 p-4 cursor-pointer text-sm font-medium text-text-secondary hover:text-text-primary select-none">
+            <FileText className="w-4 h-4 text-text-muted" />
+            Quelle · Rohtranskript ({protocol.raw_transcript.length.toLocaleString()} Zeichen)
+          </summary>
+          <div className="px-4 pb-4">
+            <pre className="text-xs text-text-secondary whitespace-pre-wrap max-h-96 overflow-y-auto bg-surface-raised rounded-lg p-3 leading-relaxed">
+              {protocol.raw_transcript}
+            </pre>
+          </div>
+        </details>
+      )}
+
       {/* Main content — only when structured notes exist. Order follows the
-          actual pipeline the user reads: overview → source → structured notes
-          → derived actions/decisions → follow-ups → tools. */}
+          actual pipeline the user reads: overview → structured notes →
+          derived actions/decisions → follow-ups → tools. */}
       {notes && (
         <>
           {/* 1. Zusammenfassung — executive overview */}
@@ -192,24 +223,7 @@ export default function ProtocolDetailClient(props: ProtocolDetailProps) {
             </p>
           </div>
 
-          {/* 2. Quelle — Rohtranskript / Notizen. Moved out of the sidebar into
-              the main flow so the pipeline reads source → structure → actions.
-              Collapsed by default; the structured view below is the daily one. */}
-          {protocol.raw_transcript && (
-            <details className="bg-surface-base rounded-lg border border-default">
-              <summary className="flex items-center gap-2 p-4 cursor-pointer text-sm font-medium text-text-secondary hover:text-text-primary select-none">
-                <FileText className="w-4 h-4 text-text-muted" />
-                Quelle · Rohtranskript ({protocol.raw_transcript.length.toLocaleString()} Zeichen)
-              </summary>
-              <div className="px-4 pb-4">
-                <pre className="text-xs text-text-secondary whitespace-pre-wrap max-h-96 overflow-y-auto bg-surface-raised rounded-lg p-3 leading-relaxed">
-                  {protocol.raw_transcript}
-                </pre>
-              </div>
-            </details>
-          )}
-
-          {/* 3. Strukturierte Notizen (Themen) — the transform of the source */}
+          {/* 2. Strukturierte Notizen (Themen) — the transform of the source */}
           <ProtocolTopicsSection
             topics={notes.topics}
             expandedTopics={expandedTopics}

--- a/src/app/admin/protocols/[id]/page.tsx
+++ b/src/app/admin/protocols/[id]/page.tsx
@@ -13,7 +13,7 @@ import { query } from '@/lib/auth/db'
 import { TABLE_NAMES } from '@/config/database'
 import { isSuperAdmin } from '@/lib/permissions'
 import { adminIconBox, adminIconColor } from '@/lib/admin-ui'
-import { getProtocolById, getActionLinks, getTeamMembers, getDecisionsByProtocolId } from '@/lib/services/protocols'
+import { getProtocolById, getActionLinks, getTeamMembers, getDecisionsByProtocolId, recoverStaleProtocolProcessing } from '@/lib/services/protocols'
 import {
   MEETING_TYPE_LABELS,
   MEETING_TYPE_COLORS,
@@ -70,9 +70,19 @@ export default async function ProtocolDetailPage({
     notFound()
   }
 
-  const protocol = await getProtocolById(id, dbUserId, isAdmin)
+  let protocol = await getProtocolById(id, dbUserId, isAdmin)
   if (!protocol) {
     notFound()
+  }
+
+  // Self-healing: a protocol stuck in "processing" (server restarted mid-run)
+  // is reset to draft on load, so the page always offers a way forward
+  // instead of an eternal spinner.
+  if (protocol.status === PROTOCOL_STATUSES.PROCESSING) {
+    const recovered = await recoverStaleProtocolProcessing(id)
+    if (recovered) {
+      protocol = (await getProtocolById(id, dbUserId, isAdmin)) ?? protocol
+    }
   }
 
   const [actionLinks, teamMembers, protocolDecisions] = await Promise.all([

--- a/src/components/admin/protocols/ProtocolDraftInput.tsx
+++ b/src/components/admin/protocols/ProtocolDraftInput.tsx
@@ -12,6 +12,8 @@ import { Button } from '@/components/ui/button'
 interface Props {
   /** Audio uploads are supported for the unified pipeline only. */
   allowAudio: boolean
+  /** A transcript is already stored (e.g. transcription succeeded but structuring failed). */
+  hasTranscript?: boolean
   transcript: string
   audioFile: File | null
   processing: boolean
@@ -24,6 +26,7 @@ interface Props {
 
 export function ProtocolDraftInput({
   allowAudio,
+  hasTranscript = false,
   transcript,
   audioFile,
   processing,
@@ -37,12 +40,14 @@ export function ProtocolDraftInput({
     <div className="bg-surface-base rounded-lg border border-default p-6 space-y-4">
       <div>
         <Heading level={2} className="text-lg text-text-primary">
-          Inhalt liefern
+          {hasTranscript ? 'Transkript bereit — jetzt strukturieren' : 'Inhalt liefern'}
         </Heading>
         <p className="text-sm text-text-secondary mt-1">
-          {allowAudio
-            ? 'Lade die Aufnahme hoch oder füge Text ein — die KI erstellt daraus das Protokoll.'
-            : 'Füge den Inhalt ein — die KI erstellt daraus das Protokoll.'}
+          {hasTranscript
+            ? 'Das Transkript ist gespeichert (unten einsehbar und bearbeitbar). Starte die KI-Strukturierung, um Themen, Aufgaben und Entscheidungen zu erhalten.'
+            : allowAudio
+              ? 'Lade die Aufnahme hoch oder füge Text ein — die KI erstellt daraus das Protokoll.'
+              : 'Füge den Inhalt ein — die KI erstellt daraus das Protokoll.'}
         </p>
       </div>
 

--- a/src/lib/services/protocols-processing.ts
+++ b/src/lib/services/protocols-processing.ts
@@ -160,6 +160,39 @@ export async function processTranscript(
 }
 
 // =============================================================================
+// STALE-PROCESSING RECOVERY
+// =============================================================================
+
+// Processing is synchronous within one request; anything still "processing"
+// after this long means the server died mid-run (deploy restart, crash) and
+// the protocol would otherwise show an eternal spinner.
+const STALE_PROCESSING_MINUTES = 10
+
+/**
+ * Reset a protocol stuck in `processing` back to `draft` so the user gets an
+ * actionable retry card instead of a spinner that never resolves. The raw
+ * transcript is preserved. Safe to call on every detail-page load — the WHERE
+ * clause makes it a no-op unless the run is genuinely stale.
+ *
+ * @returns true if the protocol was recovered (caller should re-fetch)
+ */
+export async function recoverStaleProtocolProcessing(protocolId: string): Promise<boolean> {
+  const result = await db.execute(sql`
+    UPDATE ${sql.raw(mpTable)}
+    SET status = ${PROTOCOL_STATUS.DRAFT}
+    WHERE id = ${protocolId}
+      AND status = ${PROTOCOL_STATUS.PROCESSING}
+      AND updated_at < NOW() - INTERVAL '${sql.raw(String(STALE_PROCESSING_MINUTES))} minutes'
+    RETURNING id
+  `)
+  const recovered = result.rows.length > 0
+  if (recovered) {
+    logger.warn('Recovered protocol stuck in processing', { protocolId, staleMinutes: STALE_PROCESSING_MINUTES })
+  }
+  return recovered
+}
+
+// =============================================================================
 // NOTES PROCESSING (Step 3)
 // =============================================================================
 

--- a/src/lib/services/protocols.ts
+++ b/src/lib/services/protocols.ts
@@ -25,6 +25,7 @@ export {
   processTranscript,
   processNotes,
   importTasks,
+  recoverStaleProtocolProcessing,
 } from './protocols-processing'
 
 // Action item linking (tasks & decisions)


### PR DESCRIPTION
## What & why

Staff report: "why can't I see structured notes for the raw transcript — everything is complex and unpredictable." Diagnosis: a protocol whose AI structuring died mid-run (e.g. a deploy restart — three deploys shipped today while staff were testing) sits in `status=processing` forever showing an eternal spinner: no transcript visible, no notes, no way forward. Even in healthy states the pipeline steps were invisible outside review, and the raw transcript only rendered once structured notes existed.

## Approach

The intended flow (record/upload → transcript → structured notes → tasks/decisions → finalize) already exists as the review checklist — it was just hidden and had a dead state:

- **Pipeline always visible**: the progress strip (Input → Struktur → Personen → Entscheide → Aufgaben → Abschliessen) renders in every state, so the page always says where the protocol stands and what comes next.
- **Transcript always visible**: `Quelle · Rohtranskript` renders whenever a transcript exists — expanded when it's the only content, collapsed once notes exist.
- **Processing self-heals**: the detail page auto-refreshes every 5 s while the AI runs (no manual reload to see notes appear), and a run stale for >10 min is reset to `draft` server-side on page load (transcript preserved) — the eternal spinner is impossible now.
- **Honest draft card**: when a transcript is already stored, the card says "Transkript bereit — jetzt strukturieren" with one primary action instead of asking for content the user already delivered.

## Screenshots / recordings

State recomposition of existing components; no new styles.

## Checklist

- [x] Tests pass locally (protocol suites: 42 tests)
- [x] `npm run lint` clean (0 errors)
- [x] `npm run typecheck` clean
- [x] Swiss German: no ASCII umlauts (`npm run lint:umlauts`); proper `ä/ö/ü`, `ss` (not `ß`)
- [x] No `console.log` — use `logger` from `@/lib/logger`
- [x] No hardcoded table names — use `TABLE_NAMES` from `@/config/database`
- [x] No hardcoded org data — use `@/config/org`
- [x] Parameterized SQL queries only

## Notes for review

- Stale-recovery is a guarded UPDATE (`status='processing' AND updated_at < now() - 10 min`) executed on detail-page load — a no-op for healthy runs, idempotent under concurrent loads.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01QXEBWjhBB9JYsgLSX4jNES

---
_Generated by [Claude Code](https://claude.ai/code/session_01QXEBWjhBB9JYsgLSX4jNES)_