### PR TITLE
feat(host): make evig.orangecat.ch canonical (now live)

### DIFF
--- a/.env.selfhost.local.example
+++ b/.env.selfhost.local.example
@@ -9,8 +9,8 @@
 
 DATABASE_URL=postgresql://revampit:YOUR_PROD_PASSWORD@localhost:15432/revampit
 AUTH_SECRET=your-production-auth-secret
-NEXTAUTH_URL=https://revampit.orangecat.ch
-NEXT_PUBLIC_SITE_URL=https://revampit.orangecat.ch
+NEXTAUTH_URL=https://evig.orangecat.ch
+NEXT_PUBLIC_SITE_URL=https://evig.orangecat.ch
 
 # Payrexx — see docs/operations/PAYREXX_SETUP.md (leave unset until go-live)
 # PAYREXX_INSTANCE=

--- a/docs/MISSION_STATEMENT.md
+++ b/docs/MISSION_STATEMENT.md
@@ -99,7 +99,7 @@ organisations can adopt it directly.
 
 - **Organisation**: evig (in Gründung)
 - **Base**: Zürich, Switzerland (online-first; no public store or warehouse)
-- **Website**: https://revampit.orangecat.ch (live host; `evig.orangecat.ch` pending DNS/infra cutover)
+- **Website**: https://evig.orangecat.ch (`revampit.orangecat.ch` remains a working alias)
 - **Legal status**: gemeinnütziger Verein in Gründung
 
 ---

--- a/src/config/org.ts
+++ b/src/config/org.ts
@@ -34,12 +34,11 @@ export const ORG = {
   /** Short description */
   description: 'Gute, langlebige Technik für alle bezahlbar — kuratiert statt Ramsch.',
   /**
-   * Current production app URL — the LIVE host (Layer B infra). `evig.orangecat.ch`
-   * has no DNS yet; pointing here at a non-resolving domain broke the canonical /
-   * JSON-LD / OG URLs. Keep the working host until the infra cutover (DNS + Caddy
-   * vhost + deploy paths) makes `evig.orangecat.ch` real, then flip this one line.
+   * Current production app URL. `evig.orangecat.ch` is live (DNS + Caddy vhost →
+   * the app on the Hetzner box, HTTPS). `revampit.orangecat.ch` remains a working
+   * alias until the deploy paths / systemd identifiers are cut over (Layer B).
    */
-  website: 'https://revampit.orangecat.ch',
+  website: 'https://evig.orangecat.ch',
   /** evig has no legacy site (new organisation). Empty hides the "zur aktuellen Site" banner. */
   websiteLegacy: '',
   /** Email domain. TODO: register evig.ch + mailboxes. Staff-auth domain lives in permissions.ts. */

--- a/src/config/urls.ts
+++ b/src/config/urls.ts
@@ -21,11 +21,11 @@ export const APP_URL =
  * DISTINCT from APP_URL: never falls back to NEXTAUTH_URL, which on the box is
  * the internal bind port (localhost:4004). Used as Next's `metadataBase` so
  * og:image / canonical metadata resolve to real absolute URLs a social scraper
- * can fetch — not localhost. Override with NEXT_PUBLIC_SITE_URL when the public
- * host changes (e.g. once evig.ch / evig.orangecat.ch goes live).
+ * can fetch — not localhost. Override with NEXT_PUBLIC_SITE_URL; prod sets it to
+ * the live host. `revampit.orangecat.ch` remains a working alias.
  */
 export const PUBLIC_SITE_URL =
-  process.env.NEXT_PUBLIC_SITE_URL || 'https://revampit.orangecat.ch'
+  process.env.NEXT_PUBLIC_SITE_URL || 'https://evig.orangecat.ch'
 
 /**
  * Meilisearch URL


### PR DESCRIPTION
`evig.orangecat.ch` is **live** — DNS A record (`→167.233.22.31`) + Caddy vhost (merged into the revampit block, `reverse_proxy 127.0.0.1:4004`), HTTPS with auto cert, `/api/health` → 200. Both `evig` and `revampit` hosts serve. Auth verified safe (`trustHost:true`, host-only cookies; sign-in + session 200 on evig).

Flips the **code** canonical to evig (reverting the #252 dead-URL stopgap now that the host resolves):
- `org.ts` website, `urls.ts` default, `MISSION_STATEMENT.md`, `.env.selfhost.local.example`.

The **build-time** `NEXT_PUBLIC_SITE_URL`/`APP_URL` were already flipped in the `SELFHOST_ENV` secret and the prod runtime `.env`, so merging this rebuilds with evig inlined → OG/canonical/JSON-LD all become evig. `revampit.orangecat.ch` stays a working alias (Layer B deploy paths/systemd unchanged).

🤖 Generated with [Claude Code](https://claude.com/claude-code)