### PR TITLE
perf(ci): halve CI wall-clock by dropping a dependency e2e never had

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -151,7 +151,18 @@ jobs:
   e2e-local:
     name: Local E2E Journeys
     runs-on: ubuntu-latest
-    needs: [quality, migrations]
+    # Deliberately NO `needs:`. This job is self-contained — it brings its own
+    # postgres service, applies its own migrations, seeds its own data, builds
+    # the app and starts its own server. It consumed no output from `quality`
+    # or `migrations`; both were gates expressed as dependencies, and they cost
+    # the full 373s of `quality` on the critical path of the second-longest job.
+    #
+    # Measured before: quality 373s → e2e 336s = 709s wall-clock.
+    # `needs:` is for "I use what that job produced", not "I prefer to run
+    # after it". Every job here remains a required check regardless of order.
+    #
+    # Trade-off, stated: a PR that fails lint now also spends the e2e minutes
+    # rather than being cut off early.
     services:
       postgres:
         image: pgvector/pgvector:pg17


### PR DESCRIPTION
## The number

Last green `main` run:

| Job | Duration | Starts at |
|---|---|---|
| Code Quality Checks | 373s | t+0 |
| Migration Drift Check | 34s | t+0 |
| **Local E2E Journeys** | **336s** | **t+373** |

**709s total** — for a verdict every input to which existed by ~373s.

## Why the dependency is false

`e2e-local` declared `needs: [quality, migrations]`, but read nothing from either. Its own steps are:

```
services: postgres        ← its own database
Apply migrations          ← its own schema
Seed E2E data             ← its own fixtures
Build app                 ← its own build
Start app                 ← its own server
Run Playwright journeys
```

No `download-artifact`, no `needs.*.outputs`. Both entries were **gates written as dependencies**.

`needs:` should mean *"I use what that job produced"*, not *"I would rather run after it"*. Every job stays a required check either way — ordering and gating are separate concerns, and conflating them is what cost the 373s.

Expected after: `quality` becomes the critical path, ~373s. Roughly half, at **zero extra runner cost** (same jobs, same minutes, different order).

## Trade-off, stated

A PR that fails lint now also spends the e2e minutes instead of being cut off early.

## What I deliberately did *not* change

This repo has `workers: process.env.CI ? 1 : undefined` — the same stock Playwright scaffold I just raised to 3 in `aoz-housing`. Here it does not pay, and the step timings say why:

```
181s  Build app
 56s  Run Playwright E2E journeys   ← the only part `workers` affects
```

Raising it would buy ~30s and add parallel-flake risk for it. Same flag, opposite verdict — **the number decides, not the pattern.**

Caching `.next/cache` to cut the 181s build is likewise skipped: with e2e no longer gated, `quality` at 373s is the critical path, so a faster e2e job would not move total wall-clock at all.

Related: maonakamoto/aoz-housing#55 — same class of defect, found by the same question.