### PR TITLE
fix(org): canonical URL → live host (evig.orangecat.ch has no DNS yet)

### DIFF
--- a/docs/MISSION_STATEMENT.md
+++ b/docs/MISSION_STATEMENT.md
@@ -99,7 +99,7 @@ organisations can adopt it directly.
 
 - **Organisation**: evig (in Gründung)
 - **Base**: Zürich, Switzerland (online-first; no public store or warehouse)
-- **Website**: https://evig.orangecat.ch
+- **Website**: https://revampit.orangecat.ch (live host; `evig.orangecat.ch` pending DNS/infra cutover)
 - **Legal status**: gemeinnütziger Verein in Gründung
 
 ---

--- a/src/config/org.ts
+++ b/src/config/org.ts
@@ -33,8 +33,13 @@ export const ORG = {
   motto: 'Intelligenz, für alle bezahlbar.',
   /** Short description */
   description: 'Gute, langlebige Technik für alle bezahlbar — kuratiert statt Ramsch.',
-  /** Current production app URL. */
-  website: 'https://evig.orangecat.ch',
+  /**
+   * Current production app URL — the LIVE host (Layer B infra). `evig.orangecat.ch`
+   * has no DNS yet; pointing here at a non-resolving domain broke the canonical /
+   * JSON-LD / OG URLs. Keep the working host until the infra cutover (DNS + Caddy
+   * vhost + deploy paths) makes `evig.orangecat.ch` real, then flip this one line.
+   */
+  website: 'https://revampit.orangecat.ch',
   /** evig has no legacy site (new organisation). Empty hides the "zur aktuellen Site" banner. */
   websiteLegacy: '',
   /** Email domain. TODO: register evig.ch + mailboxes. Staff-auth domain lives in permissions.ts. */


### PR DESCRIPTION
## Problem
`src/config/org.ts` set `website: 'https://evig.orangecat.ch'`, but that domain **does not resolve** (`curl` → 000, no DNS). That made the canonical URL, JSON-LD `url`, and OpenGraph URLs point at a dead host — bad for SEO and link previews. Pre-existing (predates the rebrand PRs).

## Fix
Point `website` back to the **live** production host `https://revampit.orangecat.ch` — the Layer-B infra host that actually serves the app (health 200). Per `.claude/CLAUDE.md`, the host stays `revampit.orangecat.ch` until a deliberate infra cutover. Same dead URL fixed in `docs/MISSION_STATEMENT.md`.

## To make `evig.orangecat.ch` the real host later (your infra)
DNS record for `evig.orangecat.ch` → the Hetzner box, a Caddy vhost, and deploy-path/systemd alignment — then flip the one `website` constant.

🤖 Generated with [Claude Code](https://claude.com/claude-code)