### PR TITLE
fix(email): the relay says 250 and the mail goes nowhere

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -87,7 +87,11 @@ hold the line on all of it by default:
 
 ## Production URL — don't get this wrong
 
-**This codebase runs at https://revampit.orangecat.ch** (self-hosted Hetzner, deployed from `main` by `deploy-selfhost.yml`). Health check: `https://revampit.orangecat.ch/api/health`. Staff time entry (Zeiterfassung): `/admin/zeiterfassung`.
+**This codebase runs at https://evig.orangecat.ch** (self-hosted Hetzner, deployed from `main` by `deploy-selfhost.yml`). Health check: `https://evig.orangecat.ch/api/health`. Staff time entry (Zeiterfassung): `/admin/zeiterfassung`.
+
+**`revampit.orangecat.ch` still resolves and redirects here** (Caddy, `/etc/caddy/Caddyfile`). That redirect **must stay a 308, never a 301/`permanent`**: 301 does not preserve the HTTP method, so every POST to the old host arrives as a bodyless GET. On 2026-08-16 it was set to `permanent` and `/api/auth/callback/credentials` began answering `InvalidProvider: Callback for provider type (credentials) is not supported` — Auth.js rejecting a GET on a credentials callback. Browser traffic looked fine (it lands on the canonical host and posts there), so only non-browser POST clients broke: the CI auth smoke, API callers, and any webhook still aimed at the old host.
+
+The `auth-smoke` / `inventory-smoke` CI jobs deliberately point `PLAYWRIGHT_BASE_URL` at the **old** host, so they exercise that redirect. Do not "fix" a redirect failure by repointing them at the canonical host — that deletes the only coverage of it.
 
 **https://www.revamp-it.ch is the org's LEGACY Joomla site — not this app.** Never verify deploys or smoke-test there. Full URL list: `docs/SHARED_CONTEXT.md` → Access Points.
 

--- a/docs/SHARED_CONTEXT.md
+++ b/docs/SHARED_CONTEXT.md
@@ -55,10 +55,11 @@ last_modified_summary: Access Points — production URLs (revampit.orangecat.ch)
 
 ### Production (this codebase)
 
-- **App**: https://revampit.orangecat.ch — self-hosted on the Hetzner box, deployed from `main` via `deploy-selfhost.yml` (systemd `revampit-app`)
-- **Health**: https://revampit.orangecat.ch/api/health (DB + Meilisearch status)
-- **Admin**: https://revampit.orangecat.ch/admin
-- **Zeiterfassung (staff time entry)**: https://revampit.orangecat.ch/admin/zeiterfassung (same shared `TimecardsClient` also at `/dashboard/timecards`)
+- **App**: https://evig.orangecat.ch — self-hosted on the Hetzner box, deployed from `main` via `deploy-selfhost.yml` (systemd `revampit-app`)
+- **Health**: https://evig.orangecat.ch/api/health (DB + Meilisearch status)
+- **Admin**: https://evig.orangecat.ch/admin
+- **Zeiterfassung (staff time entry)**: https://evig.orangecat.ch/admin/zeiterfassung (same shared `TimecardsClient` also at `/dashboard/timecards`)
+- **Old host**: https://revampit.orangecat.ch redirects here via Caddy. The redirect must stay **308**, not 301/`permanent` — 301 drops the method, so POSTs arrive as GETs and credentials login breaks. See the Production URL section of `CLAUDE.md`.
 
 ⚠️ **https://www.revamp-it.ch is NOT this codebase** — that is the organization's legacy Joomla site. Never smoke-test or verify deploys there.
 

--- a/scripts/test-email.ts
+++ b/scripts/test-email.ts
@@ -1,11 +1,23 @@
 /**
- * Test Email Script
+ * Email deliverability probe
  *
- * Run with: npx tsx scripts/test-email.ts
+ * Run with: npx tsx scripts/test-email.ts <recipient@example.com>
+ *
+ * WHY THIS CHECKS DNS: a relay answering `250 accepted` proves the credentials
+ * work, not that anyone receives the mail. Brevo accepts messages from a sender
+ * domain it has not authenticated and then drops them, so the SMTP conversation
+ * succeeds while the inbox stays empty forever. That is precisely how evig's
+ * production mail was silently dead: EMAIL_FROM was noreply@revampit.ch, a
+ * domain with no SPF record and no Brevo DKIM key, and not one application
+ * email had ever arrived.
+ *
+ * So this script reports the sender domain's authentication BEFORE sending, and
+ * refuses to call a relay handoff "delivered".
  */
 
 import * as fs from 'fs';
 import * as path from 'path';
