### PR TITLE
ci(deps): dependabot must bump the react family as one PR

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -13,6 +13,14 @@ updates:
       tiptap:
         patterns:
           - "@tiptap/*"
+      # react-dom and the @types packages peer-pin react's major — a half-bump
+      # (react without react-dom, or code types split) cannot even npm ci.
+      react:
+        patterns:
+          - "react"
+          - "react-dom"
+          - "@types/react"
+          - "@types/react-dom"
     commit-message:
       prefix: "deps"
     labels:


### PR DESCRIPTION
react-dom and the @types packages peer-pin react's major, so a half-family bump cannot even `npm ci` — #313 failed at install on every run until the family moved together. This adds a dependabot `groups` rule for react/react-dom/@types/react/@types/react-dom, the same never-twice fix as the tiptap group in #323. Config-only.

🤖 Generated with [Claude Code](https://claude.com/claude-code)