### PR TITLE
test(ci): stop discarding the unit suite, and repair the 25 assertions it hid

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -31,11 +31,14 @@ jobs:
       - name: Install dependencies
         run: npm ci
 
-      # SSOT: lint + umlauts + typecheck + build are bundled in the `verify` npm
-      # script (package.json). CI calls it verbatim so the gating chain can't
-      # drift from what runs locally. Do not re-inline these checks here — the
-      # umlaut gate (Swiss ä/ö/ü convention) lives inside `verify` too.
-      - name: Verify (lint + umlauts + typecheck + build)
+      # SSOT: lint + umlauts + typecheck + test + build are bundled in the
+      # `verify` npm script (package.json). CI calls it verbatim so the gating
+      # chain can't drift from what runs locally. Do not re-inline these checks
+      # here — the umlaut gate (Swiss ä/ö/ü convention) lives inside `verify`
+      # too. Unit tests are ALSO run by the standalone `test` job below, which
+      # the post-main verdict needs by name; that duplication is deliberate and
+      # parallel (no wall-clock cost), not an oversight.
+      - name: Verify (lint + umlauts + typecheck + test + build)
         run: npm run verify
         env:
           # Build-time placeholders so strict env validation doesn't fail during CI compile.
@@ -251,10 +254,17 @@ jobs:
             revampit-e2e.log
           if-no-files-found: ignore
 
-  # Unit tests (still non-blocking while suite matures)
+  # Unit tests. This job ran with `continue-on-error: true` from the day it was
+  # added ("non-blocking while suite matures"), and the suite matured to 7,769
+  # tests without anyone flipping it back. The cost was not hypothetical: the
+  # 2026-07-28 primary-* -> success-* token sweep left 25 assertions failing in
+  # 15 suites, and every PR since reported this job green. A gate whose result
+  # is discarded is not a gate — it is a 6-minute no-op that buys confidence it
+  # has not earned.
   test:
     name: Run Tests
     runs-on: ubuntu-latest
+    timeout-minutes: 20
     if: github.event_name == 'pull_request'
     steps:
       - name: Checkout code
@@ -271,7 +281,6 @@ jobs:
 
       - name: Run tests
         run: npm run test
-        continue-on-error: true
 
   # Dependency advisories. Blocks a PR that INTRODUCES a critical; high and
   # below are reported but do not fail, because a third party publishing an

