### PR TITLE
feat(feedback): forward site suggestions to a FleetCrown per-project inbox

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -154,3 +154,14 @@ OLLAMA_MODEL=llama3.2
 # the X-Kivvi-Signature header. Must match the endpoint secret configured in
 # Kivvi. Unset → the receiver fails closed (rejects all webhooks).
 # KIVVI_WEBHOOK_SECRET=<shared-secret-from-kivvi-webhook-settings>
+
+# ====================
+# FLEETCROWN FEEDBACK FORWARDING
+# ====================
+# Forwards each persisted site suggestion (floating feedback widget + /contact
+# form) to the FleetCrown per-project feedback inbox, in addition to the local
+# site_suggestions table and admin Rückmeldungen view. Without these vars the
+# forward is silently skipped (safe for local dev).
+# Issue the key in FleetCrown: project detail → Feedback tab → Enable ingestion.
+# FLEETCROWN_FEEDBACK_INGEST_URL=https://<fleetcrown-host>/api/feedback/ingest
+# FLEETCROWN_FEEDBACK_KEY=fk_...

--- a/src/app/api/suggestions/route.ts
+++ b/src/app/api/suggestions/route.ts
@@ -8,6 +8,9 @@
  * notification, and finally the team email is sent AND its result is checked
  * (sendCustomEmail resolves { success:false } instead of throwing, so the old
  * fire-and-forget `.catch` never noticed failed delivery).
+ *
+ * After a successful persist the suggestion is also forwarded (fire-and-forget)
+ * to the FleetCrown per-project feedback inbox — see lib/fleetcrown/forward.ts.
  */
 
 import { NextRequest } from 'next/server'
@@ -26,6 +29,7 @@ import { db } from '@/db'
 import { siteSuggestions, users } from '@/db/schema'
 import { createNotification } from '@/lib/services/notifications'
 import { SUPER_ADMIN_EMAILS } from '@/lib/permissions'