+import * as dns from 'dns/promises';
 import * as nodemailer from 'nodemailer';
 
 // Load .env.local manually
@@ -33,14 +45,101 @@ const EMAIL_CONFIG = {
   SECURE: process.env.EMAIL_SECURE === 'true',
 };
 
+/**
+ * DKIM selectors are chosen by the mail provider and cannot be enumerated from
+ * DNS, so absence here is only conclusive for a provider whose selector we
+ * know. Brevo documents `brevo._domainkey`; the rest are common conventions
+ * checked as a courtesy. A domain using some other selector is NOT broken —
+ * saying otherwise would make this script cry wolf on healthy domains.
+ */
+const DKIM_SELECTORS = ['brevo', 'mail', 'default', 'k1'];
+
+async function txtRecords(name: string): Promise<string[]> {
+  try {
+    const records = await dns.resolveTxt(name);
+    return records.map((chunks) => chunks.join(''));
+  } catch {
+    return [];
+  }
+}
+
+/**
+ * Report whether the sender domain authorises this relay. Returns false when
+ * the domain is provably unauthenticated, so the caller can say so loudly
+ * instead of reporting a cheerful 250.
+ */
+async function checkSenderDomain(from: string, relayHost: string): Promise<boolean> {
+  const domain = from.split('@')[1];
+  if (!domain) {
+    console.log('  Sender has no domain — cannot authenticate');
+    return false;
+  }
+
+  console.log(`Sender domain authentication for ${domain}:`);
+
+  const spf = (await txtRecords(domain)).filter((r) => r.toLowerCase().startsWith('v=spf1'));
+  console.log(spf.length ? `  SPF   : ${spf[0]}` : '  SPF   : MISSING');
+
+  const dmarc = await txtRecords(`_dmarc.${domain}`);
+  console.log(dmarc.length ? `  DMARC : ${dmarc[0]}` : '  DMARC : MISSING');
+
+  const foundSelectors: string[] = [];
+  for (const selector of DKIM_SELECTORS) {
+    const key = await txtRecords(`${selector}._domainkey.${domain}`);
+    if (key.length) foundSelectors.push(selector);
+  }
+  console.log(
+    foundSelectors.length
+      ? `  DKIM  : ${foundSelectors.join(', ')}`
+      : `  DKIM  : none of the known selectors (${DKIM_SELECTORS.join(', ')})`
+  );
+
+  // Only claim a domain is unauthenticated where the evidence is conclusive:
+  // a missing SPF record always is, and a missing `brevo` selector is when
+  // Brevo is the relay we are actually sending through.
+  const usingBrevo = relayHost.toLowerCase().includes('brevo');
+  const problems: string[] = [];
+  if (spf.length === 0) problems.push('no SPF record');
+  if (usingBrevo && !foundSelectors.includes('brevo')) {
+    problems.push('no brevo._domainkey DKIM record, but Brevo is the relay');
+  }
+
+  if (problems.length > 0) {
+    console.log('');
+    console.log(`  ⚠ ${domain} does not authenticate mail through this relay: ${problems.join('; ')}.`);
+    console.log('    The relay will still answer 250 and the message will vanish.');
+    console.log('    Fix: authenticate the sending domain with the provider and');
+    console.log('    publish the SPF + DKIM records it gives you, then re-run.');
+  } else if (!foundSelectors.length) {
+    console.log('');
+    console.log('  Note: no DKIM found under the selectors above, but providers choose');
+    console.log('  their own — this is inconclusive rather than a failure.');
+  }
+  console.log('');
+  return problems.length === 0;
+}
+
 async function testEmail() {
-  console.log('Email Configuration:');
-  console.log('  Host:', EMAIL_CONFIG.HOST);
-  console.log('  Port:', EMAIL_CONFIG.PORT);
-  console.log('  User:', EMAIL_CONFIG.USER);
-  console.log('  From:', EMAIL_CONFIG.FROM);
+  const recipient = process.argv[2];
+  if (!recipient || !recipient.includes('@')) {
+    console.error('Usage: npx tsx scripts/test-email.ts <recipient@example.com>');
+    process.exit(1);
+  }
+
+  console.log('Email configuration:');
+  console.log('  Host  :', EMAIL_CONFIG.HOST);
+  console.log('  Port  :', EMAIL_CONFIG.PORT);
+  console.log('  User  :', EMAIL_CONFIG.USER);
+  console.log('  From  :', EMAIL_CONFIG.FROM);
   console.log('  Secure:', EMAIL_CONFIG.SECURE);
   console.log('');
+
+  if (!EMAIL_CONFIG.FROM || !EMAIL_CONFIG.USER || !EMAIL_CONFIG.PASS) {
+    console.error('Incomplete SMTP configuration — set EMAIL_FROM, EMAIL_USER and EMAIL_PASS.');
+    process.exit(1);
+  }
+
+  const authenticated = await checkSenderDomain(EMAIL_CONFIG.FROM, EMAIL_CONFIG.HOST);
 
   const transporter = nodemailer.createTransport({
     host: EMAIL_CONFIG.HOST,
@@ -52,44 +151,47 @@ async function testEmail() {
     },
   });
 
-  // Test connection
   console.log('Testing SMTP connection...');
   try {
     await transporter.verify();
-    console.log('SMTP connection successful!');
+    console.log('  Connection and credentials OK');
   } catch (error) {
-    console.error('SMTP connection failed:', error);
+    console.error('  SMTP connection failed:', error);
     process.exit(1);
   }
 
-  // Send test email
-  const testRecipient = EMAIL_CONFIG.FROM; // Send to ourselves
-  console.log(`\nSending test email to ${testRecipient}...`);
+  const sentAt = new Date().toISOString();
+  console.log(`\nSending to ${recipient}...`);
 
   try {
     const info = await transporter.sendMail({
-      from: `"RevampIT Test" <${EMAIL_CONFIG.FROM}>`,
-      to: testRecipient,
-      subject: 'RevampIT Email Test',
-      text: 'This is a test email from RevampIT. If you received this, email sending is working correctly!',
-      html: `
-        <div style="font-family: Arial, sans-serif; max-width: 600px; margin: 0 auto;">
-          <h1 style="color: #22c55e;">RevampIT Email Test</h1>
-          <p>This is a test email from RevampIT.</p>
-          <p>If you received this, email sending is working correctly!</p>
-          <hr style="border: none; border-top: 1px solid #e5e7eb; margin: 20px 0;">
-          <p style="color: #6b7280; font-size: 12px;">
-            Sent via Brevo SMTP at ${new Date().toISOString()}
-          </p>
-        </div>
-      `,
+      from: EMAIL_CONFIG.FROM,
+      to: recipient,
+      subject: 'Email deliverability probe',
+      text:
+        'This is a deliverability probe sent by scripts/test-email.ts.\n\n' +
+        'If it reached an inbox, the sending domain is configured correctly.\n' +
+        'If it landed in spam, check the sender domain SPF/DKIM alignment.\n' +
+        'If it never arrived at all, the relay accepted and dropped it.\n\n' +
+        `Sent : ${sentAt}\n` +
+        `Relay: ${EMAIL_CONFIG.HOST}:${EMAIL_CONFIG.PORT}\n` +
+        `From : ${EMAIL_CONFIG.FROM}\n`,
     });
 
-    console.log('Email sent successfully!');
-    console.log('Message ID:', info.messageId);
+    console.log('  Relay accepted the message');
+    console.log('  Message ID:', info.messageId);
   } catch (error) {
-    console.error('Failed to send email:', error);
+    console.error('  Failed to send:', error);
     process.exit(1);
+  }
+
+  console.log('');
+  if (authenticated) {
+    console.log(`Now confirm it actually arrived at ${recipient} — acceptance is not delivery.`);
+  } else {
+    console.log('The relay accepted the message, but the sender domain is NOT authenticated,');
+    console.log('so expect it to be dropped or spam-filed. Treat this run as a FAILURE');
+    console.log('until a message actually lands in the inbox.');
   }
 }
 

