### PR TITLE
fix(ci): remove the invalid workflows permission that killed every sweep

### DIFF
--- a/.github/workflows/auto-merge.yml
+++ b/.github/workflows/auto-merge.yml
@@ -28,11 +28,15 @@ permissions:
   contents: write # merge the PR
   pull-requests: write # read PR state, delete the branch
   actions: write # dispatch the re-arm workflows
-  # Merging a PR that edits .github/workflows/ writes those files to the base
-  # branch, which GitHub gates on this scope. Without it the sweep reads such a
-  # PR as MERGEABLE/BLOCKED and every merge path is refused — gh, --auto, and
-  # the REST endpoint alike — while PRs touching nothing else merge normally.
-  workflows: write
+
+# KNOWN LIMIT — PRs that edit .github/workflows/ cannot be merged by this
+# sweep. GITHUB_TOKEN has no workflow-writing scope AT ALL: `workflows: write`
+# is not a valid permissions key (adding it makes this file unparseable and
+# silently kills every trigger — that exact mistake shipped as #287 and took
+# the sweep down for 5 hours). To GITHUB_TOKEN such a PR reads as
+# MERGEABLE/BLOCKED and gh, --auto, and the REST endpoint all refuse it.
+# Those PRs need a merge with a personal token (`gh pr merge --squash` as a
+# user); everything else self-merges here.
 
 # Never let two sweeps merge concurrently — they would race on the same PRs.
 concurrency:


### PR DESCRIPTION
## What happened

#287 added `workflows: write` to auto-merge.yml's permissions. **That key does not exist** — GitHub refuses to parse the file:

```
HTTP 422: failed to parse workflow: (Line: 35, Col: 3): Unexpected value 'workflows'
```

A workflow that fails to parse fires on **no trigger at all**: no cron, no `workflow_run`, no dispatch. Auto-merge has been dead since #287 merged at 14:08Z — the run list confirms zero sweeps in 5 hours on a `*/10` cron.

## The truth #287 was reaching for

`GITHUB_TOKEN` has **no scope of any kind** that permits writing workflow files. A PR editing `.github/workflows/` therefore reads as `MERGEABLE/BLOCKED` to the bot (per-viewer status) and every merge path — `gh pr merge`, `--auto`, REST — refuses. That is a platform limit, not a config gap; no permissions line fixes it.

Policy, now documented at the permissions block: workflow-editing PRs take one `gh pr merge --squash` with a personal token; everything else self-merges via the sweep.

🤖 Generated with [Claude Code](https://claude.com/claude-code)