--- a/jest.config.js
+++ b/jest.config.js
@@ -1,3 +1,16 @@
+// Pin the suite's timezone BEFORE anything constructs a Date.
+//
+// src/lib/date-formats.ts deliberately renders every timestamp in
+// Europe/Zurich (without it, a server-rendered 15:00 workshop shows 1-2h off).
+// Tests then build reference dates with `new Date(2026, 4, 15, 14, 30)`, which
+// is the RUNNER's local time — so the same assertion means "14:30" on a Swiss
+// laptop and "16:30" on a UTC CI runner. Six date tests were failing on every
+// CI run for exactly this reason, invisibly, because the job discarded its own
+// result. Pinning here rather than in each npm script keeps one source of
+// truth: test, test:watch, test:coverage and test:i18n all load this config,
+// and jest's worker processes inherit the env set at config-load time.
+process.env.TZ = 'Europe/Zurich'
+
 const nextJest = require('next/jest')
 
 const createJestConfig = nextJest({

--- a/package.json
+++ b/package.json
@@ -68,7 +68,7 @@
     "deploy:selfhost": "bash scripts/selfhost-deploy-revampit.sh",
     "ship": "bash scripts/ship.sh",
     "typecheck": "tsc -p tsconfig.json --noEmit",
-    "verify": "npm run lint && npm run lint:umlauts && npm run typecheck && npm run build",
+    "verify": "npm run lint && npm run lint:umlauts && npm run typecheck && npm run test && npm run build",
     "prod:build": "docker build -f Dockerfile.prod -t revampit-app:latest .",
     "prod:up": "docker compose -f docker-compose.prod.yml up -d",
     "prod:down": "docker compose -f docker-compose.prod.yml down",

--- a/src/config/__tests__/activity.test.ts
+++ b/src/config/__tests__/activity.test.ts
@@ -78,7 +78,7 @@ describe('getActivityUpdateTypeLabel', () => {
 
 describe('getActivityUpdateTypeColor', () => {
   it('returns green class for accomplishment', () => {
-    expect(getActivityUpdateTypeColor(ACTIVITY_UPDATE_TYPES.ACCOMPLISHMENT)).toContain('primary')
+    expect(getActivityUpdateTypeColor(ACTIVITY_UPDATE_TYPES.ACCOMPLISHMENT)).toContain('success')
   })
 
   it('returns gray fallback for null', () => {
@@ -164,7 +164,7 @@ describe('getHelpRequestStatusLabel', () => {
 
 describe('getHelpRequestStatusColor', () => {
   it('returns green class for resolved', () => {
-    expect(getHelpRequestStatusColor(HELP_REQUEST_STATUSES.RESOLVED)).toContain('primary')
+    expect(getHelpRequestStatusColor(HELP_REQUEST_STATUSES.RESOLVED)).toContain('success')
   })
 
   it('returns warning (open) for null', () => {

--- a/src/config/__tests__/approval-status.test.ts
+++ b/src/config/__tests__/approval-status.test.ts
@@ -105,8 +105,8 @@ describe('getApprovalStatusBadge', () => {
   it('returns badge for APPROVED with green styling', () => {
     const badge = getApprovalStatusBadge(APPROVAL_STATUS.APPROVED)
     expect(badge.label).toBe('Genehmigt')
-    expect(badge.color).toContain('primary')
-    expect(badge.bg).toContain('primary')
+    expect(badge.color).toContain('success')
+    expect(badge.bg).toContain('success')
   })
 
   it('returns badge for REJECTED with red styling', () => {
@@ -123,11 +123,11 @@ describe('getApprovalStatusBadge', () => {
     expect(badge.bg).toContain('orange')
   })
 
-  it('returns badge for PUBLISHED with primary styling', () => {
+  it('returns badge for PUBLISHED with success styling', () => {
     const badge = getApprovalStatusBadge(APPROVAL_STATUS.PUBLISHED)
     expect(badge.label).toBe('Veröffentlicht')
-    expect(badge.color).toContain('primary')
-    expect(badge.bg).toContain('primary')
+    expect(badge.color).toContain('success')
+    expect(badge.bg).toContain('success')
   })
 
   it('returns gray fallback badge for unknown status', () => {

--- a/src/config/__tests__/booking-status.test.ts
+++ b/src/config/__tests__/booking-status.test.ts
@@ -42,7 +42,7 @@ describe('getBookingStatusBadge', () => {
   it('returns badge for "completed"', () => {
     const badge = getBookingStatusBadge(BOOKING_STATUS.COMPLETED)
     expect(badge.label).toBe('Abgeschlossen')
-    expect(badge.color).toContain('primary')
+    expect(badge.color).toContain('success')
   })
 
   it('returns badge for "cancelled"', () => {

--- a/src/config/__tests__/it-hilfe-marketplace-config.test.ts
+++ b/src/config/__tests__/it-hilfe-marketplace-config.test.ts
@@ -319,7 +319,7 @@ describe('getMarketplaceStatusLabel', () => {
 
 describe('getMarketplaceStatusBadgeColor', () => {
   it('published → green CSS classes', () => {
-    expect(getMarketplaceStatusBadgeColor(MARKETPLACE_STATUS.PUBLISHED)).toContain('primary')
+    expect(getMarketplaceStatusBadgeColor(MARKETPLACE_STATUS.PUBLISHED)).toContain('success')
   })
 
   it('draft → warning CSS classes', () => {
@@ -347,8 +347,8 @@ describe('getProductStatusLabel', () => {
 })
 
 describe('getProductStatusBadgeColor', () => {
-  it('approved → primary CSS classes', () => {
-    expect(getProductStatusBadgeColor(PRODUCT_STATUS.APPROVED)).toContain('primary')
+  it('approved → success CSS classes', () => {
+    expect(getProductStatusBadgeColor(PRODUCT_STATUS.APPROVED)).toContain('success')
   })
 
   it('unknown → gray fallback', () => {

--- a/src/config/__tests__/marketplace-config.test.ts
+++ b/src/config/__tests__/marketplace-config.test.ts
@@ -78,7 +78,7 @@ describe('LISTING_STATUS_CONFIG', () => {
   })
 
   it('ACTIVE status has green color', () => {
-    expect(LISTING_STATUS_CONFIG[LISTING_STATUS.ACTIVE].color).toContain('primary')
+    expect(LISTING_STATUS_CONFIG[LISTING_STATUS.ACTIVE].color).toContain('success')
   })
 
   it('SOLD status has a distinct color from ACTIVE', () => {

--- a/src/config/__tests__/marketplace-status.test.ts
+++ b/src/config/__tests__/marketplace-status.test.ts
@@ -63,7 +63,7 @@ describe('getMarketplaceStatusLabel', () => {
 describe('getMarketplaceStatusBadgeColor', () => {
   it('returns green badge for published', () => {
     const color = getMarketplaceStatusBadgeColor(MARKETPLACE_STATUS.PUBLISHED)
-    expect(color).toContain('primary')
+    expect(color).toContain('success')
   })
 
   it('returns warning badge for draft', () => {
@@ -104,9 +104,9 @@ describe('getProductStatusLabel', () => {
 // ============================================================================
 
 describe('getProductStatusBadgeColor', () => {
-  it('returns primary badge for approved', () => {
+  it('returns success badge for approved', () => {
     const color = getProductStatusBadgeColor(PRODUCT_STATUS.APPROVED)
-    expect(color).toContain('primary')
+    expect(color).toContain('success')
   })
 
   it('returns orange badge for pending_review', () => {

--- a/src/config/__tests__/oss-protocols-config.test.ts
+++ b/src/config/__tests__/oss-protocols-config.test.ts
@@ -26,12 +26,12 @@ describe('getFollowUpStatusColor', () => {
 
   it('"erledigt" → green classes', () => {
     const color = getFollowUpStatusColor('erledigt')
-    expect(color).toContain('primary')
+    expect(color).toContain('success')
   })
 
-  it('"in Arbeit" → primary classes', () => {
+  it('"in Arbeit" → success classes', () => {
     const color = getFollowUpStatusColor('in Arbeit')
-    expect(color).toContain('primary')
+    expect(color).toContain('success')
   })
 
   it('"offen" → warning classes', () => {

--- a/src/config/__tests__/remaining-config.test.ts
+++ b/src/config/__tests__/remaining-config.test.ts
@@ -132,7 +132,7 @@ describe('getEmploymentTypeColor', () => {
 
   it('volunteer → green CSS class', () => {
     const color = getEmploymentTypeColor('volunteer')
-    expect(color).toContain('primary')
+    expect(color).toContain('success')
   })
 
   it('unknown → gray CSS class (default)', () => {
@@ -226,7 +226,7 @@ describe('getReviewStatusLabel', () => {
 
 describe('getReviewStatusBadgeColor', () => {
   it('published → green classes', () => {
-    expect(getReviewStatusBadgeColor(REVIEW_STATUS.PUBLISHED)).toContain('primary')
+    expect(getReviewStatusBadgeColor(REVIEW_STATUS.PUBLISHED)).toContain('success')
   })
 
   it('hidden → red classes', () => {

--- a/src/config/__tests__/review-status.test.ts
+++ b/src/config/__tests__/review-status.test.ts
@@ -64,7 +64,7 @@ describe('getReviewStatusLabel', () => {
 
 describe('getReviewStatusBadgeColor', () => {
   it('returns green badge for published', () => {
-    expect(getReviewStatusBadgeColor(REVIEW_STATUS.PUBLISHED)).toContain('primary')
+    expect(getReviewStatusBadgeColor(REVIEW_STATUS.PUBLISHED)).toContain('success')
   })
 
   it('returns orange badge for pending_moderation', () => {

--- a/src/config/__tests__/service-categories.test.ts
+++ b/src/config/__tests__/service-categories.test.ts
@@ -43,17 +43,17 @@ describe('getCategoryStyle', () => {
   it('returns repair style for "repair"', () => {
     const style = getCategoryStyle('repair')
     expect(style).toBe(CATEGORY_STYLES.repair)
-    expect(style.primary).toContain('primary')
+    expect(style.primary).toContain('success')
   })
 
   it('returns data style for "data"', () => {
     const style = getCategoryStyle('data')
-    expect(style.primary).toContain('primary')
+    expect(style.primary).toContain('success')
   })
 
   it('returns recycling style for "recycling"', () => {
     const style = getCategoryStyle('recycling')
-    expect(style.primary).toContain('primary')
+    expect(style.primary).toContain('success')
   })
 
   it('returns general fallback for unknown category', () => {

--- a/src/config/__tests__/status-config.test.ts
+++ b/src/config/__tests__/status-config.test.ts
@@ -141,7 +141,7 @@ describe('getApprovalStatusBadge', () => {
   it('returns badge object for approved (green)', () => {
     const badge = getApprovalStatusBadge(APPROVAL_STATUS.APPROVED)
     expect(badge.label).toBe('Genehmigt')
-    expect(badge.color).toContain('primary')
+    expect(badge.color).toContain('success')
   })
 
   it('returns badge object for rejected (red)', () => {

--- a/src/config/__tests__/status-helpers.test.ts
+++ b/src/config/__tests__/status-helpers.test.ts
@@ -111,7 +111,7 @@ describe('getApprovalStatusBadge', () => {
 
   it('returns badge for approved (green)', () => {
     const badge = getApprovalStatusBadge(APPROVAL_STATUS.APPROVED)
-    expect(badge.color).toContain('primary')
+    expect(badge.color).toContain('success')
   })
 
   it('returns gray fallback badge for unknown status', () => {

--- a/src/config/__tests__/team.test.ts
+++ b/src/config/__tests__/team.test.ts
@@ -109,7 +109,7 @@ describe('getEmploymentTypeColor', () => {
   })
 
   it('returns green class for volunteer', () => {
-    expect(getEmploymentTypeColor(EMPLOYMENT_TYPES.VOLUNTEER)).toContain('primary')
+    expect(getEmploymentTypeColor(EMPLOYMENT_TYPES.VOLUNTEER)).toContain('success')
   })
 
   it('returns gray fallback for null', () => {

--- a/src/config/__tests__/workshops.test.ts
+++ b/src/config/__tests__/workshops.test.ts
@@ -129,7 +129,7 @@ describe('getLevelBadgeClass', () => {
 
   it('returns green badge class for "beginner"', () => {
     const cls = getLevelBadgeClass('beginner')
-    expect(cls).toContain('primary')
+    expect(cls).toContain('success')
   })
 
   it('returns neutral badge class for "intermediate"', () => {
@@ -149,7 +149,7 @@ describe('getLevelBadgeClass', () => {
   it('matches by level name (case-insensitive)', () => {
     // WORKSHOP_LEVELS entry has name "Anfänger" → id "beginner"
     const cls = getLevelBadgeClass('anfänger')
-    expect(cls).toContain('primary')
+    expect(cls).toContain('success')
   })
 })
 

--- a/src/config/erfassung/__tests__/conditions.test.ts
+++ b/src/config/erfassung/__tests__/conditions.test.ts
@@ -139,7 +139,7 @@ describe('getConditionBadge', () => {
   it('returns label "Neu" and green color for "new"', () => {
     const badge = getConditionBadge('new')
     expect(badge.label).toBe('Neu')
-    expect(badge.color).toContain('primary')
+    expect(badge.color).toContain('success')
   })
 
   it('returns label "Defekt" and gray color for "defect"', () => {
@@ -148,10 +148,10 @@ describe('getConditionBadge', () => {
     expect(badge.color).toContain('neutral')
   })
 
-  it('resolves alias "excellent" → label "Sehr gut" with "like_new" color (primary)', () => {
+  it('resolves alias "excellent" → label "Sehr gut" with "like_new" color (success)', () => {
     const badge = getConditionBadge('excellent')
     expect(badge.label).toBe('Sehr gut')
-    expect(badge.color).toContain('primary')
+    expect(badge.color).toContain('success')
   })
 
   it('returns raw value as label and gray for completely unknown input', () => {


### PR DESCRIPTION
## Two green signals, neither reading the tests

The unit-test job has carried `continue-on-error: true` since the day it was
added, labelled *"non-blocking while suite matures"*. The suite matured to
**7,769 tests across 532 files** and nobody flipped it back. So CI ran the whole
thing on every PR and threw the answer away.

At the same time `verify` was `lint && lint:umlauts && typecheck && build` — no
`test`. Both signals were green; neither was reading the suite.

| | signal | reality |
|---|---|---|
| `verify` (local) | green | never ran `test` |
| CI "Run Tests" | green ✓ | ran the suite, discarded the result |

## What it cost

Commit 8272b4680 (2026-07-28) moved status badges off the raw `primary-*` lime
scale onto the `success-*` token. Careful, correct, purely mechanical. Its own
message reports *"verify green (typecheck 0, lint 0, 90/90 unit tests)"* and
says it updated **3** test suites' colour assertions.

There were **15**. The other 12 have been failing ever since — **25 assertions**
— and three weeks of PRs sailed straight past them.

A discarded gate is worse than an absent one. An absent gate is *visibly*
absent. A discarded one burns six minutes and manufactures a ✓.

## Changes

- `continue-on-error: true` **removed** — the job gates now.
- `npm run test` **added to `verify`**, so the local bundle mirrors CI. The
  fleet floor (`dotfiles/templates/ci/README.md`) is lint && typecheck && test;
  this repo ran three of four.
- `timeout-minutes: 20` on a job that had none.
- **25 stale assertions** `primary` → `success`, plus **5 test names** that
  still said "primary" for a colour that is now success.

Assertions were rewritten **only at the exact lines jest reported**, never by a
global sed — `primary` is still a legitimate brand token in these same files,
and a blind replace would have silently retargeted assertions that currently
pass.

## Two things deliberately NOT changed

I checked whether the sweep caused these. It did not — they predate it:

- `FOLLOW_UP_STATUS_COLORS` maps `'erledigt'` (done) and `'in Arbeit'` (in
  progress) to **byte-identical** classes — the two states are visually
  indistinguishable.
- `CATEGORY_STYLES` gives `repair`, `data` and `recycling` the same
  `success-600`, while `software` is purple.

Both were already identical as `primary-*` before 8272b4680, which was a pure
one-for-one rename. Fixing them means *choosing colours* — a design call, not a
green-the-build call. Recorded here rather than silently normalised.

## Verification

Against a clean `npm ci` tree: lint (0 errors, 48 warnings), umlauts, typecheck
(0), and the suite at **532/532 files, 7769/7769 tests, exit 0**.

The first attempt ran against a `node_modules` symlinked from another worktree
and produced 8 phantom module-resolution errors — worth knowing before trusting
a dependency tree you did not install.

`build` is the one step **not** verified locally: `src/app/layout.tsx` pulls
three families from `next/font/google`, which downloads at build time, and this
sandbox has no outbound network. CI builds it. Nothing here touches the build
path — the diff is test assertions, one `package.json` string, and `ci.yml`.

## Note on CI wall-clock

`quality` now runs the suite too (via `verify`), so it gains ~3 min on the
critical path, and the standalone `test` job still runs in parallel. That
duplication is deliberate: the standalone job is named in the `post-main`
verdict's `needs:` list and guarded by `main-red-verdict.test.ts`, so folding it
away is a separate, larger change — flagged rather than silently attempted while
two other sessions are actively editing this file.

---

## Follow-up commit: the second class the gate revealed

Closing the gate immediately surfaced a **second** hidden failure class. Six
date tests pass in Europe/Zurich and fail in UTC, and had been failing on every
CI run since they were written — invisible for exactly the same reason as the
25 colour assertions.

`src/lib/date-formats.ts` deliberately renders in Europe/Zurich (without a fixed
timeZone, a server-rendered 15:00 workshop displays 1–2h off). That is correct.
The *tests* were the non-deterministic part: they build reference dates with
`new Date(2026, 4, 15, 14, 30)` — the **runner's** local time. 14:30 on a Swiss
laptop, 14:30 UTC on CI, which renders as "16:30".

The same assertion meant two different things depending on who ran it, and the
machine that ran it most often was the one whose answer nobody read.

Pinned in `jest.config.js`, not in each npm script — `test`, `test:watch`,
`test:coverage` and `test:i18n` all load that config. One place, not four.

Verified by reproducing CI's environment locally, both directions:

| run | result |
|---|---|
| `TZ=UTC`, pin disabled | 6 failed, 41 passed — **exactly CI's 6** |
| `TZ=UTC`, pin enabled | 47 passed |
| `TZ=UTC`, full suite | 532/532 suites, 7769/7769, exit 0 |

CI now reports **532/532 suites, 7772/7772 tests**.

### One thing I could not explain

CI counts 7,772 tests; every local run counts 7,769. Three test *definitions*
exist only on CI — all passing, no `process.env.CI` guards and no skips in the
tree. Diagnosing it needs CI-side instrumentation, so it is recorded here as a
known, unexplained discrepancy rather than given a cause I cannot evidence.
