### PR TITLE
test(e2e): de-flake tasks + marketplace journeys

### DIFF
--- a/tests/e2e/marketplace-checkout-journey.spec.ts
+++ b/tests/e2e/marketplace-checkout-journey.spec.ts
@@ -96,8 +96,18 @@ test.describe('Marketplace dual-persona checkout journey', () => {
       await publishAnswer.click()
       await expect(page.getByText(testAnswer)).toBeVisible({ timeout: 15000 })
 
-      const questionsAfterAnswer = await fetchListingQuestions(page.request, listingId)
-      expect(questionsAfterAnswer.find((q) => q.question === testQuestion)?.status).toBe('answered')
+      // The UI confirms the answer above, but the question-status write can lag the
+      // read by a beat — poll the API until it reflects 'answered' instead of a
+      // single racy fetch (which flaked with status still 'open').
+      await expect
+        .poll(
+          async () => {
+            const qs = await fetchListingQuestions(page.request, listingId)
+            return qs.find((q) => q.question === testQuestion)?.status
+          },
+          { timeout: 15000 },
+        )
+        .toBe('answered')
 
       // 2c. Seller cannot buy own listing (must run while listing is still active)
       await loginWithCredentials(

--- a/tests/e2e/tasks-journey.spec.ts
+++ b/tests/e2e/tasks-journey.spec.ts
@@ -65,7 +65,10 @@ test.describe('Admin tasks staff journey', () => {
     await expect(page.getByRole('heading', { name: 'Erledigungen (1)' })).toBeVisible({
       timeout: 15000,
     })
-    await expect(page.getByText('E2E erledigt')).toBeVisible()
+    // .first(): like the empty state above, the completion note renders in two
+    // panes (list + detail), so a bare getByText matches 2 elements once both
+    // panes have hydrated — which flaked under strict mode.
+    await expect(page.getByText('E2E erledigt').first()).toBeVisible()
 
     if (hasDualPersonaCredentials()) {
       await loginWithCredentials(page, '/dashboard', USER_TEST_EMAIL, USER_TEST_PASSWORD)


### PR DESCRIPTION
Fixes the two intermittent `Local E2E Journeys` failures (both localhost, unrelated to product changes — they reddened #254 and #256):

- **tasks-journey**: `getByText('E2E erledigt')` matched **2 elements** under strict mode — the completion note renders in two panes (list + detail). Added `.first()` (mirrors the empty-state handling already in the same test).
- **marketplace-checkout-journey**: **read-after-write race** — the UI confirmed the answer, but a single API re-fetch sometimes still read status `open`. Replaced with `expect.poll(...).toBe('answered')`.

Scoped to the two observed flakes; no product code touched.

🤖 Generated with [Claude Code](https://claude.com/claude-code)