--- a/src/app/api/vote/[id]/__tests__/route.test.ts
+++ b/src/app/api/vote/[id]/__tests__/route.test.ts
@@ -48,7 +48,8 @@ jest.mock('@/lib/api/helpers', () => {
     apiSuccess: (data: unknown, status = 200) => NextResponse.json({ success: true, data }, { status }),
     apiSuccessCached: (data: unknown) => NextResponse.json({ success: true, data }, { status: 200 }),
     apiError: (_err: unknown, msg: string, status = 500) => NextResponse.json({ success: false, error: msg }, { status }),
-    apiBadRequest: (msg: string) => NextResponse.json({ success: false, error: msg }, { status: 400 }),
+    apiBadRequest: (msg: string, errors?: unknown, code?: string) =>
+      NextResponse.json({ success: false, error: msg, ...(code && { code }) }, { status: 400 }),
   }
 })
 
@@ -279,6 +280,10 @@ describe('POST /api/vote/[id] — cannot vote as a registered member', () => {
     expect(response.status).toBe(400)
     const body = await response.json()
     expect(body.error).toMatch(/registrierten Konto/i)
+    // The UI offers a login link off this code. Without it the only way to
+    // recognise this failure is matching the German sentence, which breaks
+    // the first time someone rewords or translates it.
+    expect(body.code).toBe('vote_email_registered')
     // The whole point: no ballot is cast, so the member's existing vote
     // cannot be overwritten and allow_public_voting cannot be bypassed.
     expect(mockSubmitVote).not.toHaveBeenCalled()

--- a/src/app/api/vote/[id]/route.ts
+++ b/src/app/api/vote/[id]/route.ts
@@ -22,7 +22,7 @@ import { submitVote, getPublicDecision } from '@/lib/services/decisions'
 import { TABLE_NAMES } from '@/config/database'
 import { logger } from '@/lib/logger'
 import { apiSuccess, apiSuccessCached, apiError, apiBadRequest } from '@/lib/api/helpers'
-import { ERROR_MESSAGES } from '@/config/error-messages'
+import { ERROR_CODES, ERROR_MESSAGES } from '@/config/error-messages'
 import { rateLimiters, getClientIdentifier } from '@/lib/security/rate-limit'
 
 type RouteParams = { params: Promise<{ id: string }> }
@@ -106,7 +106,11 @@ export async function POST(
         [normalizedEmail]
       )
       if (registered.rows.length > 0) {
-        return apiBadRequest(ERROR_MESSAGES.VOTE_EMAIL_REGISTERED)
+        return apiBadRequest(
+          ERROR_MESSAGES.VOTE_EMAIL_REGISTERED,
+          undefined,
+          ERROR_CODES.VOTE_EMAIL_REGISTERED,
+        )
       }
 
       voterIdentity = { voterEmail: normalizedEmail }

--- a/src/app/vote/[id]/PublicVoteClient.tsx
+++ b/src/app/vote/[id]/PublicVoteClient.tsx
@@ -16,6 +16,7 @@ import { DotVote } from '@/components/decisions/voting/DotVote'
 import { ScoreVote } from '@/components/decisions/voting/ScoreVote'
 import { RankedChoiceVote } from '@/components/decisions/voting/RankedChoiceVote'
 import { SimpleMajorityVote } from '@/components/decisions/voting/SimpleMajorityVote'
+import { ThumbsUpDownVote } from '@/components/decisions/voting/ThumbsUpDownVote'
 import { DeadlineCountdown } from '@/components/decisions/voting/DeadlineCountdown'
 import { VoteAIAdvisor } from '@/components/decisions/VoteAIAdvisor'
 
@@ -222,6 +223,9 @@ export default function PublicVoteClient({
             onMoveUp={vote.moveRankingUp}
             onMoveDown={vote.moveRankingDown}
           />
+        )}
+        {votingMethod === 'thumbs_up_down' && (
+          <ThumbsUpDownVote choice={vote.thumbsChoice} onChange={vote.setThumbsChoice} />
         )}
       </div>
 

--- a/src/app/vote/[id]/PublicVoteClient.tsx
+++ b/src/app/vote/[id]/PublicVoteClient.tsx
@@ -8,6 +8,7 @@ import { Input } from '@/components/ui/input'
 import { useTranslations } from 'next-intl'
 import { apiFetch } from '@/lib/api/client'
 import { type VotingMethod } from '@/config/decisions'
+import { ERROR_CODES } from '@/config/error-messages'
 import { useVoteState } from '@/hooks/useVoteState'
 import { ConsentVote } from '@/components/decisions/voting/ConsentVote'
 import { ApprovalVote } from '@/components/decisions/voting/ApprovalVote'
@@ -58,6 +59,7 @@ export default function PublicVoteClient({
   const [email, setEmail] = useState('')
   const [submitting, setSubmitting] = useState(false)
   const [error, setError] = useState('')
+  const [errorCode, setErrorCode] = useState<string | null>(null)
   const [success, setSuccess] = useState(false)
 
   const vote = useVoteState({ votingMethod, options, dotCount })
@@ -75,6 +77,7 @@ export default function PublicVoteClient({
     }
 
     setError('')
+    setErrorCode(null)
     setSubmitting(true)
 
     const voteData = vote.buildVoteData()
@@ -85,6 +88,7 @@ export default function PublicVoteClient({
     })
     if (!result.success) {
       setError(result.error || t('submitError'))
+      setErrorCode(result.code ?? null)
       setSubmitting(false)
       return
     }
@@ -224,6 +228,13 @@ export default function PublicVoteClient({
       {error && (
         <div className="rounded-lg bg-error-50 dark:bg-red-500/8 border border-error-200 dark:border-red-500/20 p-3 text-sm text-error-700 dark:text-red-300">
           {error}
+          {/* "Sign in to vote with this address" is a dead end without the
+              door — send them straight to it. */}
+          {errorCode === ERROR_CODES.VOTE_EMAIL_REGISTERED && (
+            <Link href={loginUrl} className="ml-1 font-semibold underline">
+              {t('successLoginCta')}
+            </Link>
+          )}
         </div>
       )}
 

--- a/src/components/decisions/VotingPanel.tsx
+++ b/src/components/decisions/VotingPanel.tsx
@@ -13,6 +13,7 @@ import { DotVote } from './voting/DotVote';
 import { ScoreVote } from './voting/ScoreVote';
 import { RankedChoiceVote } from './voting/RankedChoiceVote';
 import { SimpleMajorityVote } from './voting/SimpleMajorityVote';
+import { ThumbsUpDownVote } from './voting/ThumbsUpDownVote';
 import { VoteAIAdvisor } from '@/components/decisions/VoteAIAdvisor';
 
 interface Option {
@@ -166,6 +167,9 @@ export default function VotingPanel({
       )}
       {votingMethod === 'simple_majority' && (
         <SimpleMajorityVote response={vote.majorityResponse} onChange={vote.setMajorityResponse} />
+      )}
+      {votingMethod === 'thumbs_up_down' && (
+        <ThumbsUpDownVote choice={vote.thumbsChoice} onChange={vote.setThumbsChoice} />
       )}
 
       <Button

--- a/src/components/decisions/__tests__/ballot-coverage.test.tsx
+++ b/src/components/decisions/__tests__/ballot-coverage.test.tsx
@@ -1,0 +1,72 @@
+/**
+ * Every configured voting method must render a ballot.
+ *
+ * `thumbs_up_down` sat in VOTING_METHODS with no branch in either voting
+ * surface and no case in useVoteState. The result was silent: the page drew
+ * the "Deine Stimme" heading with nothing beneath it, buildVoteData() fell
+ * through to undefined, and the server answered "Stimmdaten erforderlich".
+ * The only decision in production could not be voted on, and nothing on
+ * screen said why.
+ *
+ * A missing branch is absence, and absence is what a normal test never sees —
+ * so this one iterates the config rather than a list someone has to remember
+ * to extend. Add a method to VOTING_METHODS without giving it a ballot and
+ * this fails.
+ */
+
+import { render } from '@testing-library/react'
+import { VOTING_METHODS, type VotingMethod } from '@/config/decisions'
+import PublicVoteClient from '../../../app/vote/[id]/PublicVoteClient'
+
+// Spread the real module — replacing it wholesale breaks defineRouting, which
+// button.tsx pulls in transitively via src/i18n/navigation.
+jest.mock('next-intl', () => ({
+  ...jest.requireActual('next-intl'),
+  useTranslations: () => (key: string) => key,
+}))
+
+jest.mock('@/lib/api/client', () => ({
+  apiFetch: jest.fn(async () => ({ success: true, data: {} })),
+}))
+
+jest.mock('@/components/decisions/VoteAIAdvisor', () => ({
+  VoteAIAdvisor: () => null,
+}))
+
+const OPTIONS = [
+  { id: 'opt-1', label: 'Erste Option' },
+  { id: 'opt-2', label: 'Zweite Option' },
+]
+
+function renderBallot(votingMethod: VotingMethod) {
+  return render(
+    <PublicVoteClient
+      decisionId="decision-1"
+      title="Testentscheidung"
+      description="Beschreibung"
+      background=""
+      votingMethod={votingMethod}
+      options={OPTIONS}
+      dotCount={5}
+      votingDeadline={null}
+      isVotingPhase
+      allowPublicVoting
+      registerUrl="/register"
+      loginUrl="/login"
+    />
+  )
+}
+
+describe('every configured voting method renders a ballot', () => {
+  it.each(VOTING_METHODS)('%s draws interactive controls', (method) => {
+    const { container } = renderBallot(method)
+
+    // The ballot lives between the email field and the submit button. Any
+    // real ballot offers something to interact with; an unhandled method
+    // renders an empty box, which is the bug this guards.
+    const controls = container.querySelectorAll(
+      'button:not([type="submit"]), input:not([type="email"]), textarea, [role="radio"], [role="slider"]'
+    )
+    expect(controls.length).toBeGreaterThan(0)
+  })
+})

--- a/src/components/decisions/voting/ThumbsUpDownVote.tsx
+++ b/src/components/decisions/voting/ThumbsUpDownVote.tsx
@@ -1,0 +1,46 @@
+'use client';
+
+import { ThumbsUp, ThumbsDown } from 'lucide-react';
+import { Button } from '@/components/ui/button';
+import {
+  THUMBS_UP_DOWN_CHOICES,
+  THUMBS_UP_DOWN_CHOICE_CONFIG,
+  type ThumbsUpDownChoice,
+} from '@/config/decisions';
+
+interface Props {
+  choice: ThumbsUpDownChoice | null;
+  onChange: (c: ThumbsUpDownChoice) => void;
+}
+
+const ICONS = { up: ThumbsUp, down: ThumbsDown } as const;
+
+export function ThumbsUpDownVote({ choice, onChange }: Props) {
+  return (
+    <div className="flex gap-3">
+      {THUMBS_UP_DOWN_CHOICES.map((c) => {
+        const Icon = ICONS[c];
+        const selected = choice === c;
+        return (
+          <Button
+            key={c}
+            type="button"
+            variant="outline"
+            aria-pressed={selected}
+            onClick={() => onChange(c)}
+            className={`flex-1 flex items-center justify-center gap-2 rounded-md border-2 px-4 py-3 text-sm font-medium transition ${
+              selected
+                ? c === 'up'
+                  ? 'border-action bg-action-muted text-action'
+                  : 'border-error-500 bg-error-50 dark:bg-error-900/20 text-error-700 dark:text-error-300'
+                : 'border text-text-secondary hover:border-strong'
+            }`}
+          >
+            <Icon className="h-4 w-4" />
+            {THUMBS_UP_DOWN_CHOICE_CONFIG[c].label}
+          </Button>
+        );
+      })}
+    </div>
+  );
+}

--- a/src/config/decisions.ts
+++ b/src/config/decisions.ts
@@ -382,6 +382,21 @@ export const SIMPLE_MAJORITY_RESPONSE_CONFIG: Record<
   abstain: { label: 'Enthaltung' },
 };
 
+// ─── Thumbs Up / Down Choices ─────────────────────────────────────────────
+// Must stay in step with thumbsUpDownVoteSchema (src/lib/schemas/decisions.ts).
+
+export const THUMBS_UP_DOWN_CHOICES = ['up', 'down'] as const;
+
+export type ThumbsUpDownChoice = (typeof THUMBS_UP_DOWN_CHOICES)[number];
+
+export const THUMBS_UP_DOWN_CHOICE_CONFIG: Record<
+  ThumbsUpDownChoice,
+  { label: string }
+> = {
+  up: { label: 'Dafür' },
+  down: { label: 'Dagegen' },
+};
+
 // ─── Comment Positions ────────────────────────────────────────────────────
 
 export const COMMENT_POSITIONS = [

--- a/src/config/error-messages.ts
+++ b/src/config/error-messages.ts
@@ -140,3 +140,18 @@ export const SUCCESS_MESSAGES = {
   // Workshops
   WORKSHOP_REGISTERED: 'Erfolgreich für Workshop angemeldet',
 } as const;
+
+/**
+ * Stable error codes — SSOT shared by the API and the UI.
+ *
+ * Only add one when the interface must *do* something different for that
+ * failure (offer a login link, a retry, a different form). The human sentence
+ * lives in ERROR_MESSAGES and is free to be reworded or translated; the code
+ * is what the UI is allowed to branch on.
+ */
+export const ERROR_CODES = {
+  /** Anonymous ballot naming an email that belongs to a registered account. */
+  VOTE_EMAIL_REGISTERED: 'vote_email_registered',
+} as const;
+
+export type ErrorCode = typeof ERROR_CODES[keyof typeof ERROR_CODES];

--- a/src/hooks/useVoteState.ts
+++ b/src/hooks/useVoteState.ts
@@ -5,6 +5,7 @@ import {
   type VotingMethod,
   type ConsentResponse,
   type SimpleMajorityResponse,
+  type ThumbsUpDownChoice,
 } from '@/config/decisions';
 
 interface Option {
@@ -31,6 +32,9 @@ export function useVoteState({ votingMethod, options, dotCount }: UseVoteStatePr
   );
   const [majorityResponse, setMajorityResponse] = useState<SimpleMajorityResponse>('yes');
   const [ranking, setRanking] = useState<string[]>(() => options.map((o) => o.id));
+  // No default: a thumbs vote is one deliberate tap, so pre-selecting "Dafür"
+  // would submit an opinion the voter never expressed.
+  const [thumbsChoice, setThumbsChoice] = useState<ThumbsUpDownChoice | null>(null);
 
   function toggleApproval(optId: string) {
     setApprovedOptions((prev) => {
@@ -75,6 +79,15 @@ export function useVoteState({ votingMethod, options, dotCount }: UseVoteStatePr
       case 'score':           return { scores };
       case 'simple_majority': return { response: majorityResponse };
       case 'ranked_choice':   return { ranking };
+      case 'thumbs_up_down':  return thumbsChoice ? { choice: thumbsChoice } : undefined;
+      default: {
+        // A method in VOTING_METHODS with no case here used to fall through to
+        // `undefined`, which the UI rendered as an empty ballot and the server
+        // rejected as "Stimmdaten erforderlich" — a decision nobody could vote
+        // on, with nothing on screen explaining why. Now it fails the build.
+        const unhandled: never = votingMethod;
+        throw new Error(`Unhandled voting method: ${String(unhandled)}`);
+      }
     }
   }
 
@@ -86,6 +99,7 @@ export function useVoteState({ votingMethod, options, dotCount }: UseVoteStatePr
     scores, setScore,
     majorityResponse, setMajorityResponse,
     ranking, moveRankingUp, moveRankingDown,
+    thumbsChoice, setThumbsChoice,
     buildVoteData,
   };
 }

--- a/src/lib/api/__tests__/client.test.ts
+++ b/src/lib/api/__tests__/client.test.ts
@@ -145,6 +145,37 @@ describe('apiFetch', () => {
     expect(result.error).toBe('Anfrage fehlgeschlagen (503)')
   })
 
+  // ── error codes ─────────────────────────────────────────────────────────────
+
+  it('passes a machine-readable error code through to the caller', async () => {
+    mockFetch.mockResolvedValueOnce(
+      jsonResponse({ success: false, error: 'Bitte melde dich an.', code: 'vote_email_registered' }, 400)
+    )
+
+    const result = await apiFetch('/api/test')
+
+    // Without this the UI can only tell failures apart by matching German
+    // prose — which breaks the moment the sentence is reworded.
+    expect(result.code).toBe('vote_email_registered')
+    expect(result.error).toBe('Bitte melde dich an.')
+  })
+
+  it('omits code entirely when the response has none', async () => {
+    mockFetch.mockResolvedValueOnce(jsonResponse({ success: false, error: 'plain' }, 400))
+
+    const result = await apiFetch('/api/test')
+
+    expect(result).toEqual({ success: false, error: 'plain' })
+  })
+
+  it('ignores a non-string code rather than passing junk to the UI', async () => {
+    mockFetch.mockResolvedValueOnce(jsonResponse({ success: false, error: 'x', code: 42 }, 400))
+
+    const result = await apiFetch('/api/test')
+
+    expect(result.code).toBeUndefined()
+  })
+
   // ── network failures ────────────────────────────────────────────────────────
 
   it('returns a friendly network error when fetch rejects', async () => {

--- a/src/lib/api/client.ts
+++ b/src/lib/api/client.ts
@@ -59,6 +59,10 @@ export async function apiFetch<T = unknown>(
         error: fieldMessages.length > 0
           ? `${baseError}: ${fieldMessages.join(' · ')}`
           : baseError,
+        // Pass the code through untouched — callers that offer a way out of a
+        // specific failure need it, and flattening it away is what forced
+        // string-matching on German prose.
+        ...(typeof data.code === 'string' && { code: data.code }),
       }
     }
 

--- a/src/lib/api/helpers.ts
+++ b/src/lib/api/helpers.ts
@@ -148,16 +148,21 @@ export function apiRateLimited(
  * Bad request response helper
  * @param message - Error message
  * @param errors - Optional validation errors
+ * @param code - Optional stable code from ERROR_CODES. The message is for the
+ *   human; the code is for the UI, so it can offer the way out (a login link,
+ *   a retry) without pattern-matching German prose that translators may change.
  */
 export function apiBadRequest(
   message: string,
-  errors?: Record<string, string[]>
+  errors?: Record<string, string[]>,
+  code?: string
 ): NextResponse {
   return NextResponse.json(
     {
       success: false,
       error: message,
       ...(errors && { errors }),
+      ...(code && { code }),
     },
     { status: 400 }
   );

--- a/src/lib/api/types.ts
+++ b/src/lib/api/types.ts
@@ -10,6 +10,12 @@ export interface ApiResponse<T = unknown> {
   success: boolean
   data?: T
   error?: string
+  /**
+   * Stable machine-readable discriminator from ERROR_CODES, set only where the
+   * UI must react to *which* failure it was. `error` stays the human sentence —
+   * branching on that text breaks the moment it is reworded or translated.
+   */
+  code?: string
 }
 
 /** Paginated API response (page-based) */


### PR DESCRIPTION
I sent a probe from the production host through the configured relay to a real mailbox. The SMTP conversation was flawless — EHLO, STARTTLS, AUTH, accepted — and **the message never arrived**. Not the inbox, not spam, not trash.

## Cause

`EMAIL_FROM` in prod is `noreply@revampit.ch`. That domain has:

| Record | State |
|---|---|
| SPF | **missing** |
| `brevo._domainkey` DKIM | **missing** |
| DMARC | `p=none` |

Brevo accepts mail from a domain it has not authenticated and then drops it. Every layer reports success — `sendEmail` returns `{ success: true }` on a relay handoff — and the inbox stays empty.

Searching the recipient mailbox back through its entire history finds **no application mail at all**. Every `revamp-it.ch` message in it is human mail from colleagues, sent via the org's own server (which is covered by `revamp-it.ch`'s SPF). evig's transactional email has never worked.

## Why the existing script could not have caught it

`scripts/test-email.ts` mailed only `EMAIL_FROM` — itself — and printed `Email sent successfully!` on relay acceptance. It measured the one thing that was never in doubt.

Rebuilt to answer the question that matters:

- takes the recipient as an argument rather than sending to itself
- resolves the sender domain's SPF, DKIM and DMARC **before** sending, and says plainly that an unauthenticated domain will vanish despite a 250
- refuses to call acceptance delivery

## The DKIM verdict is deliberately relay-aware

DKIM selectors are chosen by the provider and cannot be enumerated from DNS, so a missing selector is only conclusive when we know which one to expect. Brevo documents `brevo._domainkey`; against any other relay an unknown selector is reported as *inconclusive*, not as a failure.

My first version got this wrong and flagged google.com as broken. Checked both directions after fixing it:

- `noreply@google.com` **through Brevo** → flagged, which is true: it has no Brevo key
- `noreply@google.com` **through another relay** → not flagged, reported inconclusive

## What this does not do

It does not fix delivery. That needs a sending domain that exists and is authenticated with the provider — a purchase and a DNS change, not a code change.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
