### PR TITLE
fix(ci): post-deploy smoke called a redirect a failure, and a redirect ready

### DIFF
--- a/scripts/post-deploy-smoke.sh
+++ b/scripts/post-deploy-smoke.sh
@@ -13,7 +13,12 @@
 
 set -euo pipefail
 
-BASE_URL="${SMOKE_BASE_URL:-${PLAYWRIGHT_BASE_URL:-https://revampit.orangecat.ch}}"
+# evig.orangecat.ch is the canonical host; revampit.orangecat.ch 308s to it.
+# Every curl below passes -L: without it a redirect is reported as its 3xx and
+# every check fails, which is exactly what happened when the old host started
+# redirecting. Following redirects also means this keeps working from either
+# host, so a future rename cannot turn the whole smoke red on its own.
+BASE_URL="${SMOKE_BASE_URL:-${PLAYWRIGHT_BASE_URL:-https://evig.orangecat.ch}}"
 
 # Public pages that must render (HTTP 200).
 PAGES=(
@@ -39,7 +44,9 @@ APIS=(
 echo "=== wait for ${BASE_URL}/api/health ==="
 ready=0
 for _ in 1 2 3 4 5 6; do
-  if curl -sf --max-time 15 "${BASE_URL}/api/health" >/dev/null; then ready=1; break; fi
+  # -L matters here too: `curl -sf` does NOT fail on a 3xx, so without it this
+  # loop reports "ready" after merely receiving a redirect it never followed.
+  if curl -sfL --max-time 15 "${BASE_URL}/api/health" >/dev/null; then ready=1; break; fi
   sleep 10
 done
 if [ "$ready" -ne 1 ]; then
@@ -51,7 +58,7 @@ fails=0
 
 echo "=== pages (expect 200) → ${BASE_URL} ==="
 for path in "${PAGES[@]}"; do
-  code=$(curl -s -o /dev/null -w "%{http_code}" --max-time 20 "${BASE_URL}${path}")
+  code=$(curl -sL -o /dev/null -w "%{http_code}" --max-time 20 "${BASE_URL}${path}")
   if [ "$code" = "200" ]; then
     echo "  ok  ${path} (${code})"
   else
@@ -63,7 +70,7 @@ done
 echo "=== APIs (expect 200 + success:true) → ${BASE_URL} ==="
 for path in "${APIS[@]}"; do
   body=$(mktemp)
-  code=$(curl -s -o "$body" -w "%{http_code}" --max-time 20 "${BASE_URL}${path}")
+  code=$(curl -sL -o "$body" -w "%{http_code}" --max-time 20 "${BASE_URL}${path}")
   if [ "$code" = "200" ] && grep -q '"success":true' "$body"; then
     echo "  ok  ${path} (${code})"
   else


### PR DESCRIPTION
The deploy of `d464f6f6` went red while the deploy job itself **succeeded**. All 13 checks reported `308`:

```
=== pages (expect 200) → https://revampit.orangecat.ch ===
  FAIL / (308)
  FAIL /marketplace (308)
  ...
=== smoke FAILED: 13 check(s) failed ===
```

Nothing is wrong with the app. `scripts/post-deploy-smoke.sh` points at `revampit.orangecat.ch` and compares the status to a literal `200` **without following redirects**, so it broke the moment that host began redirecting to `evig.orangecat.ch`. This run is just the first deploy since. It would have failed identically on the `301` it originally was.

## The readiness probe had the opposite bug, and it was quieter

```bash
curl -sf --max-time 15 "${BASE_URL}/api/health"
```

`curl -sf` does **not** fail on a 3xx. So the loop reported the site ready after merely *receiving* a redirect it never followed, then handed off to checks that all failed. A wait loop satisfied by a redirect is not a wait loop.

## Fix

- default base is the canonical host, `evig.orangecat.ch`
- every curl passes `-L`, **including** the readiness probe

Following redirects rather than only repinning the host means a future rename cannot turn the whole smoke red on its own, and the run stays meaningful from either host.

## Verified against live prod

| Run | Result |
|---|---|
| `evig.orangecat.ch` | 13/13 pass |
| `revampit.orangecat.ch` (through the 308) | 13/13 pass |
| bogus base URL | **exits 1** |

The last row matters: a smoke that follows redirects could easily be one that passes on anything, so I negative-tested that it still goes red rather than trusting the green.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
