### PR TITLE
fix(security): a vote is cast by whoever proves it, not whoever types an email

### DIFF
--- a/src/app/api/vote/[id]/__tests__/route.test.ts
+++ b/src/app/api/vote/[id]/__tests__/route.test.ts
@@ -5,12 +5,27 @@
  *
  * Behaviors locked:
  *   GET  - 404 (decision not found), 200 (with decision data)
- *   POST - 400 (no email), 400 (no voteData), 404 (user not found),
- *          400 (submitVote returns error), 200 (success)
+ *   POST - 400 (no email), 400 (no voteData),
+ *          400 (submitVote returns error), 200 (anonymous success)
+ *
+ * Security invariant (the reason this route exists in its current shape):
+ * an unauthenticated caller can NEVER vote as a registered member. Identity
+ * comes from the session; a body email only ever names an anonymous voter.
+ * The negative cases below are the point — they assert the closed side.
  */
 
 const mockGetPublicDecision = jest.fn()
 const mockSubmitVote = jest.fn()
+const mockAuth = jest.fn()
+const mockGetDbUserId = jest.fn()
+
+jest.mock('@/auth', () => ({
+  auth: () => mockAuth(),
+}))
+
+jest.mock('@/lib/api/task-helpers', () => ({
+  getDbUserId: (...args: unknown[]) => mockGetDbUserId(...args),
+}))
 
 jest.mock('@/lib/services/decisions', () => ({
   getPublicDecision: (...args: unknown[]) => mockGetPublicDecision(...args),
@@ -67,7 +82,11 @@ beforeEach(() => {
 
   ;(rateLimiters.voteSubmit as jest.Mock).mockReturnValue(true)
   mockGetPublicDecision.mockResolvedValue(MOCK_DECISION)
-  mockQuery.mockResolvedValue({ rows: [{ id: 'user-1' }] })
+  // Default: no session, and the typed email belongs to nobody — the ordinary
+  // "someone opened a shared link" case.
+  mockAuth.mockResolvedValue(null)
+  mockQuery.mockResolvedValue({ rows: [] })
+  mockGetDbUserId.mockResolvedValue({ dbUserId: 'user-1' })
   mockSubmitVote.mockResolvedValue({ vote: { id: 'vote-1', optionId: 'opt-1' } })
 })
 
@@ -164,8 +183,6 @@ describe('POST /api/vote/[id] — missing voteData', () => {
 
 describe('POST /api/vote/[id] — anonymous voter', () => {
   it('submits anonymously when email is not registered', async () => {
-    mockQuery.mockResolvedValueOnce({ rows: [] })
-
     const req = new NextRequest('http://localhost/api/vote/decision-1', {
       method: 'POST',
       body: JSON.stringify({ email: 'unknown@example.com', voteData: { optionId: 'opt-1' } }),
@@ -236,6 +253,73 @@ describe('POST /api/vote/[id] — success', () => {
       expect.stringContaining('SELECT id FROM'),
       ['voter@example.com']
     )
-    expect(mockSubmitVote).toHaveBeenCalledWith('decision-1', { userId: 'user-1' }, { optionId: 'opt-1' })
+    expect(mockSubmitVote).toHaveBeenCalledWith(
+      'decision-1',
+      { voterEmail: 'voter@example.com' },
+      { optionId: 'opt-1' }
+    )
+  })
+})
+
+// ============================================================================
+// POST — identity may never be asserted by the request body
+// ============================================================================
+
+describe('POST /api/vote/[id] — cannot vote as a registered member', () => {
+  it('refuses an unauthenticated ballot claiming a registered email', async () => {
+    mockQuery.mockResolvedValueOnce({ rows: [{ id: 'victim-user' }] })
+
+    const req = new NextRequest('http://localhost/api/vote/decision-1', {
+      method: 'POST',
+      body: JSON.stringify({ email: 'Member@Example.com', voteData: { optionId: 'opt-1' } }),
+      headers: { 'Content-Type': 'application/json' },
+    })
+    const response = await POST(req, { params: Promise.resolve({ id: 'decision-1' }) })
+
+    expect(response.status).toBe(400)
+    const body = await response.json()
+    expect(body.error).toMatch(/registrierten Konto/i)
+    // The whole point: no ballot is cast, so the member's existing vote
+    // cannot be overwritten and allow_public_voting cannot be bypassed.
+    expect(mockSubmitVote).not.toHaveBeenCalled()
+  })
+
+  it('never passes a userId derived from the request body', async () => {
+    mockQuery.mockResolvedValue({ rows: [{ id: 'victim-user' }] })
+
+    for (const email of ['member@example.com', 'MEMBER@example.com ']) {
+      const req = new NextRequest('http://localhost/api/vote/decision-1', {
+        method: 'POST',
+        body: JSON.stringify({ email, voteData: { optionId: 'opt-1' } }),
+        headers: { 'Content-Type': 'application/json' },
+      })
+      await POST(req, { params: Promise.resolve({ id: 'decision-1' }) })
+    }
+
+    for (const call of mockSubmitVote.mock.calls) {
+      expect(call[1]).not.toHaveProperty('userId')
+    }
+  })
+})
+
+describe('POST /api/vote/[id] — signed-in voter', () => {
+  it('votes as the session user and ignores the email in the body', async () => {
+    mockAuth.mockResolvedValueOnce({ user: { email: 'me@example.com' } })
+
+    const req = new NextRequest('http://localhost/api/vote/decision-1', {
+      method: 'POST',
+      body: JSON.stringify({ email: 'someone-else@example.com', voteData: { optionId: 'opt-1' } }),
+      headers: { 'Content-Type': 'application/json' },
+    })
+    const response = await POST(req, { params: Promise.resolve({ id: 'decision-1' }) })
+
+    expect(response.status).toBe(200)
+    expect(mockSubmitVote).toHaveBeenCalledWith(
+      'decision-1',
+      { userId: 'user-1' },
+      { optionId: 'opt-1' }
+    )
+    // The body email is never looked up when a session decides identity.
+    expect(mockQuery).not.toHaveBeenCalled()
   })
 })

--- a/src/app/api/vote/[id]/route.ts
+++ b/src/app/api/vote/[id]/route.ts
@@ -6,11 +6,18 @@
  *
  * This endpoint is intentionally public so decisions can be shared via
  * link (email, phone, etc.) without requiring an admin account.
- * Voter identity: registered account if email matches, anonymous otherwise (when allow_public_voting=true).
+ *
+ * Voter identity comes from the SESSION, never from the request body. A
+ * signed-in member votes as themselves; everyone else votes anonymously by
+ * email (only when allow_public_voting=true). An email in the body is an
+ * unproven claim — see the POST handler.
  */
 
 import { NextRequest, NextResponse } from 'next/server'
+import { auth } from '@/auth'
 import { query } from '@/lib/auth/db'
+import type { ValidSession } from '@/lib/api/middleware'
+import { getDbUserId } from '@/lib/api/task-helpers'
 import { submitVote, getPublicDecision } from '@/lib/services/decisions'
 import { TABLE_NAMES } from '@/config/database'
 import { logger } from '@/lib/logger'
@@ -71,39 +78,62 @@ export async function POST(
     const body = await request.json()
     const { email, voteData } = body as { email?: string; voteData?: unknown }
 
-    if (!email || typeof email !== 'string') {
-      return apiBadRequest(ERROR_MESSAGES.EMAIL_REQUIRED)
-    }
     if (!voteData) {
       return apiBadRequest(ERROR_MESSAGES.VOTE_DATA_REQUIRED)
     }
 
-    const normalizedEmail = email.toLowerCase().trim()
+    // Identity is proven by the session cookie, never asserted by the body.
+    const session = await auth()
+    let voterIdentity: { userId: string } | { voterEmail: string }
 
-    // Try to match to a registered account — anonymous fallback otherwise
-    const userResult = await query<{ id: string }>(
-      `SELECT id FROM ${TABLE_NAMES.USERS} WHERE email = $1`,
-      [normalizedEmail]
-    )
+    if (session?.user?.email) {
+      const userLookup = await getDbUserId(session as ValidSession)
+      if ('error' in userLookup) return userLookup.error
+      voterIdentity = { userId: userLookup.dbUserId }
+    } else {
+      if (!email || typeof email !== 'string') {
+        return apiBadRequest(ERROR_MESSAGES.EMAIL_REQUIRED)
+      }
 
-    const voterIdentity = userResult.rows.length > 0
-      ? { userId: userResult.rows[0].id }
-      : { voterEmail: normalizedEmail }
+      const normalizedEmail = email.toLowerCase().trim()
+
+      // A body-supplied email is an unproven claim, so it may only ever
+      // identify an anonymous voter. If it belongs to a real account, casting
+      // this ballot as that member would let anyone vote in their name — on a
+      // private decision, over their existing vote. Make them prove it first.
+      const registered = await query<{ id: string }>(
+        `SELECT id FROM ${TABLE_NAMES.USERS} WHERE email = $1`,
+        [normalizedEmail]
+      )
+      if (registered.rows.length > 0) {
+        return apiBadRequest(ERROR_MESSAGES.VOTE_EMAIL_REGISTERED)
+      }
+
+      voterIdentity = { voterEmail: normalizedEmail }
+    }
 
     // Delegate to submitVote — it enforces allow_public_voting for anonymous voters
     const result = await submitVote(decisionId, voterIdentity, voteData as Parameters<typeof submitVote>[2])
+
+    const isAnonymous = 'voterEmail' in voterIdentity
 
     if ('error' in result) {
       const messages: Record<string, string> = {
         not_found: ERROR_MESSAGES.DECISION_NOT_FOUND,
         not_voting_phase: ERROR_MESSAGES.VOTE_NOT_IN_VOTING_PHASE_PUBLIC,
-        not_participant: ERROR_MESSAGES.VOTE_NOT_PUBLIC,
+        // Same code, two different situations: an anonymous voter hit a
+        // non-public decision ("sign in"), a signed-in one is outside the
+        // participant scope ("you aren't invited") — telling the latter to
+        // sign in would send them in a circle.
+        not_participant: isAnonymous
+          ? ERROR_MESSAGES.VOTE_NOT_PUBLIC
+          : ERROR_MESSAGES.VOTE_NOT_PARTICIPANT,
         invalid_data: ERROR_MESSAGES.VOTE_INVALID_DATA,
       }
       return apiBadRequest(messages[result.error as string] || ERROR_MESSAGES.VOTE_SUBMIT_FAILED)
     }
 
-    logger.info('Public vote submitted', { decisionId, voterIdentity: 'voterEmail' in voterIdentity ? 'anonymous' : 'registered' })
+    logger.info('Public vote submitted', { decisionId, voterIdentity: isAnonymous ? 'anonymous' : 'registered' })
     return apiSuccess(result.vote)
   } catch (error) {
     return apiError(error, ERROR_MESSAGES.INTERNAL_SERVER_ERROR)

--- a/src/config/error-messages.ts
+++ b/src/config/error-messages.ts
@@ -113,6 +113,7 @@ export const ERROR_MESSAGES = {
   VOTE_SUBMIT_FAILED: 'Fehler beim Abgeben der Stimme',
   VOTE_DATA_REQUIRED: 'Stimmdaten erforderlich',
   VOTE_NOT_PUBLIC: 'Diese Abstimmung ist nicht öffentlich. Bitte melde dich mit einem registrierten Konto an.',
+  VOTE_EMAIL_REGISTERED: 'Diese E-Mail gehört zu einem registrierten Konto. Bitte melde dich an, um damit abzustimmen.',
   DECISION_NOT_ACTIVE: 'Entscheidung nicht gefunden oder nicht aktiv',
   VOTE_NOT_IN_VOTING_PHASE_PUBLIC: 'Diese Abstimmung läuft gerade nicht',
   COMMENT_NOT_AUTHOR: 'Nur der Autor kann diesen Kommentar bearbeiten',


### PR DESCRIPTION
## The hole

`POST /api/vote/[id]` is public on purpose — decisions are shared by link and answering one should not require an account. But it read `email` from the request body, looked it up in `users`, and when it matched, cast the ballot **as that member**.

An email address is a name, not a proof. So anyone who knew a member's address could:

- vote on a decision with `allow_public_voting = false` — that flag only ever guarded the anonymous branch, so a body email that matched an account skipped it entirely;
- have the ballot recorded under that member's identity and displayed as theirs in the results;
- **overwrite the vote they had already cast**, via `ON CONFLICT … DO UPDATE`.

No authentication, no token, no rate limit that mattered — just an email address.

## The fix

Identity comes from the session cookie and nothing else.

- **Signed in** → vote as the session user. The body email is ignored entirely.
- **Not signed in** → vote anonymously by email, which still requires `allow_public_voting`.
- **Not signed in, but the email belongs to a real account** → refused, with "sign in to vote with this address". Recording it as an anonymous ballot instead would leave the same impersonation open one level down, and would double-count against that member's real vote.

Nothing is lost. Registered members already had `POST /api/decisions/[id]/votes` behind `withAuth`. CSRF already covers `/api/vote/` (it is not in `excludedPaths`), which is what makes reading the session in this route safe to add.

## One correctness fix alongside it

`submitVote` returns a single `not_participant` code for two different situations. For an anonymous voter it means "this decision is not public — sign in"; for a signed-in one it means "you are not in the participant scope". Now that signed-in members reach this route, the one-size message would have told someone who *is* signed in to go sign in. The route now picks by branch.

## The test was pointing the wrong way

The suite asserted the vulnerability as intended behaviour:

```ts
expect(mockSubmitVote).toHaveBeenCalledWith(
  'decision-1', { userId: 'user-1' }, { optionId: 'opt-1' })
```

That is why it survived review. It now asserts the closed side — no unauthenticated request may put a `userId` into `submitVote`, whatever it puts in the body — and I confirmed the new tests **fail against the old route** (3 of 12) rather than assuming they would.

## Blast radius

Production has **1 decision and 0 votes**, so nothing was ever cast through this and there is no forged data to clean up. I swept for the same shape elsewhere — routes resolving a user from body data, or trusting a body `userId` — and this was the only instance, so it is fixed rather than lint-ruled.

## Verification

- 2354 tests green across 251 suites (`src/app/api`, `src/lib/services`)
- ESLint clean on the changed files; umlaut linter clean
- Full local `tsc` is **not** a usable signal in this worktree: the shared `node_modules` predates two dependency changes (`@fleet/ai-forms` is in `package-lock.json` but not installed; `@tiptap/extension-table` resolves to 2.27.2 against a `^3.29.2` spec), producing 15 pre-existing errors in files this PR does not touch. CI installs cleanly and is green on `main`, so CI is the authority here.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
