### PR TITLE
test(e2e): workshops journey must watch the instance the page registers

### DIFF
--- a/tests/e2e/helpers/workshops.ts
+++ b/tests/e2e/helpers/workshops.ts
@@ -12,13 +12,16 @@ export interface WorkshopWithInstances {
   slug: string
   title: string
   price_cents: number
-  instances: Array<{
-    id: string
-    status: string
-    current_participants: number
-    max_participants: number
-  }>
+  instances: Array<WorkshopInstanceSummary>
   user_registered?: boolean
+}
+
+export interface WorkshopInstanceSummary {
+  id: string
+  status: string
+  start_date: string
+  current_participants: number
+  max_participants: number
 }
 
 async function parseApi<T>(response: {
@@ -41,34 +44,48 @@ export async function listWorkshopsWithInstances(
   return parseApi<WorkshopWithInstances[]>(response)
 }
 
+/**
+ * The instance the workshop page actually registers for. Must mirror the page
+ * exactly (src/app/[locale]/workshops/[slug]/page.tsx): scheduled AND in the
+ * future, ordered by start_date ascending, first one — regardless of capacity.
+ * Asserting on any other instance is how this journey used to go flaky: the UI
+ * registered the page's next instance while the test watched a past one.
+ */
+export function pickPageNextInstance(
+  instances: WorkshopInstanceSummary[] | undefined,
+): WorkshopInstanceSummary | null {
+  const upcoming = (instances ?? [])
+    .filter(
+      inst =>
+        inst.status === WORKSHOP_INSTANCE_STATUS.SCHEDULED &&
+        new Date(inst.start_date) > new Date(),
+    )
+    .sort((a, b) => new Date(a.start_date).getTime() - new Date(b.start_date).getTime())
+  return upcoming[0] ?? null
+}
+
+function pickWorkshopWithOpenNextInstance(
+  workshops: WorkshopWithInstances[],
+  matchesPrice: (priceCents: number) => boolean,
+): WorkshopWithInstances | null {
+  for (const workshop of workshops) {
+    if (!matchesPrice(workshop.price_cents)) continue
+    const next = pickPageNextInstance(workshop.instances)
+    if (next && next.current_participants < next.max_participants) return workshop
+  }
+  return null
+}
+
 export function pickFreeWorkshopWithCapacity(
   workshops: WorkshopWithInstances[],
 ): WorkshopWithInstances | null {
-  for (const workshop of workshops) {
-    if (workshop.price_cents > 0) continue
-    const open = workshop.instances?.find(
-      inst =>
-        inst.status === WORKSHOP_INSTANCE_STATUS.SCHEDULED &&
-        inst.current_participants < inst.max_participants,
-    )
-    if (open) return workshop
-  }
-  return null
+  return pickWorkshopWithOpenNextInstance(workshops, price => price <= 0)
 }
 
 export function pickPaidWorkshopWithCapacity(
   workshops: WorkshopWithInstances[],
 ): WorkshopWithInstances | null {
-  for (const workshop of workshops) {
-    if (workshop.price_cents <= 0) continue
-    const open = workshop.instances?.find(
-      inst =>
-        inst.status === WORKSHOP_INSTANCE_STATUS.SCHEDULED &&
-        inst.current_participants < inst.max_participants,
-    )
-    if (open) return workshop
-  }
-  return null
+  return pickWorkshopWithOpenNextInstance(workshops, price => price > 0)
 }
 
 export async function registerForFreeWorkshop(

--- a/tests/e2e/workshops-journey.spec.ts
+++ b/tests/e2e/workshops-journey.spec.ts
@@ -19,6 +19,7 @@ import {
   getRegistrationForInstance,
   listWorkshopsWithInstances,
   pickFreeWorkshopWithCapacity,
+  pickPageNextInstance,
   pickPaidWorkshopWithCapacity,
 } from './helpers/workshops'
 
@@ -44,9 +45,8 @@ test.describe('Workshops dual-persona journey', () => {
       const freeWorkshop = pickFreeWorkshopWithCapacity(workshops)
 
       if (freeWorkshop) {
-        const instance = freeWorkshop.instances.find(
-          inst => inst.status === 'scheduled' && inst.current_participants < inst.max_participants,
-        )!
+        // The page registers its OWN next instance — assert on exactly that one.
+        const instance = pickPageNextInstance(freeWorkshop.instances)!
 
         const existing = await getRegistrationForInstance(page.request, instance.id)
         if (existing.registered && existing.registration?.id) {


### PR DESCRIPTION
The flaky `Local E2E Journeys` failure that needed manual reruns on the tiptap merge and again on #331 was not flake in the retry sense — it survived Playwright's 2 CI retries both times.

**Root cause:** the journey picked the first *scheduled instance with capacity, past or future*; the workshop page registers its first *scheduled future* instance (`upcomingInstances[0]`, `ORDER BY start_date ASC`). When those diverge — which an instance drifting into the past causes, making the failure time-dependent — the UI registers one instance while the test polls another: `Registration not found after UI flow`. The real registration is left behind and poisons the next attempt ('bereits storniert', register button gone).

**Fix:** `pickPageNextInstance()` mirrors the page's selection rule exactly (with a comment pinning it to the page file), the spec asserts on that instance, and both workshop pickers now require *that* instance to have capacity — it is the only one the UI will register. Verified the `/api/workshops?include=instances` payload carries `start_date`, so the new filter cannot silently empty and skip the journey green.

🤖 Generated with [Claude Code](https://claude.com/claude-code)