### PR TITLE
perf(ci): unblock the prod smoke jobs — 634s → ~450s

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -50,7 +50,12 @@ jobs:
   auth-smoke:
     name: Auth Smoke Test
     runs-on: ubuntu-latest
-    needs: quality
+    # Deliberately NO `needs:`. This job tests the ALREADY-DEPLOYED production
+    # site (PLAYWRIGHT_BASE_URL defaults to https://revampit.orangecat.ch); it
+    # never builds this branch and reads nothing `quality` produced. Waiting on
+    # `quality` (429s) was ordering, not dependency — and after #303 unblocked
+    # the e2e job, this pair became the new critical path: quality 429s →
+    # inventory-smoke 181s = 610s of a 634s run.
     steps:
       - name: Checkout code
         uses: actions/checkout@v7
@@ -90,7 +95,10 @@ jobs:
   inventory-smoke:
     name: Dual-Persona Inventory Smoke
     runs-on: ubuntu-latest
-    needs: quality
+    # Deliberately NO `needs:` — same reason as auth-smoke above. This walks 186
+    # routes on the LIVE site via scripts/e2e-inventory-prod.sh; nothing about
+    # that verdict depends on whether this branch lints. Removing the wait moves
+    # 181s off the critical path without changing what is checked.
     steps:
       - name: Checkout code
         uses: actions/checkout@v7


### PR DESCRIPTION
## The number

#303 predicted ~373s and delivered 634s. This PR explains the gap and closes it.

Removing the e2e job's false `needs:` worked — e2e now starts at t+0 and finishes
in 400s, comfortably inside the run. But it only revealed the next layer of the
same defect. Measured on run
[31901402584](https://github.com/maonakamoto/evig/actions/runs/31901402584)
(`main`, after #303 merged):

| job | duration | starts at |
|---|---|---|
| Code Quality Checks | 429s | +0 |
| Local E2E Journeys | 400s | +0 |
| **Dual-Persona Inventory Smoke** | **181s** | **+435** ⟵ waited on quality |
| **Auth Smoke Test** | **73s** | **+434** ⟵ waited on quality |
| Migration Drift Check | 39s | +0 |
| Dependency Security Audit | 38s | +0 |
| **total** | **634s** | |

Critical path = quality 429s → inventory-smoke 181s = **610s of a 634s run**.

## Why the wait is false

Both smoke jobs test the **already-deployed production site** —
`PLAYWRIGHT_BASE_URL` defaults to `https://revampit.orangecat.ch`, and
`inventory-smoke` runs `scripts/e2e-inventory-prod.sh` over 186 live routes.
Neither builds this branch. Neither downloads an artifact. Neither reads a
`needs.<job>.output`. Whether this branch lints has no bearing on whether prod
is healthy, so `needs: quality` was ordering expressed as dependency.

`post-main` keeps its `needs:` — it reads `needs.quality.result` and friends to
compute the run verdict. That one is real.

## Expected after

Critical path collapses to `quality` alone: **~450s**. Verified by this PR's own
run — compare against the 634s above.

## Trade-off, stated

The smoke jobs now run even when lint fails, so a broken PR spends those runner
minutes instead of being cut off early. Same trade as #303: all verdicts at
once rather than in sequence.

🤖 Generated with [Claude Code](https://claude.com/claude-code)