### PR TITLE
fix(security): cron auth failed open on 5 of 6 routes

### DIFF
--- a/src/app/api/cron/close-decisions/__tests__/route.test.ts
+++ b/src/app/api/cron/close-decisions/__tests__/route.test.ts
@@ -104,7 +104,11 @@ const MOCK_UPCOMING_DECISION = {
   invitedParticipants: [],
 }
 
-function makeRequest(authHeader?: string): NextRequest {
+function makeRequest(
+  authHeader: string | undefined = `Bearer ${process.env.CRON_SECRET}`,
+  opts: { omitAuth?: boolean } = {},
+): NextRequest {
+  if (opts.omitAuth) authHeader = undefined
   return new NextRequest('http://localhost/api/cron/close-decisions', {
     headers: authHeader ? { authorization: authHeader } : {},
   })
@@ -112,7 +116,9 @@ function makeRequest(authHeader?: string): NextRequest {
 
 beforeEach(() => {
   jest.resetAllMocks()
-  delete process.env.CRON_SECRET
+  // Configured, because an unset secret now denies every request —
+  // these routes are no longer reachable without one.
+  process.env.CRON_SECRET = 'test-cron-secret'
   mockTransitionDecision.mockResolvedValue({ id: 'decision-1', status: 'closed' })
   mockNotifyAllStaff.mockResolvedValue(undefined)
   mockNotifyUsers.mockResolvedValue(undefined)
@@ -129,15 +135,17 @@ beforeEach(() => {
 
 describe('GET /api/cron/close-decisions — auth', () => {
   it('returns 401 when CRON_SECRET is set and authorization header is missing', async () => {
-    process.env.CRON_SECRET = 'secret-abc'
-    const res = await GET(makeRequest())
+    process.env.CRON_SECRET = 'test-cron-secret'
+    // Explicitly headerless — makeRequest() now defaults to a valid bearer,
+    // because every other test needs one to reach the route body at all.
+    const res = await GET(makeRequest(undefined, { omitAuth: true }))
     expect(res.status).toBe(401)
     const body = await res.json()
     expect(body.error).toBe('Unauthorized')
   })
 
   it('returns 401 when CRON_SECRET is set and authorization header is wrong', async () => {
-    process.env.CRON_SECRET = 'secret-abc'
+    process.env.CRON_SECRET = 'test-cron-secret'
     const res = await GET(makeRequest('Bearer wrong-secret'))
     expect(res.status).toBe(401)
   })
@@ -149,8 +157,8 @@ describe('GET /api/cron/close-decisions — auth', () => {
   })
 
   it('runs with correct Bearer token', async () => {
-    process.env.CRON_SECRET = 'secret-abc'
-    const res = await GET(makeRequest('Bearer secret-abc'))
+    process.env.CRON_SECRET = 'test-cron-secret'
+    const res = await GET(makeRequest(`Bearer ${process.env.CRON_SECRET}`))
     expect(res.status).toBe(200)
   })
 })

--- a/src/app/api/cron/close-decisions/route.ts
+++ b/src/app/api/cron/close-decisions/route.ts
@@ -19,16 +19,11 @@ import { logger } from '@/lib/logger'
 import { DECISION_STATUS, PARTICIPANT_SCOPE_DEFAULT } from '@/config/decisions'
 import { NOTIFICATION_TYPES, RELATED_TYPES } from '@/config/notifications'
 import { TABLE_NAMES } from '@/config/database'
+import { requireCronAuth } from '@/lib/api/cron-auth'
 
 export async function GET(request: NextRequest) {
-  // Verify cron secret (skip in dev if not set)
-  const cronSecret = process.env.CRON_SECRET
-  if (cronSecret) {
-    const authHeader = request.headers.get('authorization')
-    if (authHeader !== `Bearer ${cronSecret}`) {
-      return Response.json({ error: 'Unauthorized' }, { status: 401 })
-    }
-  }
+  const auth = requireCronAuth(request)
+  if (!auth.ok) return auth.response
 
   try {
     // Send 24h deadline reminders to non-voters for decisions expiring tomorrow

--- a/src/app/api/cron/close-it-hilfe-requests/__tests__/route.test.ts
+++ b/src/app/api/cron/close-it-hilfe-requests/__tests__/route.test.ts
@@ -56,7 +56,9 @@ import { GET } from '../route'
 
 beforeEach(() => {
   jest.resetAllMocks()
-  delete process.env.CRON_SECRET
+  // Configured, because an unset secret now denies every request —
+  // these routes are no longer reachable without one.
+  process.env.CRON_SECRET = 'test-cron-secret'
 
   // Chain: db.update(...).set(...).where(...).returning() -> [rows]
   mockReturning.mockResolvedValue([])
@@ -66,7 +68,7 @@ beforeEach(() => {
 
 describe('GET /api/cron/close-it-hilfe-requests — auth', () => {
   it('returns 401 when CRON_SECRET is set and bearer is wrong', async () => {
-    process.env.CRON_SECRET = 'top-secret'
+    process.env.CRON_SECRET = 'test-cron-secret'
     const req = new NextRequest('http://localhost/api/cron/close-it-hilfe-requests', {
       headers: { authorization: 'Bearer nope' },
     })
@@ -75,22 +77,27 @@ describe('GET /api/cron/close-it-hilfe-requests — auth', () => {
   })
 
   it('returns 401 when CRON_SECRET is set and bearer is missing', async () => {
-    process.env.CRON_SECRET = 'top-secret'
+    process.env.CRON_SECRET = 'test-cron-secret'
     const req = new NextRequest('http://localhost/api/cron/close-it-hilfe-requests')
     const res = await GET(req)
     expect(res.status).toBe(401)
   })
 
-  it('skips auth check when CRON_SECRET is unset (dev mode)', async () => {
-    const req = new NextRequest('http://localhost/api/cron/close-it-hilfe-requests')
+  // Was: 'skips auth check when CRON_SECRET is unset (dev mode)', asserting a
+  // 200. That convenience is exactly the hole — this route closes IT-Hilfe
+  // requests, and its siblings release escrowed money. An unset secret is a
+  // broken deployment, so it now denies everything.
+  it('denies everything when CRON_SECRET is unset, rather than skipping the check', async () => {
+    delete process.env.CRON_SECRET
+    const req = new NextRequest('http://localhost/api/cron/close-it-hilfe-requests', { headers: { authorization: 'Bearer anything' } })
     const res = await GET(req)
-    expect(res.status).toBe(200)
+    expect(res.status).toBe(401)
   })
 
   it('accepts the correct bearer token', async () => {
-    process.env.CRON_SECRET = 'top-secret'
+    process.env.CRON_SECRET = 'test-cron-secret'
     const req = new NextRequest('http://localhost/api/cron/close-it-hilfe-requests', {
-      headers: { authorization: 'Bearer top-secret' },
+      headers: { authorization: `Bearer ${process.env.CRON_SECRET}` },
     })
     const res = await GET(req)
     expect(res.status).toBe(200)
@@ -101,7 +108,7 @@ describe('GET /api/cron/close-it-hilfe-requests — bulk expire', () => {
   it('returns expired=0 when nothing is past its deadline', async () => {
     mockReturning.mockResolvedValueOnce([])
 
-    const req = new NextRequest('http://localhost/api/cron/close-it-hilfe-requests')
+    const req = new NextRequest('http://localhost/api/cron/close-it-hilfe-requests', { headers: { authorization: `Bearer ${process.env.CRON_SECRET}` } })
     const res = await GET(req)
 
     expect(res.status).toBe(200)
@@ -117,7 +124,7 @@ describe('GET /api/cron/close-it-hilfe-requests — bulk expire', () => {
       { id: 'req-3' },
     ])
 
-    const req = new NextRequest('http://localhost/api/cron/close-it-hilfe-requests')
+    const req = new NextRequest('http://localhost/api/cron/close-it-hilfe-requests', { headers: { authorization: `Bearer ${process.env.CRON_SECRET}` } })
     const res = await GET(req)
 
     expect(res.status).toBe(200)
@@ -126,7 +133,7 @@ describe('GET /api/cron/close-it-hilfe-requests — bulk expire', () => {
   })
 
   it('sets status=expired in the update payload', async () => {
-    const req = new NextRequest('http://localhost/api/cron/close-it-hilfe-requests')
+    const req = new NextRequest('http://localhost/api/cron/close-it-hilfe-requests', { headers: { authorization: `Bearer ${process.env.CRON_SECRET}` } })
     await GET(req)
 
     const setPayload = mockSet.mock.calls[0]?.[0]
@@ -134,7 +141,7 @@ describe('GET /api/cron/close-it-hilfe-requests — bulk expire', () => {
   })
 
   it('locks the three where-predicates so MATCHED/COMPLETED rows can never be touched', async () => {
-    const req = new NextRequest('http://localhost/api/cron/close-it-hilfe-requests')
+    const req = new NextRequest('http://localhost/api/cron/close-it-hilfe-requests', { headers: { authorization: `Bearer ${process.env.CRON_SECRET}` } })
     await GET(req)
 
     // The where clause is and(eq(status, 'open'), isNotNull(expiresAt), lt(expiresAt, NOW()))
@@ -156,7 +163,7 @@ describe('GET /api/cron/close-it-hilfe-requests — DB error', () => {
   it('returns 500 when the update throws', async () => {
     mockReturning.mockRejectedValueOnce(new Error('connection refused'))
 
-    const req = new NextRequest('http://localhost/api/cron/close-it-hilfe-requests')
+    const req = new NextRequest('http://localhost/api/cron/close-it-hilfe-requests', { headers: { authorization: `Bearer ${process.env.CRON_SECRET}` } })
     const res = await GET(req)
     expect(res.status).toBe(500)
     const body = await res.json()

--- a/src/app/api/cron/close-it-hilfe-requests/route.ts
+++ b/src/app/api/cron/close-it-hilfe-requests/route.ts
@@ -19,16 +19,11 @@ import { itHilfeRequests } from '@/db/schema'
 import { and, eq, isNotNull, lt, sql } from 'drizzle-orm'
 import { logger } from '@/lib/logger'
 import { REQUEST_STATUS } from '@/config/it-hilfe'
+import { requireCronAuth } from '@/lib/api/cron-auth'
 
 export async function GET(request: NextRequest) {
-  // Verify cron secret (skip in dev if not set)
-  const cronSecret = process.env.CRON_SECRET
-  if (cronSecret) {
-    const authHeader = request.headers.get('authorization')
-    if (authHeader !== `Bearer ${cronSecret}`) {
-      return Response.json({ error: 'Unauthorized' }, { status: 401 })
-    }
-  }
+  const auth = requireCronAuth(request)
+  if (!auth.ok) return auth.response
 
   try {
     const expired = await db

--- a/src/app/api/cron/prune-audit-log/route.ts
+++ b/src/app/api/cron/prune-audit-log/route.ts
@@ -18,22 +18,13 @@ import { db } from '@/db'
 import { authAuditLog } from '@/db/schema'
 import { and, lt, ne, sql } from 'drizzle-orm'
 import { logger } from '@/lib/logger'
+import { requireCronAuth } from '@/lib/api/cron-auth'
 
 const RETENTION_DAYS = 180
 
 export async function GET(request: NextRequest) {
-  // Authenticate via CRON_SECRET (Authorization: Bearer ...). When CRON_SECRET
-  // is unset (local dev), the check is skipped — matches the other cron routes
-  // and scripts/ops/run-cron.sh. Reject anything else to avoid arbitrary
-  // external triggers.
-  const cronSecret = process.env.CRON_SECRET
-  const authorized =
-    !cronSecret ||
-    request.headers.get('authorization') === `Bearer ${cronSecret}`
-
-  if (!authorized) {
-    return NextResponse.json({ error: 'Unauthorized' }, { status: 401 })
-  }
+  const auth = requireCronAuth(request)
+  if (!auth.ok) return auth.response
 
   try {
     const result = await db

--- a/src/app/api/cron/release-escrow/__tests__/route.test.ts
+++ b/src/app/api/cron/release-escrow/__tests__/route.test.ts
@@ -63,18 +63,20 @@ function setDue(rows: unknown[]) {
 
 beforeEach(() => {
   jest.resetAllMocks()
-  delete process.env.CRON_SECRET
+  // Configured, because an unset secret now denies every request —
+  // these routes are no longer reachable without one.
+  process.env.CRON_SECRET = 'test-cron-secret'
   // db.update(...).set(...).where(...) resolves
   mockSet.mockReturnValue({ where: mockUpdateWhere })
   mockUpdateWhere.mockResolvedValue(undefined)
   mockCapture.mockResolvedValue({ id: 1, status: 'confirmed' })
 })
 
-const req = () => new NextRequest('http://localhost/api/cron/release-escrow')
+const req = () => new NextRequest('http://localhost/api/cron/release-escrow', { headers: { authorization: `Bearer ${process.env.CRON_SECRET}` } })
 
 describe('GET /api/cron/release-escrow — auth', () => {
   it('returns 401 when CRON_SECRET is set and bearer is wrong', async () => {
-    process.env.CRON_SECRET = 'top-secret'
+    process.env.CRON_SECRET = 'test-cron-secret'
     const res = await GET(new NextRequest('http://localhost/api/cron/release-escrow', { headers: { authorization: 'Bearer nope' } }))
     expect(res.status).toBe(401)
   })

--- a/src/app/api/cron/release-escrow/route.ts
+++ b/src/app/api/cron/release-escrow/route.ts
@@ -19,16 +19,11 @@ import { and, eq, lt, isNotNull, sql } from 'drizzle-orm'
 import { captureTransaction } from '@/lib/payments/payrexx-client'
 import { ESCROW_STATUS } from '@/config/payment-status'
 import { logger } from '@/lib/logger'
+import { requireCronAuth } from '@/lib/api/cron-auth'
 
 export async function GET(request: NextRequest) {
-  // Verify cron secret (skip in dev if not set) — same convention as the other crons.
-  const cronSecret = process.env.CRON_SECRET
-  if (cronSecret) {
-    const authHeader = request.headers.get('authorization')
-    if (authHeader !== `Bearer ${cronSecret}`) {
-      return Response.json({ error: 'Unauthorized' }, { status: 401 })
-    }
-  }
+  const auth = requireCronAuth(request)
+  if (!auth.ok) return auth.response
 
   try {
     // Active escrows past their deadline, with the gateway transaction to capture.

--- a/src/app/api/cron/timecard-reminders/route.ts
+++ b/src/app/api/cron/timecard-reminders/route.ts
@@ -16,17 +16,11 @@ import { getReminderUserIdsForToday } from '@/lib/services/saldo'
 import { createNotification } from '@/lib/services/notifications'
 import { NOTIFICATION_TYPES } from '@/config/notifications'
 import { logger } from '@/lib/logger'
-
-function authorized(request: NextRequest): boolean {
-  const cronSecret = process.env.CRON_SECRET
-  if (!cronSecret) return false
-  return request.headers.get('authorization') === `Bearer ${cronSecret}`
-}
+import { requireCronAuth } from '@/lib/api/cron-auth'
 
 export async function GET(request: NextRequest) {
-  if (!authorized(request)) {
-    return NextResponse.json({ error: 'Unauthorized' }, { status: 401 })
-  }
+  const auth = requireCronAuth(request)
+  if (!auth.ok) return auth.response
   try {
     const userIds = await getReminderUserIdsForToday()
     const monthLabel = new Intl.DateTimeFormat('de-CH', {

--- a/src/app/api/cron/wake-recurring-tasks/route.ts
+++ b/src/app/api/cron/wake-recurring-tasks/route.ts
@@ -41,18 +41,11 @@ import { ORG } from '@/config/org'
 import { notifyUsers, notifyAllStaff } from '@/lib/services/notifications'
 import { NOTIFICATION_TYPES, RELATED_TYPES } from '@/config/notifications'
 import { logger } from '@/lib/logger'
-
-function authorized(request: NextRequest): boolean {
-  const cronSecret = process.env.CRON_SECRET
-  if (!cronSecret) return true // dev: allow if not configured
-  const authHeader = request.headers.get('authorization')
-  return authHeader === `Bearer ${cronSecret}`
-}
+import { requireCronAuth } from '@/lib/api/cron-auth'
 
 export async function GET(request: NextRequest) {
-  if (!authorized(request)) {
-    return Response.json({ error: 'Unauthorized' }, { status: 401 })
-  }
+  const auth = requireCronAuth(request)
+  if (!auth.ok) return auth.response
 
   try {
     const candidates = await db

--- a/src/lib/api/__tests__/cron-auth.test.ts
+++ b/src/lib/api/__tests__/cron-auth.test.ts
@@ -1,0 +1,81 @@
+/**
+ * @jest-environment node
+ */
+import { requireCronAuth } from '@/lib/api/cron-auth'
+
+jest.mock('@/lib/logger', () => ({ logger: { error: jest.fn(), warn: jest.fn(), info: jest.fn() } }))
+
+const req = (authorization?: string) =>
+  new Request('http://localhost/api/cron/thing', {
+    headers: authorization ? { authorization } : {},
+  })
+
+const ORIGINAL = process.env.CRON_SECRET
+afterEach(() => {
+  if (ORIGINAL === undefined) delete process.env.CRON_SECRET
+  else process.env.CRON_SECRET = ORIGINAL
+})
+
+describe('an unset secret denies everything', () => {
+  // The bug this file exists for. Five of six cron routes used a variant that
+  // failed open when CRON_SECRET was unset — including release-escrow, which
+  // captures payment transactions and releases escrowed funds.
+  it('denies when CRON_SECRET is missing, whatever is sent', () => {
+    delete process.env.CRON_SECRET
+    expect(requireCronAuth(req('Bearer anything')).ok).toBe(false)
+    expect(requireCronAuth(req('Bearer undefined')).ok).toBe(false)
+    expect(requireCronAuth(req()).ok).toBe(false)
+  })
+
+  it('denies when CRON_SECRET is empty or whitespace', () => {
+    process.env.CRON_SECRET = ''
+    expect(requireCronAuth(req('Bearer ')).ok).toBe(false)
+    process.env.CRON_SECRET = '   '
+    expect(requireCronAuth(req('Bearer    ')).ok).toBe(false)
+  })
+})
+
+describe('with a secret configured', () => {
+  const SECRET = 'a-real-cron-secret-value'
+  beforeEach(() => {
+    process.env.CRON_SECRET = SECRET
+  })
+
+  it('accepts the matching bearer token', () => {
+    expect(requireCronAuth(req(`Bearer ${SECRET}`)).ok).toBe(true)
+  })
+
+  it('rejects a wrong token', () => {
+    expect(requireCronAuth(req('Bearer wrong')).ok).toBe(false)
+  })
+
+  it('rejects a token that merely starts or ends correctly', () => {
+    expect(requireCronAuth(req(`Bearer ${SECRET.slice(0, -1)}`)).ok).toBe(false)
+    expect(requireCronAuth(req(`Bearer ${SECRET}x`)).ok).toBe(false)
+  })
+
+  it('rejects a missing header', () => {
+    expect(requireCronAuth(req()).ok).toBe(false)
+  })
+
+  it('rejects the raw secret without the Bearer scheme', () => {
+    expect(requireCronAuth(req(SECRET)).ok).toBe(false)
+  })
+
+  it('rejects another scheme carrying the right secret', () => {
+    expect(requireCronAuth(req(`Basic ${SECRET}`)).ok).toBe(false)
+  })
+
+  it('is case-sensitive', () => {
+    expect(requireCronAuth(req(`Bearer ${SECRET.toUpperCase()}`)).ok).toBe(false)
+  })
+
+  it('answers 401 without explaining why', async () => {
+    const result = requireCronAuth(req('Bearer wrong'))
+    expect(result.ok).toBe(false)
+    if (!result.ok) {
+      expect(result.response.status).toBe(401)
+      await expect(result.response.json()).resolves.toEqual({ error: 'Unauthorized' })
+    }
+  })
+})

--- a/src/lib/api/__tests__/cron-routes-guarded.test.ts
+++ b/src/lib/api/__tests__/cron-routes-guarded.test.ts
@@ -1,0 +1,58 @@
+/**
+ * @jest-environment node
+ */
+import { readFileSync, readdirSync, statSync } from 'node:fs'
+import { join } from 'node:path'
+
+/**
+ * Every cron route goes through requireCronAuth, and none re-inlines the check.
+ *
+ * This is the part that stops it coming back. Fixing six routes fixes six
+ * routes; asserting it against the directory fixes the seventh one nobody has
+ * written yet — and the seventh will be written by copying the sixth, which is
+ * exactly how five of the six ended up failing open in the first place.
+ */
+
+const CRON_DIR = join(process.cwd(), 'src', 'app', 'api', 'cron')
+
+function routeFiles(dir: string): string[] {
+  return readdirSync(dir).flatMap((entry) => {
+    const full = join(dir, entry)
+    if (statSync(full).isDirectory()) {
+      return entry === '__tests__' ? [] : routeFiles(full)
+    }
+    return entry === 'route.ts' ? [full] : []
+  })
+}
+
+const routes = routeFiles(CRON_DIR)
+
+describe('cron routes are uniformly guarded', () => {
+  it('finds the cron routes at all', () => {
+    // A path typo would make every assertion below vacuously true.
+    expect(routes.length).toBeGreaterThan(3)
+  })
+
+  it.each(routes.map((f) => [f.slice(f.indexOf('src/app/api/cron')), f]))(
+    '%s calls requireCronAuth',
+    (_name, file) => {
+      expect(readFileSync(file, 'utf8')).toContain('requireCronAuth')
+    },
+  )
+
+  it.each(routes.map((f) => [f.slice(f.indexOf('src/app/api/cron')), f]))(
+    '%s does not read CRON_SECRET itself',
+    (_name, file) => {
+      // The shapes that failed open, all of which read the variable directly:
+      //   if (cronSecret) { ...check... }
+      //   const ok = !cronSecret || headerMatches
+      //   if (!cronSecret) return true
+      const src = readFileSync(file, 'utf8')
+      const code = src
+        .split('\n')
+        .filter((l) => !l.trimStart().startsWith('*') && !l.trimStart().startsWith('//'))
+        .join('\n')
+      expect(code).not.toMatch(/process\.env\.CRON_SECRET/)
+    },
+  )
+})

--- a/src/lib/api/cron-auth.ts
+++ b/src/lib/api/cron-auth.ts
@@ -1,0 +1,66 @@
+import { NextResponse } from 'next/server'
+import { timingSafeEqual } from 'node:crypto'
+import { logger } from '@/lib/logger'
+
+/**
+ * The one place a cron request is authorised.
+ *
+ * Every cron route used to inline its own version, and five of the six inlined
+ * a variant that **fails open** when CRON_SECRET is unset:
+ *
+ *     if (cronSecret) { ...check... }              // no secret → no check at all
+ *     const ok = !cronSecret || headerMatches      // no secret → authorised
+ *     if (!cronSecret) return true                 // no secret → authorised
+ *
+ * Each was written to make local development convenient, and each turns a
+ * missing environment variable into an open endpoint. The routes behind this
+ * gate close decisions, prune the audit log, wake recurring tasks and — in
+ * release-escrow — capture payment transactions and release escrowed funds.
+ * "Convenient in dev" is not worth "anyone can release escrow if an env var
+ * goes missing".
+ *
+ * Only `timecard-reminders` got it right, with `if (!cronSecret) return false`.
+ * This generalises that one.
+ *
+ * Local development is still convenient: set CRON_SECRET in .env.local, which
+ * scripts/ops/run-cron.sh already reads.
+ */
+
+export type CronAuthResult =
+  | { ok: true }
+  | { ok: false; response: NextResponse }
+
+const unauthorized = () =>
+  NextResponse.json({ error: 'Unauthorized' }, { status: 401 })
+
+/** Constant-time compare. Over TLS this is close to unexploitable, so it is not
+ *  the point — a helper that is obviously correct removes the need for anyone to
+ *  reason about whether it matters here. */
+function secretsMatch(provided: string, expected: string): boolean {
+  const a = Buffer.from(provided)
+  const b = Buffer.from(expected)
+  // timingSafeEqual throws on a length mismatch, which would leak the length.
+  if (a.length !== b.length) return false
+  return timingSafeEqual(a, b)
+}
+
+export function requireCronAuth(request: Request): CronAuthResult {
+  const expected = process.env.CRON_SECRET
+
+  // Fail closed. An unconfigured secret is a broken deployment, not an open door.
+  if (!expected || expected.trim().length === 0) {
+    logger.error(
+      'CRON_SECRET is not set — refusing every cron request. Set it in the environment; the timers will fail loudly until you do.',
+    )
+    return { ok: false, response: unauthorized() }
+  }
+
+  const header = request.headers.get('authorization')
+  if (!header || !header.startsWith('Bearer ')) {
+    return { ok: false, response: unauthorized() }
+  }
+
+  return secretsMatch(header.slice('Bearer '.length), expected)
+    ? { ok: true }
+    : { ok: false, response: unauthorized() }
+}


### PR DESCRIPTION
## What

Five of the six cron routes authorized **every** request whenever `CRON_SECRET` was unset. Three inline shapes, all failing open:

- `if (cronSecret) { ...check... }` — skip the check entirely
- `const ok = !cronSecret || headerMatches`
- `if (!cronSecret) return true`

That includes **release-escrow**, which captures payment transactions and releases escrowed funds. Prod has the secret set (verified in `/opt/revampit/app/.env`), so this was latent, not exploited — but it was one dropped env var away from an open money endpoint.

## Fix

- `src/lib/api/cron-auth.ts`: one `requireCronAuth()` — denies when the secret is unset or empty (and logs why), requires the `Bearer` scheme, compares with `timingSafeEqual`, answers a bare 401.
- All six routes call it; none reads `CRON_SECRET` itself anymore.
- The route tests asserted the vulnerability (`delete process.env.CRON_SECRET` + expect 200) — patched to configure a secret and send a valid bearer; the explicit "skips auth in dev" test now expects 401.
- `cron-routes-guarded.test.ts` asserts against the `src/app/api/cron` **directory**: every `route.ts` must call `requireCronAuth` and must not read `CRON_SECRET` — so the seventh route, written by copying the sixth, can't reintroduce the class.

## Verification

- 129 tests green across the 10 cron/cron-auth suites (locally, rebased on current main).
- `lint:umlauts` clean; lint 0 errors.
- Box timers send `Authorization: Bearer $CRON_SECRET` — unchanged contract, no deploy-side changes needed.

🤖 Generated with [Claude Code](https://claude.com/claude-code)