### PR TITLE
fix(erfassung): reliable photo intake + restore the AI review/refine step

### DIFF
--- a/src/app/admin/erfassung/page.tsx
+++ b/src/app/admin/erfassung/page.tsx
@@ -1,6 +1,6 @@
 'use client'
 
-import { useState, useCallback, Suspense } from 'react'
+import { useState, useCallback, useEffect, useRef, Suspense } from 'react'
 import Link from 'next/link'
 import { apiFetch } from '@/lib/api/client'
 import { logger } from '@/lib/logger'
@@ -39,6 +39,18 @@ function ErfassungContent() {
   const [selectedProductId, setSelectedProductId] = useState<string | null>(null)
   const [bulkPage, setBulkPage] = useState(0)
   const [bulkSaveResult, setBulkSaveResult] = useState<BulkSaveResponse | null>(null)
+
+  // When the AI fills the form (or the operator picks manual entry), bring the
+  // review step into view. Without this the form silently appears below the
+  // fold on mobile and "where did step 2 go?" is a real complaint.
+  const reviewRef = useRef<HTMLFormElement>(null)
+  const wasReviewing = useRef(false)
+  useEffect(() => {
+    if (form.reviewStarted && !wasReviewing.current && !form.isEditMode) {
+      reviewRef.current?.scrollIntoView({ behavior: 'smooth', block: 'start' })
+    }
+    wasReviewing.current = form.reviewStarted
+  }, [form.reviewStarted, form.isEditMode])
 
   // Bulk handlers
   const handleBulkData = useCallback((products: BulkProduct[]) => {
@@ -284,7 +296,7 @@ function ErfassungContent() {
       {/* SINGLE MODE */}
       {viewMode === 'single' && (form.isEditMode || form.reviewStarted) && (
         <>
-          <form data-product-form onSubmit={(e) => form.handleSubmit(e, 'erfassen')} className="space-y-5">
+          <form ref={reviewRef} data-product-form onSubmit={(e) => form.handleSubmit(e, 'erfassen')} className="scroll-mt-24 space-y-5">
             {form.saveError && (
               <div className="bg-error-50 dark:bg-error-900/20 border border-error-200 dark:border-error-800 text-error-700 dark:text-error-300 px-4 py-3 rounded-lg text-sm">
                 {form.saveError}
@@ -304,12 +316,29 @@ function ErfassungContent() {
 
               {/* Ask the AI to change the extracted data in natural language —
                   "Beschreibung ausführlicher", "Preis auf 80 CHF", "Specs ergänzen".
-                  Uses the shared FORM_AI_REGISTRY (formType 'erfassung') like every
-                  other admin form. */}
+                  Expanded by default so the tweak surface is visible, not hidden
+                  behind a chevron. Uses the shared FORM_AI_REGISTRY (formType
+                  'erfassung') like every other admin form. */}
               <AIFormAssist
                 formType="erfassung"
                 variant="section"
-                currentData={form.formData as unknown as Record<string, unknown>}
+                defaultExpanded
+                hasContentOverride={Boolean(
+                  form.formData.hersteller.trim() ||
+                  form.formData.produktname.trim() ||
+                  form.formData.kurzbeschreibung.trim(),
+                )}
+                currentData={{
+                  hersteller: form.formData.hersteller,
+                  produktname: form.formData.produktname,
+                  kurzbeschreibung: form.formData.kurzbeschreibung,
+                  verkaufspreis: form.formData.verkaufspreis,
+                  zustand: form.formData.zustand,
+                  hauptkategorie: form.formData.hauptkategorie,
+                  unterkategorie: form.formData.unterkategorie,
+                  specs: form.formData.specs.filter(s => s.key && s.value),
+                  kundenprofile: form.formData.kundenprofile,
+                }}
                 onFieldsFilled={(data, metadata) =>
                   form.handleAssistFields(data as Partial<typeof form.formData>, metadata)
                 }

--- a/src/app/admin/erfassung/page.tsx
+++ b/src/app/admin/erfassung/page.tsx
@@ -14,6 +14,7 @@ import { BulkActionBar } from '@/components/erfassung/BulkActionBar'
 import { BulkSuccessScreen } from '@/components/erfassung/BulkSuccessScreen'
 import { CaptureDestinationFields } from '@/components/erfassung/CaptureDestinationFields'
 import { ErfassungSubmitBar } from '@/components/erfassung/ErfassungSubmitBar'
+import { AIFormAssist } from '@/components/ai/AIFormAssist'
 import { useErfassungForm } from '@/components/erfassung/useErfassungForm'
 import { Button } from '@/components/ui/button'
 import type { BulkProduct, BulkSaveResponse } from '@/types/erfassung'
@@ -300,6 +301,20 @@ function ErfassungContent() {
                   <p className="mt-0.5 text-sm text-text-secondary">KI-Vorschläge kontrollieren. Nur Hersteller und Produktname sind zum Speichern nötig.</p>
                 </div>
               </div>
+
+              {/* Ask the AI to change the extracted data in natural language —
+                  "Beschreibung ausführlicher", "Preis auf 80 CHF", "Specs ergänzen".
+                  Uses the shared FORM_AI_REGISTRY (formType 'erfassung') like every
+                  other admin form. */}
+              <AIFormAssist
+                formType="erfassung"
+                variant="section"
+                currentData={form.formData as unknown as Record<string, unknown>}
+                onFieldsFilled={(data, metadata) =>
+                  form.handleAssistFields(data as Partial<typeof form.formData>, metadata)
+                }
+              />
+
               <ProductForm
                 formData={form.formData}
                 aiMetadata={form.aiMetadata}

--- a/src/app/api/admin/erfassung/image/route.ts
+++ b/src/app/api/admin/erfassung/image/route.ts
@@ -1,0 +1,63 @@
+/**
+ * API: Photo-to-Product Erfassung
+ *
+ * POST /api/admin/erfassung/image
+ * Accepts a base64 image and returns the SAME structured product data as the
+ * text route — full fidelity (specs, category, description, profiles), not the
+ * four-field subset the old /api/ai/analyze-product path handed back.
+ *
+ * Staff-only; part of the /api/admin/erfassung/* family (text, voice, bulk-*).
+ *
+ * Example:
+ *   POST { "image": "data:image/jpeg;base64,..." }
+ *   Returns: { success: true, data: { hersteller, produktname, specs, ... }, metadata }
+ */
+
+import { withAdmin } from '@/lib/api/middleware'
+import { logger } from '@/lib/logger'
+import { apiSuccess, apiError, apiRateLimited } from '@/lib/api/helpers'
+import { ERROR_MESSAGES } from '@/config/error-messages'
+import { validateBody, ErfassungImageSchema } from '@/lib/schemas'
+import { extractProductFromImage } from '@/lib/erfassung/ai-extraction'
+import { rateLimiters } from '@/lib/security/rate-limit'
+
+export const POST = withAdmin('products', async (request, session) => {
+  try {
+    // Bound expensive vision inference per operator (generous staff limit).
+    if (!rateLimiters.erfassungImage(session.user.id + ':erfassung-image')) {
+      return apiRateLimited()
+    }
+
+    const body = await request.json()
+    const validation = validateBody(ErfassungImageSchema, body)
+    if (!validation.success) return validation.error
+    const { image } = validation.data
+
+    logger.info('Image erfassung started', {
+      userId: session.user.id,
+      imageBytes: image.length,
+    })
+
+    const result = await extractProductFromImage(image)
+
+    if (!result.success) {
+      return apiError(result.error, result.error || ERROR_MESSAGES.EXTRACTION_FAILED)
+    }
+
+    logger.info('Image erfassung complete', {
+      userId: session.user.id,
+      product: result.data.produktname,
+      model: result.model,
+    })
+
+    return apiSuccess({
+      data: result.data,
+      metadata: result.metadata,
+      model: result.model,
+      sourceType: result.sourceType,
+      verificationSources: result.verificationSources,
+    })
+  } catch (error) {
+    return apiError(error, ERROR_MESSAGES.INTERNAL_SERVER_ERROR)
+  }
+})

--- a/src/components/ai/AIFormAssist.tsx
+++ b/src/components/ai/AIFormAssist.tsx
@@ -29,6 +29,13 @@ interface AIFormAssistProps<T = Record<string, unknown>> {
   defaultExpanded?: boolean
   variant?: 'bar' | 'section'
   className?: string
+  /**
+   * Override the auto extract-vs-refine decision. Set by structured forms
+   * (e.g. erfassung) whose populated fields are too short for the default
+   * length heuristic to recognise as "the form already has a record".
+   * Undefined = use the built-in heuristic (unchanged for existing callers).
+   */
+  hasContentOverride?: boolean
 }
 
 export function AIFormAssist<T = Record<string, unknown>>({
@@ -39,6 +46,7 @@ export function AIFormAssist<T = Record<string, unknown>>({
   defaultExpanded = false,
   variant = 'bar',
   className = '',
+  hasContentOverride,
 }: AIFormAssistProps<T>) {
   const t = useTranslations('ai.formAssist')
   const [isExpanded, setIsExpanded] = useState(defaultExpanded)
@@ -62,10 +70,17 @@ export function AIFormAssist<T = Record<string, unknown>>({
     ? Object.entries(config.quickActions).map(([key, { label }]) => ({ key, label }))
     : []
 
-  // Form has meaningful user content (not just defaults)
-  const hasContent = currentData && Object.values(currentData).some(v =>
+  // Does the form already hold a record? If so, plain-language input is a
+  // REFINE ("change the price to 80"), not a fresh extraction that would
+  // clobber the fields. Default heuristic: any field with substantial text.
+  // Structured forms whose real fields are short (erfassung: "iRobot" +
+  // "Roomba 600 Series") pass hasContentOverride so a filled record still
+  // refines — without that override the auto-heuristic (unchanged for the
+  // other forms, which carry short default fields) governs.
+  const autoHasContent = Boolean(currentData && Object.values(currentData).some(v =>
     typeof v === 'string' && v.trim().length > 20
-  )
+  ))
+  const hasContent = hasContentOverride ?? autoHasContent
 
   const handleSubmit = () => {
     if (!inputText.trim() || isExtracting) return

--- a/src/components/erfassung/DataEntryTabs.tsx
+++ b/src/components/erfassung/DataEntryTabs.tsx
@@ -287,8 +287,8 @@ export function DataEntryTabs({
         {activeMode === 'picture' && (
           <ImageCapture
             onImageCapture={handleImageCapture}
-            onAnalysisComplete={(data) => {
-              onProductData(data)
+            onAnalysisComplete={(data, metadata) => {
+              onProductData(data, metadata)
               onDataFilled?.()
             }}
             onError={onError}

--- a/src/components/erfassung/ImageCapture.tsx
+++ b/src/components/erfassung/ImageCapture.tsx
@@ -31,11 +31,12 @@ import {
 import { useTranslations } from 'next-intl'
 import { Button } from '@/components/ui/button'
 import { useProductAnalysis } from '@/hooks/useProductAnalysis'
-import type { ErfassungFormData } from '@/types/erfassung'
+import { downscaleImage } from '@/lib/images/downscale'
+import type { ErfassungFormData, AIFieldMetadata } from '@/types/erfassung'
 
 interface ImageCaptureProps {
   onImageCapture: (imageBase64: string) => void
-  onAnalysisComplete?: (data: Partial<ErfassungFormData>) => void
+  onAnalysisComplete?: (data: Partial<ErfassungFormData>, metadata?: AIFieldMetadata) => void
   onError?: (error: string) => void
   disabled?: boolean
   className?: string
@@ -60,28 +61,33 @@ export function ImageCapture({
   const fileInputRef = useRef<HTMLInputElement>(null)
   const cameraInputRef = useRef<HTMLInputElement>(null)
 
-  // Handle file selection
+  // Handle file selection — downscale before anything else so a 10 MB phone
+  // photo never reaches the network or the vision provider at full size.
   const handleFileSelect = useCallback(
-    (file: File) => {
+    async (file: File) => {
       if (!file.type.startsWith('image/')) {
         setErrorMessage(t('errorImageOnly'))
         setState('error')
         return
       }
 
-      const reader = new FileReader()
-      reader.onload = (ev) => {
-        const base64 = ev.target?.result as string
+      try {
+        const base64 = await downscaleImage(file)
+        if (!base64) {
+          setErrorMessage(t('errorReadFile'))
+          setState('error')
+          onError?.(t('errorReadFile'))
+          return
+        }
+        setErrorMessage(null)
         setImagePreview(base64)
         setState('preview')
         onImageCapture(base64)
-      }
-      reader.onerror = () => {
+      } catch {
         setErrorMessage(t('errorReadFile'))
         setState('error')
         onError?.(t('errorReadFile'))
       }
-      reader.readAsDataURL(file)
     },
     [t, onImageCapture, onError]
   )
@@ -143,7 +149,7 @@ export function ImageCapture({
     const result = await analyzeProduct(imagePreview)
 
     if (result) {
-      onAnalysisComplete?.(result.formData)
+      onAnalysisComplete?.(result.formData, result.metadata)
       setState('success')
 
       // Reset to preview after 2 seconds
@@ -151,8 +157,11 @@ export function ImageCapture({
         setState('preview')
       }, 2000)
     } else {
+      // Non-destructive: keep the photo in preview and surface the (actionable)
+      // provider message inline, so the operator can retry or switch to text
+      // without re-taking the picture.
       setErrorMessage(analysisError || t('errorAnalysis'))
-      setState('error')
+      setState('preview')
       onError?.(analysisError || t('errorAnalysis'))
     }
   }, [t, imagePreview, analyzeProduct, analysisError, onAnalysisComplete, onError])
@@ -160,7 +169,7 @@ export function ImageCapture({
   return (
     <div className={`flex flex-col gap-4 ${className}`}>
       {/* Main capture area */}
-      <div className="card-shell p-6">
+      <div className="card-shell p-4 sm:p-6">
         {/* Idle state: Upload area */}
         {state === 'idle' && (
           <div
@@ -258,6 +267,14 @@ export function ImageCapture({
                 </Button>
               </div>
 
+              {/* Inline, non-destructive analysis error — the photo stays put. */}
+              {state === 'preview' && errorMessage && (
+                <div className="flex items-start gap-2 py-2 px-3 bg-error-50 dark:bg-error-900/20 rounded-lg text-error-700 dark:text-error-400 text-sm">
+                  <AlertCircle className="w-4 h-4 mt-0.5 shrink-0" />
+                  <span>{errorMessage}</span>
+                </div>
+              )}
+
               {/* Action buttons */}
               <div className="flex items-center justify-center gap-3">
                 {state === 'preview' && (
@@ -277,7 +294,7 @@ export function ImageCapture({
                       variant="primary"
                     >
                       <Zap className="w-4 h-4" />
-                      {t('analyzeWithAI')}
+                      {errorMessage ? t('retry') : t('analyzeWithAI')}
                     </Button>
                   </>
                 )}

--- a/src/components/erfassung/ProductImageSection.tsx
+++ b/src/components/erfassung/ProductImageSection.tsx
@@ -12,6 +12,7 @@ import { Camera, X } from 'lucide-react'
 import { useTranslations } from 'next-intl'
 import { Button } from '@/components/ui/button'
 import Heading from '@/components/ui/Heading'
+import { downscaleImage } from '@/lib/images/downscale'
 
 interface ProductImageSectionProps {
   image: string | null
@@ -57,15 +58,13 @@ export function ProductImageSection({ image, onImageChange }: ProductImageSectio
               type="file"
               accept="image/*"
               className="hidden"
-              onChange={(e) => {
+              onChange={async (e) => {
                 const file = e.target.files?.[0]
                 if (file) {
-                  const reader = new FileReader()
-                  reader.onload = (event) => {
-                    const base64 = event.target?.result as string
-                    onImageChange(base64)
-                  }
-                  reader.readAsDataURL(file)
+                  // Downscale so the stored/uploaded image is a bounded JPEG,
+                  // not a raw multi-megabyte phone photo.
+                  const base64 = await downscaleImage(file)
+                  if (base64) onImageChange(base64)
                 }
               }}
             />

--- a/src/components/erfassung/useErfassungForm.ts
+++ b/src/components/erfassung/useErfassungForm.ts
@@ -208,6 +208,46 @@ export function useErfassungForm() {
     }
   }, [])
 
+  /**
+   * Bridge AIFormAssist output → erfassung form state.
+   *
+   * The generic assistant returns arbitrary keys plus a flat
+   * `{ confidence, model, timestamp }` metadata map. Whitelist to real form
+   * fields (so `fieldsChanged`/`bemerkungen` don't pollute formData) and lift
+   * the metadata into the erfassung `AIFieldSource` shape (type 'text') that
+   * the field indicators render.
+   */
+  const handleAssistFields = useCallback((
+    data: Partial<ErfassungFormData>,
+    metadataEntries: Record<string, { confidence: number; model: string; timestamp: number }>,
+  ) => {
+    const clean: Partial<ErfassungFormData> = {}
+    for (const key of Object.keys(DEFAULT_FORM_DATA) as Array<keyof ErfassungFormData>) {
+      if (!(key in data)) continue
+      const value = (data as Record<string, unknown>)[key]
+      // Arrays (specs, kundenprofile) pass through; every other field is a
+      // string input, so coerce scalars — the refine model may emit a numeric
+      // price, and a raw number would drift from the form's string typing.
+      ;(clean as Record<string, unknown>)[key] =
+        Array.isArray(value) || value === null || value === undefined ? value : String(value)
+    }
+
+    const meta: AIFieldMetadata = {}
+    for (const [key, entry] of Object.entries(metadataEntries)) {
+      if (key in DEFAULT_FORM_DATA) {
+        meta[key as keyof ErfassungFormData] = {
+          type: 'text',
+          confidence: entry.confidence,
+          model: entry.model,
+          timestamp: entry.timestamp,
+        }
+      }
+    }
+
+    setFormData(prev => mergeFormData(prev, clean))
+    setAiMetadata(prev => ({ ...prev, ...meta }))
+  }, [])
+
   const handleImageCapture = useCallback((imageBase64: string) => {
     setFormData(prev => ({ ...prev, image: imageBase64 }))
   }, [])
@@ -361,6 +401,7 @@ export function useErfassungForm() {
     removeSpecField,
     toggleProfile,
     handleProductData,
+    handleAssistFields,
     handleImageCapture,
     handleDataFilled,
     handleManualEntry,

--- a/src/hooks/__tests__/useProductAnalysis.test.tsx
+++ b/src/hooks/__tests__/useProductAnalysis.test.tsx
@@ -3,16 +3,17 @@
  * erfassung donor-intake flow.
  *
  * Mission-relevant: this hook lets staff snap a photo of donated
- * hardware and get an AI-extracted brand/product/condition/price
- * pre-filled into the erfassung form. A regression here breaks the
- * scan-to-fill UX that makes intake fast.
+ * hardware and get an AI-extracted product record pre-filled into the
+ * erfassung form. A regression here breaks the scan-to-fill UX that makes
+ * intake fast.
  *
  * Behaviors locked:
- *   - POSTs to /api/ai/analyze-product with image + saveToDatabase=false
- *   - returns mapped formData on success (4 fields with safe defaults)
+ *   - POSTs the image to the full-fidelity staff route /api/admin/erfassung/image
+ *   - returns the WHOLE product record (specs, category, profiles, description),
+ *     not a four-field subset, plus AI confidence metadata
  *   - throws + sets error from result.error on success=false
  *   - "Analyse fehlgeschlagen" Swiss-German fallback
- *   - "Keine Analysedaten erhalten" guard when data.analysis missing
+ *   - "Keine Analysedaten erhalten" guard when the nested data is missing
  *   - non-Error throws fall back to "Analyse fehlgeschlagen"
  *   - isAnalyzing lifecycle (true mid-flight, false after)
  *   - clears previous error on new attempt
@@ -31,7 +32,22 @@ jest.mock('@/lib/logger', () => ({
 import { renderHook, act, waitFor } from '@testing-library/react'
 import { useProductAnalysis } from '../useProductAnalysis'
 
-const TINY_PNG_BASE64 = 'iVBORw0KGgoAAAANSUhEUgAAAAEAAAABCAQAAAC1HAwCAAAAC0lEQVR42mNkYAAAAAYAAjCB0C8AAAAASUVORK5CYII='
+const TINY_PNG_BASE64 = 'data:image/png;base64,iVBORw0KGgoAAAANSUhEUgAAAAEAAAABCAQAAAC1HAwCAAAAC0lEQVR42mNkYAAAAAYAAjCB0C8AAAAASUVORK5CYII='
+
+/** A full VoiceProductData record as the vision route returns it. */
+function fullProduct() {
+  return {
+    hersteller: 'Canon',
+    produktname: 'MAXIFY MB2350',
+    kurzbeschreibung: 'Multifunktions-Tintenstrahldrucker',
+    specs: [{ key: 'Typ', value: 'Tintenstrahl' }],
+    verkaufspreis: '60',
+    zustand: 'good',
+    hauptkategorie: '99',
+    unterkategorie: '',
+    kundenprofile: ['buero'],
+  }
+}
 
 beforeEach(() => {
   mockApiFetch.mockReset()
@@ -54,17 +70,10 @@ describe('useProductAnalysis — initial state', () => {
 // ============================================================================
 
 describe('analyzeProduct — happy path', () => {
-  it('POSTs to /api/ai/analyze-product with image + saveToDatabase=false', async () => {
+  it('POSTs the image to the full-fidelity staff route', async () => {
     mockApiFetch.mockResolvedValueOnce({
       success: true,
-      data: {
-        analysis: {
-          brand: 'Apple',
-          product_name: 'MacBook Pro 14"',
-          condition: 'good',
-          estimated_price_chf: 1500,
-        },
-      },
+      data: { data: fullProduct(), metadata: {} },
     })
 
     const { result } = renderHook(() => useProductAnalysis())
@@ -73,41 +82,17 @@ describe('analyzeProduct — happy path', () => {
       await result.current.analyzeProduct(TINY_PNG_BASE64)
     })
 
-    expect(mockApiFetch).toHaveBeenCalledWith('/api/ai/analyze-product', {
+    expect(mockApiFetch).toHaveBeenCalledWith('/api/admin/erfassung/image', {
       method: 'POST',
-      body: { image: TINY_PNG_BASE64, saveToDatabase: false },
+      body: { image: TINY_PNG_BASE64 },
     })
   })
 
-  it('does NOT persist to database on this code path (saveToDatabase=false)', async () => {
-    // Critical invariant: the analyze-from-photo flow is preview-only —
-    // staff verify the AI extraction before any DB write. saveToDatabase=true
-    // would create orphan records every time someone tries the camera.
+  it('returns the whole product record (not a 4-field subset) plus metadata', async () => {
+    const metadata = { hersteller: { type: 'image', confidence: 0.9, timestamp: 1 } }
     mockApiFetch.mockResolvedValueOnce({
       success: true,
-      data: { analysis: { brand: 'X', product_name: 'Y', condition: 'good', estimated_price_chf: 100 } },
-    })
-
-    const { result } = renderHook(() => useProductAnalysis())
-
-    await act(async () => {
-      await result.current.analyzeProduct(TINY_PNG_BASE64)
-    })
-
-    expect(mockApiFetch.mock.calls[0][1].body.saveToDatabase).toBe(false)
-  })
-
-  it('returns mapped formData on success (4 erfassung fields)', async () => {
-    mockApiFetch.mockResolvedValueOnce({
-      success: true,
-      data: {
-        analysis: {
-          brand: 'Apple',
-          product_name: 'MacBook Pro 14"',
-          condition: 'good',
-          estimated_price_chf: 1500,
-        },
-      },
+      data: { data: fullProduct(), metadata },
     })
 
     const { result } = renderHook(() => useProductAnalysis())
@@ -119,19 +104,24 @@ describe('analyzeProduct — happy path', () => {
 
     expect(analysisResult).toEqual({
       formData: {
-        hersteller: 'Apple',
-        produktname: 'MacBook Pro 14"',
+        hersteller: 'Canon',
+        produktname: 'MAXIFY MB2350',
+        kurzbeschreibung: 'Multifunktions-Tintenstrahldrucker',
+        specs: [{ key: 'Typ', value: 'Tintenstrahl' }],
+        verkaufspreis: '60',
         zustand: 'good',
-        verkaufspreis: '1500',
+        hauptkategorie: '99',
+        unterkategorie: '',
+        kundenprofile: ['buero'],
       },
+      metadata,
     })
   })
 
-  it('coerces estimated_price_chf number to string for the form input', async () => {
-    // Forms use string inputs; the price needs to be a string for binding
+  it('tolerates a missing metadata object (defaults to {})', async () => {
     mockApiFetch.mockResolvedValueOnce({
       success: true,
-      data: { analysis: { estimated_price_chf: 2499.99 } },
+      data: { data: fullProduct() },
     })
 
     const { result } = renderHook(() => useProductAnalysis())
@@ -141,35 +131,13 @@ describe('analyzeProduct — happy path', () => {
       analysisResult = await result.current.analyzeProduct(TINY_PNG_BASE64)
     })
 
-    expect(analysisResult!.formData.verkaufspreis).toBe('2499.99')
-    expect(typeof analysisResult!.formData.verkaufspreis).toBe('string')
-  })
-
-  it('uses empty-string defaults when analysis fields are missing', async () => {
-    mockApiFetch.mockResolvedValueOnce({
-      success: true,
-      data: { analysis: {} }, // empty analysis
-    })
-
-    const { result } = renderHook(() => useProductAnalysis())
-
-    let analysisResult: Awaited<ReturnType<typeof result.current.analyzeProduct>> = null
-    await act(async () => {
-      analysisResult = await result.current.analyzeProduct(TINY_PNG_BASE64)
-    })
-
-    expect(analysisResult!.formData).toEqual({
-      hersteller: '',
-      produktname: '',
-      zustand: '',
-      verkaufspreis: '',
-    })
+    expect(analysisResult!.metadata).toEqual({})
   })
 
   it('error is null after success', async () => {
     mockApiFetch.mockResolvedValueOnce({
       success: true,
-      data: { analysis: { brand: 'X' } },
+      data: { data: fullProduct(), metadata: {} },
     })
 
     const { result } = renderHook(() => useProductAnalysis())
@@ -213,9 +181,9 @@ describe('analyzeProduct — failure paths', () => {
     expect(result.current.error).toBe('Analyse fehlgeschlagen')
   })
 
-  it('success=true but analysis missing → "Keine Analysedaten erhalten"', async () => {
-    // Defensive: API returned ok but no analysis payload (model timed out, etc.)
-    mockApiFetch.mockResolvedValueOnce({ success: true, data: {} })
+  it('success=true but nested data missing → "Keine Analysedaten erhalten"', async () => {
+    // Defensive: API returned ok but no product payload (model timed out, etc.)
+    mockApiFetch.mockResolvedValueOnce({ success: true, data: { metadata: {} } })
 
     const { result } = renderHook(() => useProductAnalysis())
 
@@ -263,7 +231,7 @@ describe('analyzeProduct — state management', () => {
       .mockResolvedValueOnce({ success: false, error: 'first error' })
       .mockResolvedValueOnce({
         success: true,
-        data: { analysis: { brand: 'X' } },
+        data: { data: fullProduct(), metadata: {} },
       })
 
     const { result } = renderHook(() => useProductAnalysis())
@@ -295,7 +263,7 @@ describe('analyzeProduct — state management', () => {
     await act(async () => {
       resolveRequest({
         success: true,
-        data: { analysis: { brand: 'X' } },
+        data: { data: fullProduct(), metadata: {} },
       })
       await analyzePromise
     })

--- a/src/hooks/useProductAnalysis.ts
+++ b/src/hooks/useProductAnalysis.ts
@@ -2,17 +2,33 @@
 
 import { useState, useCallback } from 'react'
 import { logger } from '@/lib/logger'
-import { callAnalyzeProductAPI } from '@/lib/api/ai-product-analysis'
-import type { ErfassungFormData } from '@/types/erfassung'
+import { apiFetch } from '@/lib/api/client'
+import type { ErfassungFormData, AIFieldMetadata, VoiceProductData } from '@/types/erfassung'
 
 interface AnalysisResult {
   formData: Partial<ErfassungFormData>
+  metadata: AIFieldMetadata
 }
 
 interface UseProductAnalysisResult {
   isAnalyzing: boolean
   error: string | null
   analyzeProduct: (imageBase64: string) => Promise<AnalysisResult | null>
+}
+
+/** Whitelist AI output to real form fields so formData stays clean. */
+function toFormData(data: VoiceProductData): Partial<ErfassungFormData> {
+  return {
+    hersteller: data.hersteller,
+    produktname: data.produktname,
+    kurzbeschreibung: data.kurzbeschreibung,
+    specs: data.specs,
+    verkaufspreis: data.verkaufspreis,
+    zustand: data.zustand,
+    hauptkategorie: data.hauptkategorie,
+    unterkategorie: data.unterkategorie,
+    kundenprofile: data.kundenprofile,
+  }
 }
 
 export function useProductAnalysis(): UseProductAnalysisResult {
@@ -24,24 +40,22 @@ export function useProductAnalysis(): UseProductAnalysisResult {
     setError(null)
 
     try {
-      const result = await callAnalyzeProductAPI(imageBase64, false)
+      // Full-fidelity staff route — fills ALL fields (specs, category,
+      // description, profiles) with confidence metadata, same as text intake.
+      const result = await apiFetch<{ data: VoiceProductData; metadata: AIFieldMetadata }>(
+        '/api/admin/erfassung/image',
+        { method: 'POST', body: { image: imageBase64 } },
+      )
 
-      if (!result.success) {
+      if (!result.success || !result.data) {
         throw new Error(result.error || 'Analyse fehlgeschlagen')
       }
 
-      const a = result.data?.analysis
-      if (!a) throw new Error('Keine Analysedaten erhalten')
+      const productData = result.data.data
+      if (!productData) throw new Error('Keine Analysedaten erhalten')
 
-      const formData: Partial<ErfassungFormData> = {
-        hersteller: a.brand || '',
-        produktname: a.product_name || '',
-        zustand: a.condition || '',
-        verkaufspreis: a.estimated_price_chf?.toString() || '',
-      }
-
-      logger.info('Image analysis completed', { product: a.product_name })
-      return { formData }
+      logger.info('Image analysis completed', { product: productData.produktname })
+      return { formData: toFormData(productData), metadata: result.data.metadata || {} }
     } catch (err) {
       const message = err instanceof Error ? err.message : 'Analyse fehlgeschlagen'
       logger.error('Image analysis failed', { error: err })

--- a/src/lib/images/__tests__/downscale.test.ts
+++ b/src/lib/images/__tests__/downscale.test.ts
@@ -1,0 +1,29 @@
+/**
+ * Tests for downscaleImage — pre-upload image compression.
+ *
+ * The canvas encode path needs a real browser, so here we lock the safe
+ * passthrough guarantees that matter for correctness: a caller can ALWAYS
+ * upload whatever comes back, and non-raster / unreadable inputs are never
+ * mangled or thrown on.
+ */
+
+import { downscaleImage } from '../downscale'
+
+describe('downscaleImage — safe passthrough', () => {
+  it('returns a non-image data URL unchanged (nothing to downscale)', async () => {
+    const input = 'data:text/plain;base64,aGVsbG8='
+    await expect(downscaleImage(input)).resolves.toBe(input)
+  })
+
+  it('returns a plain (non data-URL) string unchanged', async () => {
+    await expect(downscaleImage('not-a-data-url')).resolves.toBe('not-a-data-url')
+  })
+
+  it('never rejects on an unreadable blob — resolves to a usable string', async () => {
+    // A Blob whose type is not image/* takes the passthrough branch after the
+    // FileReader produces its data URL; the result must be a string.
+    const blob = new Blob(['plain text'], { type: 'text/plain' })
+    const result = await downscaleImage(blob)
+    expect(typeof result).toBe('string')
+  })
+})

--- a/src/lib/images/downscale.ts
+++ b/src/lib/images/downscale.ts
@@ -1,0 +1,127 @@
+/**
+ * Client-side image downscaling (SSOT for pre-upload compression).
+ *
+ * Phone photos routinely weigh 3–12 MB. Sent verbatim as a base64 data URL
+ * they inflate ~33% in JSON, crawl over mobile uplinks, and blow past the
+ * vision providers' per-request image ceilings — which is exactly why photo
+ * analysis returned "Analyse fehlgeschlagen". Downscaling to a sane long-edge
+ * and re-encoding as JPEG makes the upload small, fast and within provider
+ * limits while keeping enough detail for the model to read labels.
+ *
+ * Browser-only (uses <img> + canvas). On the server, or if the browser cannot
+ * decode the file, it returns the original data URL untouched — never throws.
+ */
+
+export interface DownscaleOptions {
+  /** Longest edge in pixels after scaling. Labels stay legible at ~1600. */
+  maxEdge?: number
+  /** JPEG quality 0–1 for the first encode pass. */
+  quality?: number
+  /** Target byte ceiling for the encoded image; quality steps down to meet it. */
+  maxBytes?: number
+}
+
+const DEFAULTS: Required<DownscaleOptions> = {
+  maxEdge: 1600,
+  quality: 0.82,
+  // ~2.6 MB of base64 ≈ ~1.9 MB binary — comfortably under the vision
+  // providers' base64 image limits with headroom for the JSON envelope.
+  maxBytes: 2_600_000,
+}
+
+/** Approximate decoded byte length of a base64 data URL without allocating it. */
+function dataUrlByteLength(dataUrl: string): number {
+  const comma = dataUrl.indexOf(',')
+  const b64 = comma >= 0 ? dataUrl.slice(comma + 1) : dataUrl
+  // 4 base64 chars -> 3 bytes; ignore padding for an estimate.
+  return Math.floor((b64.length * 3) / 4)
+}
+
+function loadImage(src: string): Promise<HTMLImageElement> {
+  return new Promise((resolve, reject) => {
+    const img = new Image()
+    img.onload = () => resolve(img)
+    img.onerror = () => reject(new Error('decode-failed'))
+    img.src = src
+  })
+}
+
+function readAsDataUrl(input: Blob): Promise<string> {
+  return new Promise((resolve, reject) => {
+    const reader = new FileReader()
+    reader.onload = () => resolve(reader.result as string)
+    reader.onerror = () => reject(new Error('read-failed'))
+    reader.readAsDataURL(input)
+  })
+}
+
+/**
+ * Downscale/compress an image to a JPEG data URL.
+ *
+ * @param input A File/Blob or an existing data-URL string.
+ * @returns A JPEG data URL. Falls back to the original data URL if the
+ *          environment or file can't be processed — callers can always upload
+ *          the result as-is.
+ */
+export async function downscaleImage(
+  input: Blob | string,
+  options: DownscaleOptions = {},
+): Promise<string> {
+  const opts = { ...DEFAULTS, ...options }
+
+  // Normalise to a data URL up front so every return path yields something
+  // uploadable, even when canvas/DOM isn't available (SSR, tests).
+  let originalDataUrl: string
+  try {
+    originalDataUrl = typeof input === 'string' ? input : await readAsDataUrl(input)
+  } catch {
+    // Can't even read it — hand back whatever we were given.
+    return typeof input === 'string' ? input : ''
+  }
+
+  // Only raster images are downscalable; anything else passes through.
+  if (typeof document === 'undefined' || !originalDataUrl.startsWith('data:image/')) {
+    return originalDataUrl
+  }
+
+  try {
+    const img = await loadImage(originalDataUrl)
+    const width = img.naturalWidth || img.width
+    const height = img.naturalHeight || img.height
+    if (!width || !height) return originalDataUrl
+
+    const longest = Math.max(width, height)
+    const scale = longest > opts.maxEdge ? opts.maxEdge / longest : 1
+
+    // Nothing to gain: already small and already a JPEG within budget.
+    const alreadyJpeg = originalDataUrl.startsWith('data:image/jpeg')
+    if (scale === 1 && alreadyJpeg && dataUrlByteLength(originalDataUrl) <= opts.maxBytes) {
+      return originalDataUrl
+    }
+
+    const targetW = Math.max(1, Math.round(width * scale))
+    const targetH = Math.max(1, Math.round(height * scale))
+
+    const canvas = document.createElement('canvas')
+    canvas.width = targetW
+    canvas.height = targetH
+    const ctx = canvas.getContext('2d')
+    if (!ctx) return originalDataUrl
+    ctx.drawImage(img, 0, 0, targetW, targetH)
+
+    // Encode, then step quality down until under the byte budget (floor 0.5
+    // so labels stay readable). Guarantees a bounded upload regardless of
+    // how noisy the source photo is.
+    let quality = opts.quality
+    let out = canvas.toDataURL('image/jpeg', quality)
+    while (dataUrlByteLength(out) > opts.maxBytes && quality > 0.5) {
+      quality -= 0.12
+      out = canvas.toDataURL('image/jpeg', quality)
+    }
+
+    // Never return something larger than we started with.
+    return dataUrlByteLength(out) < dataUrlByteLength(originalDataUrl) ? out : originalDataUrl
+  } catch {
+    return originalDataUrl
+  }
+}

--- a/src/lib/schemas/erfassung.ts
+++ b/src/lib/schemas/erfassung.ts
@@ -226,3 +226,16 @@ export const ErfassungTextSchema = z.object({
 });
 
 export type ErfassungTextInput = z.infer<typeof ErfassungTextSchema>;
+
+// Image intake: a base64 data URL. Photos are downscaled client-side, so the
+// ~9 MB char ceiling is a defensive backstop, not the normal case — it keeps a
+// pathological upload from reaching the vision provider (and its own limit).
+export const ErfassungImageSchema = z.object({
+  image: z
+    .string()
+    .min(1, 'Bilddaten erforderlich')
+    .max(9_000_000, 'Bild zu gross. Bitte ein kleineres Foto verwenden.')
+    .refine((v) => v.startsWith('data:image/'), 'Ungültiges Bildformat'),
+});
+
+export type ErfassungImageInput = z.infer<typeof ErfassungImageSchema>;

--- a/src/lib/security/rate-limit.ts
+++ b/src/lib/security/rate-limit.ts
@@ -62,6 +62,12 @@ export const rateLimiters = {
   // AI product analysis: 5 per hour per user (expensive inference)
   aiAnalyze: createRateLimiter(ONE_HOUR_MS, 5),
 
+  // Staff photo intake: 60 per hour. An intake operator photographs many
+  // devices in a session; the public 5/hour ceiling would block real work
+  // after the first handful. Still bounded so a stuck retry loop can't hammer
+  // the vision providers.
+  erfassungImage: createRateLimiter(ONE_HOUR_MS, 60),
+
   // Reviews: 10 per hour per user
   reviewCreate: createRateLimiter(ONE_HOUR_MS, 10),
 

--- a/tests/e2e/helpers/inventory-routes.ts
+++ b/tests/e2e/helpers/inventory-routes.ts
@@ -119,7 +119,9 @@ export const ADMIN_ROUTES: InventoryRoute[] = [
   { id: 114, label: 'Admin donations', path: '/admin/donations' },
   { id: 115, label: 'Admin projects', path: ROUTES.admin.projects, urlPattern: /\/admin\/projects/ },
   { id: 122, label: 'Admin dashboard', path: ROUTES.admin.dashboard, urlPattern: /\/admin/ },
-  { id: 123, label: 'Erfassung', path: ROUTES.admin.erfassung, urlPattern: /\/admin\/erfassung/ },
+  // ROUTES.admin.erfassung canonicalised to /admin/intake/capture; the pattern
+  // must follow the route or this smoke can never match (it lands on capture).
+  { id: 123, label: 'Erfassung', path: ROUTES.admin.erfassung, urlPattern: /\/admin\/intake\/capture/ },
   { id: 125, label: 'Intake pipeline', path: ROUTES.admin.intake },
   { id: 126, label: 'Locations', path: ROUTES.admin.locations, urlPattern: /\/admin\/locations/ },
   { id: 127, label: 'Admin services', path: ROUTES.admin.services, urlPattern: /\/admin\/services/ },


### PR DESCRIPTION
## What & why

Device intake by photo was failing (“Analyse fehlgeschlagen”) and, even when it worked, threw away most of what the vision model read. After a prior “declutter” commit there was also no way to tell the AI to change the extracted data (“make the description longer”, “change the price”). This restores a fast, low-friction capture flow: snap a photo → the whole record fills → review and tweak it in plain language → save.

## Approach

**Reliability — stop sending raw phone photos.** New `src/lib/images/downscale.ts` compresses images client-side to a bounded JPEG (long edge 1600px, quality-stepped under ~2.6 MB) before upload. A 3–12 MB phone photo was inflating in base64, crawling over mobile uplinks and blowing past the vision providers’ per-request image limits — the actual cause of the failures. Used by the Bild tab and the in-form image upload; never throws.

**Full-fidelity fill.** New staff route `POST /api/admin/erfassung/image` returns the *same* rich record as text intake, so photo capture fills specs, category, description and profiles with confidence indicators — not the four-field subset the old lossy `/api/ai/analyze-product` transform handed back. Staff rate limit raised to 60/h.

**Restore the AI review/refine step (intentional).** `AIFormAssist` (formType `erfassung`) is back in the review step, expanded by default. Natural-language edits and quick actions via the shared `FORM_AI_REGISTRY`. Fixed the extract-vs-refine decision for short structured records (a filled “iRobot / Roomba 600 Series / 60” was misread as *empty*, so a tweak would clobber the form) via an opt-in `hasContentOverride` prop — the other 14 forms keep the unchanged heuristic. Note: this deliberately reverses commit `4ebe5ea`, which removed the box as “clutter”; the product owner asked for it back.

**Flow clarity.** Analysis failures are non-destructive (photo stays, message inline, button flips to retry). When the form first fills, the review step scrolls into view instead of appearing silently below the fold on mobile.

**CI fix (pre-existing).** The prod inventory smoke asserted `/admin/erfassung` for route #123, but `ROUTES.admin.erfassung` was canonicalised to `/admin/intake/capture` — the pattern now follows the route. Unrelated to the intake changes; it was failing on main.

## Screenshots / recordings

UI-only change on the capture page. Reporter’s screenshots (Canon MB2350, iRobot Roomba) drove the fixes: the form filled but offered no way to talk to the AI afterward.

## Checklist

- [x] `npm test` — relevant suites green; `useProductAnalysis` test rewritten for the new contract; downscale util tests added
- [x] `npm run lint` clean (only pre-existing warnings in untouched effects)
- [x] `npm run typecheck` clean
- [x] Swiss German: `npm run lint:umlauts` clean
- [x] No `console.log`; uses `logger`
- [x] No hardcoded table names / org data
- [x] Parameterized SQL only (no new SQL)

## Notes for review

- Supersedes the auto-generated caution about the AI-refine box: reinstating it is the explicit ask, and `hasContentOverride` + expanded placement is the mitigation for the earlier “second AI engine” concern (it’s the same `/api/ai/extract` engine every other form uses).
- `/api/ai/analyze-product` is left intact for the public marketplace camera; only erfassung was repointed to the new full-fidelity staff route.
- No DB migrations.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01YDvNuyTRxtRNL8LC3A8RUK