### PR TITLE
deps: lucide-react 0.488 -> 1.28 (replace dropped brand icons)

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -40,7 +40,7 @@
         "jsonwebtoken": "^9.0.2",
         "leaflet": "^1.9.4",
         "lru-cache": "^11.2.6",
-        "lucide-react": "0.488.0",
+        "lucide-react": "^1.28.0",
         "next": "^16.2.11",
         "next-auth": "^5.0.0-beta.30",
         "next-intl": "^4.12.0",
@@ -14550,9 +14550,9 @@
       }
     },
     "node_modules/lucide-react": {
-      "version": "0.488.0",
-      "resolved": "https://registry.npmjs.org/lucide-react/-/lucide-react-0.488.0.tgz",
-      "integrity": "sha512-ronlL0MyKut4CEzBY/ai2ZpKPxyWO4jUqdAkm2GNK5Zn3Rj+swDz+3lvyAUXN0PNqPKIX6XM9Xadwz/skLs/pQ==",
+      "version": "1.28.0",
+      "resolved": "https://registry.npmjs.org/lucide-react/-/lucide-react-1.28.0.tgz",
+      "integrity": "sha512-fARAFJULsGuDDydjp6+6blekG/sBIM29TerzLjc9bQUKAcEfrSc4ZQKb25KRz4OMKd87cZTb5dgq0w/T6KufVg==",
       "license": "ISC",
       "peerDependencies": {
         "react": "^16.5.1 || ^17.0.0 || ^18.0.0 || ^19.0.0"

--- a/package.json
+++ b/package.json
@@ -120,7 +120,7 @@
     "jsonwebtoken": "^9.0.2",
     "leaflet": "^1.9.4",
     "lru-cache": "^11.2.6",
-    "lucide-react": "0.488.0",
+    "lucide-react": "^1.28.0",
     "next": "^16.2.11",
     "next-auth": "^5.0.0-beta.30",
     "next-intl": "^4.12.0",

--- a/src/app/[locale]/projects/[slug]/page.tsx
+++ b/src/app/[locale]/projects/[slug]/page.tsx
@@ -5,7 +5,7 @@ export const dynamic = 'force-dynamic'
 import type { Metadata } from 'next'
 import { notFound } from 'next/navigation'
 import { getTranslations } from 'next-intl/server'
-import { ArrowLeft, ExternalLink, Github, Scale } from 'lucide-react'
+import { ArrowLeft, ExternalLink, GitBranch, Scale } from 'lucide-react'
 import { Link } from '@/i18n/navigation'
 import { PageHero } from '@/components/layout/PageHero'
 import { Section } from '@/components/layout/Section'
@@ -73,7 +73,7 @@ export default async function ProjectDetailPage({ params }: ProjectDetailProps) 
                 )}
                 {project.repoUrl && (
                   <a href={project.repoUrl} target="_blank" rel="noopener noreferrer" className="inline-flex items-center gap-2 text-action hover:underline underline-offset-2">
-                    <Github className="h-4 w-4" /> {t('detail.source')}
+                    <GitBranch className="h-4 w-4" /> {t('detail.source')}
                   </a>
                 )}
                 {project.license && (

--- a/src/app/services/open-source-solutions/data.ts
+++ b/src/app/services/open-source-solutions/data.ts
@@ -25,7 +25,7 @@ import {
   FileCheck,
   FileX,
   FileText,
-  Chrome,
+  Compass,
   Image,
   Video,
   Cloud,
@@ -256,7 +256,7 @@ export const consumerComparisons: Comparison[] = [
     },
     proprietary: {
       name: 'Chrome/Edge',
-      icon: Chrome,
+      icon: Compass,
       cost: 'Kostenlos mit Datenerfassung',
       comparisons: [
         'Umfangreiche Datenerfassung und Tracking',


### PR DESCRIPTION
Supersedes #263, which could not go green on its own: lucide v1 removes brand icons and two were in use, so dependabot's version-only bump failed typecheck.

```
error TS2305: Module '"lucide-react"' has no exported member 'Github'.
error TS2724: '"lucide-react"' has no exported member named 'Chrome'.
```

## Changes

| Was | Now | Where |
|---|---|---|
| `Github` | `GitBranch` | "view source" link on a project's `repoUrl` |
| `Chrome` | `Compass` | Chrome/Edge row of the browser comparison |

`Compass` rather than `Globe` because **`Globe` is already the icon on the Firefox/Brave row directly above it** — reusing it would have collapsed the open-source vs proprietary distinction that comparison exists to draw.

## Verification

- `npm run typecheck` — clean. This is the meaningful check: it enumerates every icon export in use, so any *other* glyph dropped in v1 would have failed here. Only these two did.
- `npm run lint` — 48 warnings, 0 errors: **the same count as main**, so the bump adds no new lint debt.
- Both replacement icons confirmed present in the installed v1 package before use.

Build runs in CI.

🤖 Generated with [Claude Code](https://claude.com/claude-code)