### PR TITLE
fix(vote): the one live decision could not be voted on at all

### DIFF
--- a/src/app/api/vote/[id]/__tests__/route.test.ts
+++ b/src/app/api/vote/[id]/__tests__/route.test.ts
@@ -48,7 +48,8 @@ jest.mock('@/lib/api/helpers', () => {
     apiSuccess: (data: unknown, status = 200) => NextResponse.json({ success: true, data }, { status }),
     apiSuccessCached: (data: unknown) => NextResponse.json({ success: true, data }, { status: 200 }),
     apiError: (_err: unknown, msg: string, status = 500) => NextResponse.json({ success: false, error: msg }, { status }),
-    apiBadRequest: (msg: string) => NextResponse.json({ success: false, error: msg }, { status: 400 }),
+    apiBadRequest: (msg: string, errors?: unknown, code?: string) =>
+      NextResponse.json({ success: false, error: msg, ...(code && { code }) }, { status: 400 }),
   }
 })
 
@@ -279,6 +280,10 @@ describe('POST /api/vote/[id] — cannot vote as a registered member', () => {
     expect(response.status).toBe(400)
     const body = await response.json()
     expect(body.error).toMatch(/registrierten Konto/i)
+    // The UI offers a login link off this code. Without it the only way to
+    // recognise this failure is matching the German sentence, which breaks
+    // the first time someone rewords or translates it.
+    expect(body.code).toBe('vote_email_registered')
     // The whole point: no ballot is cast, so the member's existing vote
     // cannot be overwritten and allow_public_voting cannot be bypassed.
     expect(mockSubmitVote).not.toHaveBeenCalled()

--- a/src/app/api/vote/[id]/route.ts
+++ b/src/app/api/vote/[id]/route.ts
@@ -22,7 +22,7 @@ import { submitVote, getPublicDecision } from '@/lib/services/decisions'
 import { TABLE_NAMES } from '@/config/database'
 import { logger } from '@/lib/logger'
 import { apiSuccess, apiSuccessCached, apiError, apiBadRequest } from '@/lib/api/helpers'
-import { ERROR_MESSAGES } from '@/config/error-messages'
+import { ERROR_CODES, ERROR_MESSAGES } from '@/config/error-messages'
 import { rateLimiters, getClientIdentifier } from '@/lib/security/rate-limit'
 
 type RouteParams = { params: Promise<{ id: string }> }
@@ -106,7 +106,11 @@ export async function POST(
         [normalizedEmail]
       )
       if (registered.rows.length > 0) {
-        return apiBadRequest(ERROR_MESSAGES.VOTE_EMAIL_REGISTERED)
+        return apiBadRequest(
+          ERROR_MESSAGES.VOTE_EMAIL_REGISTERED,
+          undefined,
+          ERROR_CODES.VOTE_EMAIL_REGISTERED,
+        )
       }
 
       voterIdentity = { voterEmail: normalizedEmail }

--- a/src/app/vote/[id]/PublicVoteClient.tsx
+++ b/src/app/vote/[id]/PublicVoteClient.tsx
@@ -16,6 +16,7 @@ import { DotVote } from '@/components/decisions/voting/DotVote'
 import { ScoreVote } from '@/components/decisions/voting/ScoreVote'
 import { RankedChoiceVote } from '@/components/decisions/voting/RankedChoiceVote'
 import { SimpleMajorityVote } from '@/components/decisions/voting/SimpleMajorityVote'
+import { ThumbsUpDownVote } from '@/components/decisions/voting/ThumbsUpDownVote'
 import { DeadlineCountdown } from '@/components/decisions/voting/DeadlineCountdown'
 import { VoteAIAdvisor } from '@/components/decisions/VoteAIAdvisor'
 
@@ -222,6 +223,9 @@ export default function PublicVoteClient({
             onMoveUp={vote.moveRankingUp}
             onMoveDown={vote.moveRankingDown}
           />
+        )}
+        {votingMethod === 'thumbs_up_down' && (
+          <ThumbsUpDownVote choice={vote.thumbsChoice} onChange={vote.setThumbsChoice} />
         )}
       </div>
 

--- a/src/app/vote/[id]/PublicVoteClient.tsx
+++ b/src/app/vote/[id]/PublicVoteClient.tsx
@@ -8,6 +8,7 @@ import { Input } from '@/components/ui/input'
 import { useTranslations } from 'next-intl'
 import { apiFetch } from '@/lib/api/client'
 import { type VotingMethod } from '@/config/decisions'
+import { ERROR_CODES } from '@/config/error-messages'
 import { useVoteState } from '@/hooks/useVoteState'
 import { ConsentVote } from '@/components/decisions/voting/ConsentVote'
 import { ApprovalVote } from '@/components/decisions/voting/ApprovalVote'
@@ -58,6 +59,7 @@ export default function PublicVoteClient({
   const [email, setEmail] = useState('')
   const [submitting, setSubmitting] = useState(false)
   const [error, setError] = useState('')
+  const [errorCode, setErrorCode] = useState<string | null>(null)
   const [success, setSuccess] = useState(false)
 
   const vote = useVoteState({ votingMethod, options, dotCount })
@@ -75,6 +77,7 @@ export default function PublicVoteClient({
     }
 
     setError('')
+    setErrorCode(null)
     setSubmitting(true)
 
     const voteData = vote.buildVoteData()
@@ -85,6 +88,7 @@ export default function PublicVoteClient({
     })
     if (!result.success) {
       setError(result.error || t('submitError'))
+      setErrorCode(result.code ?? null)
       setSubmitting(false)
       return
     }
@@ -224,6 +228,13 @@ export default function PublicVoteClient({
       {error && (
         <div className="rounded-lg bg-error-50 dark:bg-red-500/8 border border-error-200 dark:border-red-500/20 p-3 text-sm text-error-700 dark:text-red-300">
           {error}
+          {/* "Sign in to vote with this address" is a dead end without the
+              door — send them straight to it. */}
+          {errorCode === ERROR_CODES.VOTE_EMAIL_REGISTERED && (
+            <Link href={loginUrl} className="ml-1 font-semibold underline">
+              {t('successLoginCta')}
+            </Link>
+          )}
         </div>
       )}
 

--- a/src/components/decisions/VotingPanel.tsx
+++ b/src/components/decisions/VotingPanel.tsx
@@ -13,6 +13,7 @@ import { DotVote } from './voting/DotVote';
 import { ScoreVote } from './voting/ScoreVote';
 import { RankedChoiceVote } from './voting/RankedChoiceVote';
 import { SimpleMajorityVote } from './voting/SimpleMajorityVote';
+import { ThumbsUpDownVote } from './voting/ThumbsUpDownVote';
 import { VoteAIAdvisor } from '@/components/decisions/VoteAIAdvisor';
 
 interface Option {
@@ -166,6 +167,9 @@ export default function VotingPanel({
       )}
       {votingMethod === 'simple_majority' && (
         <SimpleMajorityVote response={vote.majorityResponse} onChange={vote.setMajorityResponse} />
+      )}
+      {votingMethod === 'thumbs_up_down' && (
+        <ThumbsUpDownVote choice={vote.thumbsChoice} onChange={vote.setThumbsChoice} />
       )}
 
       <Button

--- a/src/components/decisions/__tests__/ballot-coverage.test.tsx
+++ b/src/components/decisions/__tests__/ballot-coverage.test.tsx
@@ -1,0 +1,72 @@
+/**
+ * Every configured voting method must render a ballot.
+ *
+ * `thumbs_up_down` sat in VOTING_METHODS with no branch in either voting
+ * surface and no case in useVoteState. The result was silent: the page drew
+ * the "Deine Stimme" heading with nothing beneath it, buildVoteData() fell
+ * through to undefined, and the server answered "Stimmdaten erforderlich".
+ * The only decision in production could not be voted on, and nothing on
+ * screen said why.
+ *
+ * A missing branch is absence, and absence is what a normal test never sees —
+ * so this one iterates the config rather than a list someone has to remember
+ * to extend. Add a method to VOTING_METHODS without giving it a ballot and
+ * this fails.
+ */
+
+import { render } from '@testing-library/react'
+import { VOTING_METHODS, type VotingMethod } from '@/config/decisions'
+import PublicVoteClient from '../../../app/vote/[id]/PublicVoteClient'
+
+// Spread the real module — replacing it wholesale breaks defineRouting, which
+// button.tsx pulls in transitively via src/i18n/navigation.
+jest.mock('next-intl', () => ({
+  ...jest.requireActual('next-intl'),
+  useTranslations: () => (key: string) => key,
+}))
+
+jest.mock('@/lib/api/client', () => ({
+  apiFetch: jest.fn(async () => ({ success: true, data: {} })),
+}))
+
+jest.mock('@/components/decisions/VoteAIAdvisor', () => ({
+  VoteAIAdvisor: () => null,
+}))
+
+const OPTIONS = [
+  { id: 'opt-1', label: 'Erste Option' },
+  { id: 'opt-2', label: 'Zweite Option' },
+]
+
+function renderBallot(votingMethod: VotingMethod) {
+  return render(
+    <PublicVoteClient
+      decisionId="decision-1"
+      title="Testentscheidung"
+      description="Beschreibung"
+      background=""
+      votingMethod={votingMethod}
+      options={OPTIONS}
+      dotCount={5}
+      votingDeadline={null}
+      isVotingPhase
+      allowPublicVoting
+      registerUrl="/register"
+      loginUrl="/login"
+    />
+  )
+}
+
+describe('every configured voting method renders a ballot', () => {
+  it.each(VOTING_METHODS)('%s draws interactive controls', (method) => {
+    const { container } = renderBallot(method)
+
+    // The ballot lives between the email field and the submit button. Any
+    // real ballot offers something to interact with; an unhandled method
+    // renders an empty box, which is the bug this guards.
+    const controls = container.querySelectorAll(
+      'button:not([type="submit"]), input:not([type="email"]), textarea, [role="radio"], [role="slider"]'
+    )
+    expect(controls.length).toBeGreaterThan(0)
+  })
+})

--- a/src/components/decisions/voting/ThumbsUpDownVote.tsx
+++ b/src/components/decisions/voting/ThumbsUpDownVote.tsx
@@ -1,0 +1,46 @@
+'use client';
+
+import { ThumbsUp, ThumbsDown } from 'lucide-react';
+import { Button } from '@/components/ui/button';
+import {
+  THUMBS_UP_DOWN_CHOICES,
+  THUMBS_UP_DOWN_CHOICE_CONFIG,
+  type ThumbsUpDownChoice,
+} from '@/config/decisions';
+
+interface Props {
+  choice: ThumbsUpDownChoice | null;
+  onChange: (c: ThumbsUpDownChoice) => void;
+}
+
+const ICONS = { up: ThumbsUp, down: ThumbsDown } as const;
+
+export function ThumbsUpDownVote({ choice, onChange }: Props) {
+  return (
+    <div className="flex gap-3">
+      {THUMBS_UP_DOWN_CHOICES.map((c) => {
+        const Icon = ICONS[c];
+        const selected = choice === c;
+        return (
+          <Button
+            key={c}
+            type="button"
+            variant="outline"
+            aria-pressed={selected}
+            onClick={() => onChange(c)}
+            className={`flex-1 flex items-center justify-center gap-2 rounded-md border-2 px-4 py-3 text-sm font-medium transition ${
+              selected
+                ? c === 'up'
+                  ? 'border-action bg-action-muted text-action'
+                  : 'border-error-500 bg-error-50 dark:bg-error-900/20 text-error-700 dark:text-error-300'
+                : 'border text-text-secondary hover:border-strong'
+            }`}
+          >
+            <Icon className="h-4 w-4" />
+            {THUMBS_UP_DOWN_CHOICE_CONFIG[c].label}
+          </Button>
+        );
+      })}
+    </div>
+  );
+}

--- a/src/config/decisions.ts
+++ b/src/config/decisions.ts
@@ -382,6 +382,21 @@ export const SIMPLE_MAJORITY_RESPONSE_CONFIG: Record<
   abstain: { label: 'Enthaltung' },
 };
 
+// ─── Thumbs Up / Down Choices ─────────────────────────────────────────────
+// Must stay in step with thumbsUpDownVoteSchema (src/lib/schemas/decisions.ts).
+
+export const THUMBS_UP_DOWN_CHOICES = ['up', 'down'] as const;
+
+export type ThumbsUpDownChoice = (typeof THUMBS_UP_DOWN_CHOICES)[number];
+
+export const THUMBS_UP_DOWN_CHOICE_CONFIG: Record<
+  ThumbsUpDownChoice,
+  { label: string }
+> = {
+  up: { label: 'Dafür' },
+  down: { label: 'Dagegen' },
+};
+
 // ─── Comment Positions ────────────────────────────────────────────────────
 
 export const COMMENT_POSITIONS = [

--- a/src/config/error-messages.ts
+++ b/src/config/error-messages.ts
@@ -140,3 +140,18 @@ export const SUCCESS_MESSAGES = {
   // Workshops
   WORKSHOP_REGISTERED: 'Erfolgreich für Workshop angemeldet',
 } as const;
+
+/**
+ * Stable error codes — SSOT shared by the API and the UI.
+ *
+ * Only add one when the interface must *do* something different for that
+ * failure (offer a login link, a retry, a different form). The human sentence
+ * lives in ERROR_MESSAGES and is free to be reworded or translated; the code
+ * is what the UI is allowed to branch on.
+ */
+export const ERROR_CODES = {
+  /** Anonymous ballot naming an email that belongs to a registered account. */
+  VOTE_EMAIL_REGISTERED: 'vote_email_registered',
+} as const;
+
+export type ErrorCode = typeof ERROR_CODES[keyof typeof ERROR_CODES];

--- a/src/hooks/useVoteState.ts
+++ b/src/hooks/useVoteState.ts
@@ -5,6 +5,7 @@ import {
   type VotingMethod,
   type ConsentResponse,
   type SimpleMajorityResponse,
+  type ThumbsUpDownChoice,
 } from '@/config/decisions';
 
 interface Option {
@@ -31,6 +32,9 @@ export function useVoteState({ votingMethod, options, dotCount }: UseVoteStatePr
   );
   const [majorityResponse, setMajorityResponse] = useState<SimpleMajorityResponse>('yes');
   const [ranking, setRanking] = useState<string[]>(() => options.map((o) => o.id));
+  // No default: a thumbs vote is one deliberate tap, so pre-selecting "Dafür"
+  // would submit an opinion the voter never expressed.
+  const [thumbsChoice, setThumbsChoice] = useState<ThumbsUpDownChoice | null>(null);
 
   function toggleApproval(optId: string) {
     setApprovedOptions((prev) => {
@@ -75,6 +79,15 @@ export function useVoteState({ votingMethod, options, dotCount }: UseVoteStatePr
       case 'score':           return { scores };
       case 'simple_majority': return { response: majorityResponse };
       case 'ranked_choice':   return { ranking };
+      case 'thumbs_up_down':  return thumbsChoice ? { choice: thumbsChoice } : undefined;
+      default: {
+        // A method in VOTING_METHODS with no case here used to fall through to
+        // `undefined`, which the UI rendered as an empty ballot and the server
+        // rejected as "Stimmdaten erforderlich" — a decision nobody could vote
+        // on, with nothing on screen explaining why. Now it fails the build.
+        const unhandled: never = votingMethod;
+        throw new Error(`Unhandled voting method: ${String(unhandled)}`);
+      }
     }
   }
 
@@ -86,6 +99,7 @@ export function useVoteState({ votingMethod, options, dotCount }: UseVoteStatePr
     scores, setScore,
     majorityResponse, setMajorityResponse,
     ranking, moveRankingUp, moveRankingDown,
+    thumbsChoice, setThumbsChoice,
     buildVoteData,
   };
 }

--- a/src/lib/api/__tests__/client.test.ts
+++ b/src/lib/api/__tests__/client.test.ts
@@ -145,6 +145,37 @@ describe('apiFetch', () => {
     expect(result.error).toBe('Anfrage fehlgeschlagen (503)')
   })
 
+  // ── error codes ─────────────────────────────────────────────────────────────
+
+  it('passes a machine-readable error code through to the caller', async () => {
+    mockFetch.mockResolvedValueOnce(
+      jsonResponse({ success: false, error: 'Bitte melde dich an.', code: 'vote_email_registered' }, 400)
+    )
+
+    const result = await apiFetch('/api/test')
+
+    // Without this the UI can only tell failures apart by matching German
+    // prose — which breaks the moment the sentence is reworded.
+    expect(result.code).toBe('vote_email_registered')
+    expect(result.error).toBe('Bitte melde dich an.')
+  })
+
+  it('omits code entirely when the response has none', async () => {
+    mockFetch.mockResolvedValueOnce(jsonResponse({ success: false, error: 'plain' }, 400))
+
+    const result = await apiFetch('/api/test')
+
+    expect(result).toEqual({ success: false, error: 'plain' })
+  })
+
+  it('ignores a non-string code rather than passing junk to the UI', async () => {
+    mockFetch.mockResolvedValueOnce(jsonResponse({ success: false, error: 'x', code: 42 }, 400))
+
+    const result = await apiFetch('/api/test')
+
+    expect(result.code).toBeUndefined()
+  })
+
   // ── network failures ────────────────────────────────────────────────────────
 
   it('returns a friendly network error when fetch rejects', async () => {

--- a/src/lib/api/client.ts
+++ b/src/lib/api/client.ts
@@ -59,6 +59,10 @@ export async function apiFetch<T = unknown>(
         error: fieldMessages.length > 0
           ? `${baseError}: ${fieldMessages.join(' · ')}`
           : baseError,
+        // Pass the code through untouched — callers that offer a way out of a
+        // specific failure need it, and flattening it away is what forced
+        // string-matching on German prose.
+        ...(typeof data.code === 'string' && { code: data.code }),
       }
     }
 

--- a/src/lib/api/helpers.ts
+++ b/src/lib/api/helpers.ts
@@ -148,16 +148,21 @@ export function apiRateLimited(
  * Bad request response helper
  * @param message - Error message
  * @param errors - Optional validation errors
+ * @param code - Optional stable code from ERROR_CODES. The message is for the
+ *   human; the code is for the UI, so it can offer the way out (a login link,
+ *   a retry) without pattern-matching German prose that translators may change.
  */
 export function apiBadRequest(
   message: string,
-  errors?: Record<string, string[]>
+  errors?: Record<string, string[]>,
+  code?: string
 ): NextResponse {
   return NextResponse.json(
     {
       success: false,
       error: message,
       ...(errors && { errors }),
+      ...(code && { code }),
     },
     { status: 400 }
   );

--- a/src/lib/api/types.ts
+++ b/src/lib/api/types.ts
@@ -10,6 +10,12 @@ export interface ApiResponse<T = unknown> {
   success: boolean
   data?: T
   error?: string
+  /**
+   * Stable machine-readable discriminator from ERROR_CODES, set only where the
+   * UI must react to *which* failure it was. `error` stays the human sentence —
+   * branching on that text breaks the moment it is reworded or translated.
+   */
+  code?: string
 }
 
 /** Paginated API response (page-based) */


### PR DESCRIPTION
Found by opening the real share link at 390px while verifying #307 — not by any test. The page drew **"Deine Stimme"** and then nothing beneath it. Submitting answered *"Stimmdaten erforderlich"*. There was no ballot, and nothing on screen said why.

`thumbs_up_down` has been in `VOTING_METHODS` all along, with a zod schema, a validator and a tally on the server — but **no branch in either voting surface** and **no case in `useVoteState`'s switch**. `buildVoteData()` fell through to `undefined`, which TypeScript permits because the switch had no default and the return type is `unknown`. The absence compiled, rendered blank, and failed at the server.

**Production's only decision uses that method**, so the one live vote could not be cast at all — by anyone, through either surface.

## Fixed

One `ThumbsUpDownVote` component wired into both the public share-link page and the members' `VotingPanel`, with the choice labels in `src/config/decisions.ts` beside the other methods' rather than typed into JSX. No default selection — a thumbs vote is a single deliberate tap, so pre-selecting *Dafür* would submit an opinion the voter never expressed.

## Two guards, because the compile-time one alone would not have caught this

| Guard | Catches |
|---|---|
| `never` exhaustiveness default in `useVoteState` | A method with no `case` is now a build error, not a silent `undefined` |
| `ballot-coverage.test.tsx` | Renders **every** entry in `VOTING_METHODS` and asserts the ballot contains something interactive |

The switch guard cannot see a missing *render* branch — which is what actually broke here. The coverage test iterates the config itself, so it cannot drift from it: add a method without giving it a ballot and it fails.

I checked that test fails with the branch removed — `thumbs_up_down` only, 6 of 7 still passing — rather than trusting a green suite.

## Verification

- 7747 tests green across 529 suites; eslint + umlaut linter clean
- Verified against the live decision's actual method (`thumbs_up_down`, 0 options) read from production

🤖 Generated with [Claude Code](https://claude.com/claude-code)
