### PR TITLE
fix(ci): grant the sweep the workflows scope it needs to merge CI changes

### DIFF
--- a/.github/workflows/auto-merge.yml
+++ b/.github/workflows/auto-merge.yml
@@ -28,6 +28,11 @@ permissions:
   contents: write # merge the PR
   pull-requests: write # read PR state, delete the branch
   actions: write # dispatch the re-arm workflows
+  # Merging a PR that edits .github/workflows/ writes those files to the base
+  # branch, which GitHub gates on this scope. Without it the sweep reads such a
+  # PR as MERGEABLE/BLOCKED and every merge path is refused — gh, --auto, and
+  # the REST endpoint alike — while PRs touching nothing else merge normally.
+  workflows: write
 
 # Never let two sweeps merge concurrently — they would race on the same PRs.
 concurrency:


### PR DESCRIPTION
## What this fixes

The auto-merge sweep cannot merge any PR that edits `.github/workflows/`.

Merging such a PR writes workflow files to the base branch, and GitHub gates
that on the `workflows` permission — which `auto-merge.yml` never granted. The
symptom is indirect and misleading: `GITHUB_TOKEN` is told the PR is

```
MERGEABLE/BLOCKED
```

while a PAT reads the *same PR at the same moment* as `MERGEABLE/**CLEAN**`,
because `mergeStateStatus` is computed **per viewer**.

Every merge path is refused identically — `gh pr merge`, `gh pr merge --auto`
(#283), and `PUT /pulls/{n}/merge` (#286). Ruled out along the way:

| checked | result |
|---|---|
| branch protection on `main` | exists, **every option disabled** |
| rulesets / CODEOWNERS / required checks / required reviews | none |
| "the bot can't write workflows at all" | false — #224/#225/#226 modify workflows and merged |

## Blast radius

#278 and #282 have been green and unmergeable through eight sweeps. Both fix
CI itself, so both are in exactly the class this blocks.

## ⚠️ This PR cannot merge itself

It *is* the change that grants the permission, so it needs **one merge by
hand**. After that the queue is self-draining again — including #278 and #282.

🤖 Generated with [Claude Code](https://claude.com/claude-code)