### PR TITLE
fix(hirn): the OpenRouter default was a paid model wearing a free name

### DIFF
--- a/src/lib/hirn/__tests__/free-model-default.test.ts
+++ b/src/lib/hirn/__tests__/free-model-default.test.ts
@@ -1,0 +1,39 @@
+/**
+ * The OpenRouter default must be a FREE model.
+ *
+ * Pinned as a test because the failure is silent and only shows up on a bill.
+ * The previous default, `meta-llama/llama-3.3-70b-instruct`, reads as a free
+ * community model and is not one: OpenRouter's own catalogue reports
+ * `pricing.prompt = 0.0000001` for it (checked 2026-08-16), and the `:free`
+ * sibling people remember has been retired — so every Hirn chat answered by
+ * OpenRouter was charged.
+ *
+ * The rule mirrors `modelCost` in the shared `ai-ration` package: a routed id
+ * (`vendor/model`) is free only with the `:free` suffix. That suffix is the
+ * whole difference between free routing and a per-call charge for identical
+ * weights, which is why an id one token away from correct went unnoticed.
+ *
+ * Free catalogues rot. When this id dies, replace it with another `:free` one —
+ * never by dropping the suffix, which is how it broke the first time.
+ */
+import { OpenRouterProvider } from '../providers/openrouter'
+
+describe('OpenRouter default model', () => {
+  const originalEnv = process.env.OPENROUTER_MODEL
+
+  afterEach(() => {
+    if (originalEnv === undefined) delete process.env.OPENROUTER_MODEL
+    else process.env.OPENROUTER_MODEL = originalEnv
+  })
+
+  it('is a :free id, so the default never bills', () => {
+    const provider = new OpenRouterProvider({ apiKey: 'test-key' })
+    expect(provider.getDefaultModel()).toMatch(/:free$/)
+  })
+
+  it('is never an Anthropic model', () => {
+    // Standing fleet rule: Anthropic is paid and is not a default or fallback.
+    const provider = new OpenRouterProvider({ apiKey: 'test-key' })
+    expect(provider.getDefaultModel()).not.toMatch(/anthropic/i)
+  })
+})

--- a/src/lib/hirn/providers/openrouter.ts
+++ b/src/lib/hirn/providers/openrouter.ts
@@ -17,7 +17,22 @@ import type {
 } from './types'
 
 const OPENROUTER_API_URL = 'https://openrouter.ai/api/v1'
-const DEFAULT_MODEL = 'meta-llama/llama-3.3-70b-instruct'
+
+/**
+ * The default model, and it must be a FREE one.
+ *
+ * This was `meta-llama/llama-3.3-70b-instruct`, which is billed — verified
+ * against OpenRouter's own catalogue on 2026-08-16, where it reports
+ * `pricing.prompt = 0.0000001`. It reads free because the price is tiny and
+ * because a `:free` sibling used to exist; that sibling is no longer in the
+ * catalogue at all, so every Hirn chat answered by OpenRouter has been charged.
+ *
+ * `openai/gpt-oss-20b:free` reports `pricing.prompt = 0` and was probed live for
+ * tool-call support on 2026-08-15. Free catalogues rot, so this is overridable
+ * without a deploy — and when it rots, replace it with another `:free` id rather
+ * than dropping the suffix.
+ */
+const DEFAULT_MODEL = process.env.OPENROUTER_MODEL?.trim() || 'openai/gpt-oss-20b:free'
 const REQUEST_TIMEOUT_MS = 30_000
 const AVAILABILITY_TIMEOUT_MS = 5_000
 


### PR DESCRIPTION
`DEFAULT_MODEL` was **`meta-llama/llama-3.3-70b-instruct`**.

That reads like the free community Llama and is not. OpenRouter's own catalogue reports **`pricing.prompt = 0.0000001`** for it (checked 2026-08-16 against `/api/v1/models`), and the `:free` sibling people remember **is no longer in the catalogue at all**.

So every Hirn chat answered by OpenRouter has been charged — quietly, because the per-token price is small enough to look like a rounding error until it is a line item.

Now `openai/gpt-oss-20b:free` (`pricing.prompt = 0`, probed live for tool-call support 2026-08-15), overridable via `OPENROUTER_MODEL` so a rotted free id can be routed around without a deploy.

### Guarded
A test pins that the default ends in `:free`. The rule mirrors `modelCost` in the shared `ai-ration` package: a routed id (`vendor/model`) is free **only** with that suffix — the whole difference between free routing and a per-call charge for identical weights.

When this id rots, replace it with another `:free` one — **never** by dropping the suffix, which is how it broke the first time.

**The same mistake was found in three apps on the same day** (also botsmann and kivvi).

🤖 Generated with [Claude Code](https://claude.com/claude-code)