### PR TITLE
fix(security): bump js-yaml to 4.3.1 for CVE-2026-59870

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -13145,9 +13145,9 @@
       "license": "MIT"
     },
     "node_modules/js-yaml": {
-      "version": "4.3.0",
-      "resolved": "https://registry.npmjs.org/js-yaml/-/js-yaml-4.3.0.tgz",
-      "integrity": "sha512-1td788aAnnZ5qs7V2QIRl1owjtYpbKt749Y3xauqQgwIIGF/xXWz1wMTEBx5O3LK3lXLVuqXPdPxj2BoFHaW9Q==",
+      "version": "4.3.1",
+      "resolved": "https://registry.npmjs.org/js-yaml/-/js-yaml-4.3.1.tgz",
+      "integrity": "sha512-CY6crGq313MX8GkwvB7tzgp99vjQxY1++5y10/BKN/GUfHqWaOGQMNZkBvqSzsZKWk/ijwHlWzzkLulsGHhjWQ==",
       "funding": [
         {
           "type": "github",

--- a/package.json
+++ b/package.json
@@ -183,7 +183,7 @@
     "ajv": "^6.14.0",
     "minimatch": "^10.2.1",
     "nodemailer": "^9.0.1",
-    "js-yaml": "^4.3.0",
+    "js-yaml": "^4.3.1",
     "basic-ftp": ">=5.3.0",
     "postcss": "^8.5.26",
     "esbuild": "0.28.1",


### PR DESCRIPTION
Closes the one high advisory the daily security audit filed as #289: quadratic CPU in js-yaml `!!omap` resolution, vulnerable `>=4.0.0 <4.3.1`.

- Override floor raised `^4.3.0` → `^4.3.1`, lock refreshed.
- **Resolved tree verified**, per the 2026-08-06 lesson: the lockfile holds a single deduped `js-yaml@4.3.1` — no nested vulnerable copy behind a patched hoisted one.
- Install-time audit: 0 vulnerabilities. 441 tests green, including the blog frontmatter path that uses js-yaml as gray-matter's engine.

#289 closes itself on the next scheduled audit after this merges.

🤖 Generated with [Claude Code](https://claude.com/claude-code)