### PR TITLE
fix(vote): give the "sign in to vote" error the door it names

### DIFF
--- a/src/app/api/vote/[id]/__tests__/route.test.ts
+++ b/src/app/api/vote/[id]/__tests__/route.test.ts
@@ -48,7 +48,8 @@ jest.mock('@/lib/api/helpers', () => {
     apiSuccess: (data: unknown, status = 200) => NextResponse.json({ success: true, data }, { status }),
     apiSuccessCached: (data: unknown) => NextResponse.json({ success: true, data }, { status: 200 }),
     apiError: (_err: unknown, msg: string, status = 500) => NextResponse.json({ success: false, error: msg }, { status }),
-    apiBadRequest: (msg: string) => NextResponse.json({ success: false, error: msg }, { status: 400 }),
+    apiBadRequest: (msg: string, errors?: unknown, code?: string) =>
+      NextResponse.json({ success: false, error: msg, ...(code && { code }) }, { status: 400 }),
   }
 })
 
@@ -279,6 +280,10 @@ describe('POST /api/vote/[id] — cannot vote as a registered member', () => {
     expect(response.status).toBe(400)
     const body = await response.json()
     expect(body.error).toMatch(/registrierten Konto/i)
+    // The UI offers a login link off this code. Without it the only way to
+    // recognise this failure is matching the German sentence, which breaks
+    // the first time someone rewords or translates it.
+    expect(body.code).toBe('vote_email_registered')
     // The whole point: no ballot is cast, so the member's existing vote
     // cannot be overwritten and allow_public_voting cannot be bypassed.
     expect(mockSubmitVote).not.toHaveBeenCalled()

--- a/src/app/api/vote/[id]/route.ts
+++ b/src/app/api/vote/[id]/route.ts
@@ -22,7 +22,7 @@ import { submitVote, getPublicDecision } from '@/lib/services/decisions'
 import { TABLE_NAMES } from '@/config/database'
 import { logger } from '@/lib/logger'
 import { apiSuccess, apiSuccessCached, apiError, apiBadRequest } from '@/lib/api/helpers'
-import { ERROR_MESSAGES } from '@/config/error-messages'
+import { ERROR_CODES, ERROR_MESSAGES } from '@/config/error-messages'
 import { rateLimiters, getClientIdentifier } from '@/lib/security/rate-limit'
 
 type RouteParams = { params: Promise<{ id: string }> }
@@ -106,7 +106,11 @@ export async function POST(
         [normalizedEmail]
       )
       if (registered.rows.length > 0) {
-        return apiBadRequest(ERROR_MESSAGES.VOTE_EMAIL_REGISTERED)
+        return apiBadRequest(
+          ERROR_MESSAGES.VOTE_EMAIL_REGISTERED,
+          undefined,
+          ERROR_CODES.VOTE_EMAIL_REGISTERED,
+        )
       }
 
       voterIdentity = { voterEmail: normalizedEmail }

--- a/src/app/vote/[id]/PublicVoteClient.tsx
+++ b/src/app/vote/[id]/PublicVoteClient.tsx
@@ -8,6 +8,7 @@ import { Input } from '@/components/ui/input'
 import { useTranslations } from 'next-intl'
 import { apiFetch } from '@/lib/api/client'
 import { type VotingMethod } from '@/config/decisions'
+import { ERROR_CODES } from '@/config/error-messages'
 import { useVoteState } from '@/hooks/useVoteState'
 import { ConsentVote } from '@/components/decisions/voting/ConsentVote'
 import { ApprovalVote } from '@/components/decisions/voting/ApprovalVote'
@@ -58,6 +59,7 @@ export default function PublicVoteClient({
   const [email, setEmail] = useState('')
   const [submitting, setSubmitting] = useState(false)
   const [error, setError] = useState('')
+  const [errorCode, setErrorCode] = useState<string | null>(null)
   const [success, setSuccess] = useState(false)
 
   const vote = useVoteState({ votingMethod, options, dotCount })
@@ -75,6 +77,7 @@ export default function PublicVoteClient({
     }
 
     setError('')
+    setErrorCode(null)
     setSubmitting(true)
 
     const voteData = vote.buildVoteData()
@@ -85,6 +88,7 @@ export default function PublicVoteClient({
     })
     if (!result.success) {
       setError(result.error || t('submitError'))
+      setErrorCode(result.code ?? null)
       setSubmitting(false)
       return
     }
@@ -224,6 +228,13 @@ export default function PublicVoteClient({
       {error && (
         <div className="rounded-lg bg-error-50 dark:bg-red-500/8 border border-error-200 dark:border-red-500/20 p-3 text-sm text-error-700 dark:text-red-300">
           {error}
+          {/* "Sign in to vote with this address" is a dead end without the
+              door — send them straight to it. */}
+          {errorCode === ERROR_CODES.VOTE_EMAIL_REGISTERED && (
+            <Link href={loginUrl} className="ml-1 font-semibold underline">
+              {t('successLoginCta')}
+            </Link>
+          )}
         </div>
       )}
 

--- a/src/config/error-messages.ts
+++ b/src/config/error-messages.ts
@@ -140,3 +140,18 @@ export const SUCCESS_MESSAGES = {
   // Workshops
   WORKSHOP_REGISTERED: 'Erfolgreich für Workshop angemeldet',
 } as const;
+
+/**
+ * Stable error codes — SSOT shared by the API and the UI.
+ *
+ * Only add one when the interface must *do* something different for that
+ * failure (offer a login link, a retry, a different form). The human sentence
+ * lives in ERROR_MESSAGES and is free to be reworded or translated; the code
+ * is what the UI is allowed to branch on.
+ */
+export const ERROR_CODES = {
+  /** Anonymous ballot naming an email that belongs to a registered account. */
+  VOTE_EMAIL_REGISTERED: 'vote_email_registered',
+} as const;
+
+export type ErrorCode = typeof ERROR_CODES[keyof typeof ERROR_CODES];

--- a/src/lib/api/__tests__/client.test.ts
+++ b/src/lib/api/__tests__/client.test.ts
@@ -145,6 +145,37 @@ describe('apiFetch', () => {
     expect(result.error).toBe('Anfrage fehlgeschlagen (503)')
   })
 
+  // ── error codes ─────────────────────────────────────────────────────────────
+
+  it('passes a machine-readable error code through to the caller', async () => {
+    mockFetch.mockResolvedValueOnce(
+      jsonResponse({ success: false, error: 'Bitte melde dich an.', code: 'vote_email_registered' }, 400)
+    )
+
+    const result = await apiFetch('/api/test')
+
+    // Without this the UI can only tell failures apart by matching German
+    // prose — which breaks the moment the sentence is reworded.
+    expect(result.code).toBe('vote_email_registered')
+    expect(result.error).toBe('Bitte melde dich an.')
+  })
+
+  it('omits code entirely when the response has none', async () => {
+    mockFetch.mockResolvedValueOnce(jsonResponse({ success: false, error: 'plain' }, 400))
+
+    const result = await apiFetch('/api/test')
+
+    expect(result).toEqual({ success: false, error: 'plain' })
+  })
+
+  it('ignores a non-string code rather than passing junk to the UI', async () => {
+    mockFetch.mockResolvedValueOnce(jsonResponse({ success: false, error: 'x', code: 42 }, 400))
+
+    const result = await apiFetch('/api/test')
+
+    expect(result.code).toBeUndefined()
+  })
+
   // ── network failures ────────────────────────────────────────────────────────
 
   it('returns a friendly network error when fetch rejects', async () => {

--- a/src/lib/api/client.ts
+++ b/src/lib/api/client.ts
@@ -59,6 +59,10 @@ export async function apiFetch<T = unknown>(
         error: fieldMessages.length > 0
           ? `${baseError}: ${fieldMessages.join(' · ')}`
           : baseError,
+        // Pass the code through untouched — callers that offer a way out of a
+        // specific failure need it, and flattening it away is what forced
+        // string-matching on German prose.
+        ...(typeof data.code === 'string' && { code: data.code }),
       }
     }
 

--- a/src/lib/api/helpers.ts
+++ b/src/lib/api/helpers.ts
@@ -148,16 +148,21 @@ export function apiRateLimited(
  * Bad request response helper
  * @param message - Error message
  * @param errors - Optional validation errors
+ * @param code - Optional stable code from ERROR_CODES. The message is for the
+ *   human; the code is for the UI, so it can offer the way out (a login link,
+ *   a retry) without pattern-matching German prose that translators may change.
  */
 export function apiBadRequest(
   message: string,
-  errors?: Record<string, string[]>
+  errors?: Record<string, string[]>,
+  code?: string
 ): NextResponse {
   return NextResponse.json(
     {
       success: false,
       error: message,
       ...(errors && { errors }),
+      ...(code && { code }),
     },
     { status: 400 }
   );

--- a/src/lib/api/types.ts
+++ b/src/lib/api/types.ts
@@ -10,6 +10,12 @@ export interface ApiResponse<T = unknown> {
   success: boolean
   data?: T
   error?: string
+  /**
+   * Stable machine-readable discriminator from ERROR_CODES, set only where the
+   * UI must react to *which* failure it was. `error` stays the human sentence —
+   * branching on that text breaks the moment it is reworded or translated.
+   */
+  code?: string
 }
 
 /** Paginated API response (page-based) */


### PR DESCRIPTION
Follow-up to #305. That fix tells someone whose email belongs to an account to sign in — and then leaves them standing there with no way to do it. This repo's own rule is that every stated problem links to where it is fixed; a warning without a way out is a dead end.

## Why the link was missing

`apiFetch` flattened every failure to a bare `{ success, error }` string. The only way for the UI to know **which** failure it got was to match the German sentence — and branching on prose breaks the first time someone rewords or translates it. So the fix is one level down: give the envelope a machine-readable code.

| Change | Detail |
|---|---|
| `ERROR_CODES` | One SSOT for codes, beside `ERROR_MESSAGES`. Add one only when the interface must *do* something different — the message is for the human, the code is for the UI. |
| `apiBadRequest` | Optional third argument; omitted from the body when unset |
| `ApiResponse.code` | Optional, so all ~100 existing callers are untouched |
| `apiFetch` | Passes a string code through; ignores a non-string one rather than handing junk to the UI |

The vote page renders **Anmelden** as a link to `loginUrl` beside that error, reusing the string already present in the success panel — no new i18n keys, so no locale can desync and the parity test stays green.

## Verification

- 5963 tests green across 440 suites; eslint + umlaut linter clean on the changed files
- The passthrough test **fails with the `apiFetch` change reverted** (1 of 14) — checked, not assumed
- The route test pins the code using a mock that actually forwards the third argument; a mock that dropped it would have made the assertion vacuous

Scope note: this deliberately does not touch ballot-stuffing with arbitrary *unregistered* emails on decisions that opt into public voting. Closing that needs email verification, which is a product decision rather than a bug fix.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