+import { forwardSuggestionInBackground } from '@/lib/fleetcrown/forward'
 
 const SuggestionSchema = z.object({
   suggestion: z.string().min(1).max(5000),
@@ -64,7 +68,7 @@ export async function POST(request: NextRequest) {
     // 1) PERSIST — the reliable channel. Never silently lost.
     let stored = false
     try {
-      await db.insert(siteSuggestions).values({
+      const [inserted] = await db.insert(siteSuggestions).values({
         suggestion: data.suggestion,
         contact: data.contact ?? null,
         page: data.page ?? null,
@@ -74,8 +78,24 @@ export async function POST(request: NextRequest) {
         scope,
         selectedElements: data.selectedElements ?? null,
         authorUserId,
-      })
+      }).returning({ id: siteSuggestions.id })
       stored = true
+
+      // 1b) FORWARD to the FleetCrown per-project feedback inbox — fire-and-forget,
+      // silently skipped when not configured; the row id de-duplicates retries.
+      if (inserted) {
+        forwardSuggestionInBackground({
+          id: inserted.id,
+          suggestion: data.suggestion,
+          contact: data.contact,
+          scope,
+          url: data.url,
+          page: data.page,
+          pageTitle: data.pageTitle,
+          pageSection: data.pageSection,
+          selectedElements: data.selectedElements,
+        })
+      }
     } catch (e) {
       logger.error('Failed to persist site suggestion', { error: e })
     }

--- a/src/lib/fleetcrown/forward.ts
+++ b/src/lib/fleetcrown/forward.ts
@@ -1,0 +1,107 @@
+/**
+ * FleetCrown feedback forwarder.
+ *
+ * After a site suggestion is persisted locally (the SSOT stays
+ * site_suggestions + the admin Rückmeldungen inbox), it is additionally
+ * forwarded to the founder's FleetCrown per-project feedback inbox, where
+ * website feedback from all projects is triaged in one place.
+ *
+ * Configuration (add to .env):
+ *   FLEETCROWN_FEEDBACK_INGEST_URL=https://<fleetcrown-host>/api/feedback/ingest
+ *   FLEETCROWN_FEEDBACK_KEY=fk_...   (issued in the FleetCrown project's Feedback tab)
+ *
+ * Mirrors the Kivvi sync contract: never throws, silently skips when not
+ * configured (expected in dev), and passes the suggestion row id as
+ * externalId so FleetCrown de-duplicates retries. Server-side only.
+ */
+
+import { logger } from '@/lib/logger'
+
+function getConfig(): { url: string; key: string } | null {
+  const url = process.env.FLEETCROWN_FEEDBACK_INGEST_URL
+  const key = process.env.FLEETCROWN_FEEDBACK_KEY
+  if (!url || !key) return null
+  return { url, key }
+}
+
+export function isFleetCrownFeedbackConfigured(): boolean {
+  return getConfig() !== null
+}
+
+export interface ForwardSuggestionInput {
+  /** site_suggestions row id — FleetCrown's dedup handle for retries */
+  id: string
+  suggestion: string
+  contact?: string | null
+  scope?: string | null
+  url?: string | null
+  page?: string | null
+  pageTitle?: string | null
+  pageSection?: string | null
+  selectedElements?: unknown[] | null
+}
+
+export type ForwardResult = { success: true } | { success: false; error: string }
+
+const FORWARD_SCOPES = new Set(['page', 'element', 'site'])
+
+/**
+ * Forward a persisted suggestion to FleetCrown. Never throws — the local
+ * pipeline (DB + notifications + email) must not depend on FleetCrown being
+ * reachable. Call fire-and-forget after the local persist succeeds.
+ */
+export async function forwardSuggestionToFleetCrown(
+  input: ForwardSuggestionInput,
+): Promise<ForwardResult> {
+  const config = getConfig()
+  if (!config) {
+    return { success: false, error: 'FleetCrown feedback forwarding not configured' }
+  }
+
+  try {
+    const response = await fetch(config.url, {
+      method: 'POST',
+      headers: { 'Content-Type': 'application/json' },
+      body: JSON.stringify({
+        key: config.key,
+        message: input.suggestion,
+        contact: input.contact || undefined,
+        scope: input.scope && FORWARD_SCOPES.has(input.scope) ? input.scope : undefined,
+        pageUrl: input.url || undefined,
+        pageTitle: input.pageTitle || input.page || undefined,
+        selectedElements: input.selectedElements ?? undefined,
+        source: 'forward',
+        externalId: input.id,
+        metadata: {
+          origin: 'revampit',
+          page: input.page ?? null,
+          pageSection: input.pageSection ?? null,
+        },
+      }),
+      signal: AbortSignal.timeout(10_000),
+    })
+    if (!response.ok) {
+      const body = (await response.json().catch(() => ({}))) as { error?: string }
+      return { success: false, error: body.error || `FleetCrown ingest HTTP ${response.status}` }
+    }
+    return { success: true }
+  } catch (error) {
+    return {
+      success: false,
+      error: error instanceof Error ? error.message : 'FleetCrown forward failed',
+    }
+  }
+}
+
+/**
+ * Fire-and-forget wrapper for the suggestion route: skips silently when not
+ * configured, logs (never throws) when a configured forward fails.
+ */
+export function forwardSuggestionInBackground(input: ForwardSuggestionInput): void {
+  if (!isFleetCrownFeedbackConfigured()) return
+  void forwardSuggestionToFleetCrown(input).then(result => {
+    if (!result.success) {
+      logger.warn('FleetCrown feedback forward failed', { suggestionId: input.id, error: result.error })
+    }
+  })
+}


### PR DESCRIPTION
Recovered from a dangling branch during a repo cleanup. Additive, low-risk:

- `src/lib/fleetcrown/forward.ts` (new) — forwards submitted site suggestions to a FleetCrown per-project inbox.
- `src/app/api/suggestions/route.ts` — wires the forward into the existing suggestions endpoint.
- `.env.example` — documents the opt-in env vars (no-op if unset).

Clean feature, no conflicts expected. Review & merge or close.

🤖 Generated with [Claude Code](https://claude.com/claude-code)