### PR TITLE
chore(ci): converge on the verify SSOT script

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -30,19 +30,12 @@ jobs:
       - name: Install dependencies
         run: npm ci
 
-      - name: Run ESLint
-        run: npm run lint
-
-      # Enforces the Swiss umlaut convention (display text keeps ä/ö/ü; only
-      # code identifiers/slugs may use ASCII). Was manual-only before — now gated.
-      - name: Check umlauts
-        run: npm run lint:umlauts
-
-      - name: Type check
-        run: npx tsc --noEmit
-
-      - name: Build verification
-        run: npm run build
+      # SSOT: lint + umlauts + typecheck + build are bundled in the `verify` npm
+      # script (package.json). CI calls it verbatim so the gating chain can't
+      # drift from what runs locally. Do not re-inline these checks here — the
+      # umlaut gate (Swiss ä/ö/ü convention) lives inside `verify` too.
+      - name: Verify (lint + umlauts + typecheck + build)
+        run: npm run verify
         env:
           # Build-time placeholders so strict env validation doesn't fail during CI compile.
           AUTH_SECRET: ci-build-placeholder-secret-32chars

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -1,0 +1,55 @@
+# AGENTS.md — Revamp-IT
+
+Swiss non-profit tech platform: used computers repaired and rehomed, not landfilled.
+This file is the quick agent brief. The full engineering standards and repo rules
+live in `CLAUDE.md` (+ `.claude/CLAUDE.md` and the imported global standards) — read
+those before non-trivial work. Don't duplicate their content here; this is a pointer.
+
+## Stack
+
+- **Framework:** Next.js 16, TypeScript 5.3 (strict), Tailwind CSS 4
+- **DB:** PostgreSQL + Drizzle ORM. **Prod = self-hosted Postgres on Hetzner**
+  (`DATABASE_URL=…@localhost:5432/revampit`); dev points at its own DB. Neon is retired for prod.
+- **Auth:** NextAuth v5 (Auth.js) + `@auth/pg-adapter`. Staff = `@revamp-it.ch` email.
+- **Search:** Meilisearch · **Payments:** Payrexx
+
+## Develop
+
+```bash
+npm run d        # start everything (services + dev server)
+npm run dev      # frontend only
+```
+
+## Verify — run before every commit
+
+```bash
+npm run verify   # lint + typecheck + build (SSOT)
+```
+
+`verify` is the single gating check bundle. CI's `quality` job in
+`.github/workflows/ci.yml` calls `npm run verify` verbatim, so green locally ⇒ green
+CI for that gate. Do not re-inline lint/typecheck/build in CI — edit the `verify`
+script only. (i18n/umlaut/compliance helpers: `npm run compliance`, `npm run lint:umlauts`.)
+
+## Database migrations
+
+- **Location:** `scripts/db/migrations/*.sql` — forward-only, ordered, protected (never delete/edit applied ones).
+- **`drizzle-kit push` is FORBIDDEN** against dev/prod. Add a new `.sql` migration instead.
+- Apply locally: `npm run db:migrate`. CI replays every migration from zero (Migration Drift job).
+- Deploy auto-applies unrecorded migrations to the prod DB before activating.
+- App enums live in `src/config/*` + zod at the write boundary, NOT in SQL CHECK constraints.
+
+## Deploy — self-hosted
+
+- Production runs at **https://revampit.orangecat.ch** (self-hosted Hetzner).
+  `https://www.revamp-it.ch` is the LEGACY Joomla site — never smoke-test deploys there.
+- Push to `main` → `.github/workflows/deploy-selfhost.yml` runs lint + typecheck +
+  i18n gate, then rsyncs the build to the box via `scripts/selfhost-deploy-revampit.sh`
+  and runs a read-only prod smoke. Health check: `/api/health`.
+
+## Non-negotiables (see CLAUDE.md for the full list + rationale)
+
+- SSOT / DRY / SoC · no god files (>300 lines) · nothing hardcoded (labels, stats, colors)
+- `logger` not `console.log` · `TABLE_NAMES` + parameterized SQL · validate at boundaries
+- Swiss German: real umlauts ä/ö/ü, `ß`→`ss` (`npm run lint:umlauts`)
+- Design tokens only, no arbitrary hex (`grep -rn '\[#' src/` must be empty)

--- a/package.json
+++ b/package.json
@@ -68,6 +68,7 @@
     "deploy:selfhost": "bash scripts/selfhost-deploy-revampit.sh",
     "ship": "bash scripts/ship.sh",
     "typecheck": "tsc -p tsconfig.json --noEmit",
+    "verify": "npm run lint && npm run lint:umlauts && npm run typecheck && npm run build",
     "prod:build": "docker build -f Dockerfile.prod -t revampit-app:latest .",
     "prod:up": "docker compose -f docker-compose.prod.yml up -d",
     "prod:down": "docker compose -f docker-compose.prod.yml down",


### PR DESCRIPTION
Recreates #238 on **current main** (its branch was stale). CI's Code Quality job runs a single `npm run verify` instead of re-inlining lint/typecheck/build — so the gating chain can't drift from what runs locally (matches the "one definition of verified" standard). Adds `AGENTS.md`.

**Conflict resolution + improvement:** `main` had since added a separate `Check umlauts` CI step. I folded `lint:umlauts` **into** the `verify` script (`lint + umlauts + typecheck + build`) so the umlaut gate isn't dropped and `npm run verify` is the complete local SSOT — better than #238's original, which would have dropped it.

Supersedes #238 (now closed).

🤖 Generated with [Claude Code](https://claude.com/claude-code)