### PR TITLE
ci(umlauts): enforce lint:umlauts gate in CI and pre-deploy

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -33,6 +33,11 @@ jobs:
       - name: Run ESLint
         run: npm run lint
 
+      # Enforces the Swiss umlaut convention (display text keeps ä/ö/ü; only
+      # code identifiers/slugs may use ASCII). Was manual-only before — now gated.
+      - name: Check umlauts
+        run: npm run lint:umlauts
+
       - name: Type check
         run: npx tsc --noEmit
 

--- a/.github/workflows/deploy-selfhost.yml
+++ b/.github/workflows/deploy-selfhost.yml
@@ -70,6 +70,10 @@ jobs:
         if: steps.secrets.outputs.configured == 'true'
         run: npm run lint
 
+      - name: Check umlauts
+        if: steps.secrets.outputs.configured == 'true'
+        run: npm run lint:umlauts
+
       - name: Type check
         if: steps.secrets.outputs.configured == 'true'
         run: npm run typecheck


### PR DESCRIPTION
## What

Wires the existing `npm run lint:umlauts` check into:
- **`ci.yml`** — `quality` job, right after ESLint (runs on every PR + push to main)
- **`deploy-selfhost.yml`** — pre-deploy checks, alongside the existing lint/typecheck/i18n gates

## Why

The Swiss umlaut convention — display text keeps `ä/ö/ü`; only code identifiers, slugs, and URL anchors may use ASCII `ue/oe/ae` (documented in `scripts/lint-umlauts.sh`) — was enforced **only when someone ran the script by hand**. That's knowledge-in-a-head, not a gate. This closes the class: a `fuer`/`prueft`/`zurueck` slipping into user-facing text now fails CI instead of shipping.

## Risk

None today — the gate passes clean (`exit 0`) on current `src/`, so this is purely additive and changes no behavior. YAML validated for both workflows.

🤖 Generated with [Claude Code](https://claude.com/claude-code)