### PR TITLE
refactor(hooks): migrate 7 fetch-on-mount sites to useSwrFetch (46→38 set-state-in-effect warnings)

### DIFF
--- a/src/app/admin/decisions/[id]/DiscussionThread.tsx
+++ b/src/app/admin/decisions/[id]/DiscussionThread.tsx
@@ -1,6 +1,7 @@
 'use client';
 
-import { useEffect, useState } from 'react';
+import { useState } from 'react';
+import { useSwrFetch } from '@/lib/api/swr';
 import { adminInteractive } from '@/lib/admin-ui'
 import { Pencil, Trash2, Check, X } from 'lucide-react';
 import { ConfirmDialog } from '@/components/ui/ConfirmDialog';
@@ -34,23 +35,18 @@ export default function DiscussionThread({
   readOnly: boolean;
   currentUserId?: string;
 }) {
-  const [comments, setComments] = useState<Comment[]>([]);
-  const [loading, setLoading] = useState(true);
+  const {
+    data,
+    isLoading: loading,
+    mutate: refreshComments,
+  } = useSwrFetch<Comment[]>(`/api/decisions/${decisionId}/comments`);
+  const comments = data ?? [];
 
   // New comment state
   const [content, setContent] = useState('');
   const [position, setPosition] = useState<CommentPosition>('info');
   const [submitting, setSubmitting] = useState(false);
   const [error, setError] = useState('');
-
-  async function fetchComments() {
-    const result = await apiFetch<Comment[]>(`/api/decisions/${decisionId}/comments`);
-    if (result.success && result.data) setComments(result.data);
-    setLoading(false);
-  }
-
-  // eslint-disable-next-line react-hooks/exhaustive-deps
-  useEffect(() => { fetchComments(); }, [decisionId]);
 
   async function handleSubmit(e: React.FormEvent) {
     e.preventDefault();
@@ -70,7 +66,7 @@ export default function DiscussionThread({
     }
 
     setContent('');
-    fetchComments();
+    refreshComments();
     setSubmitting(false);
   }
 
@@ -109,7 +105,7 @@ export default function DiscussionThread({
 
     setEditingId(null);
     setEditContent('');
-    fetchComments();
+    refreshComments();
     setEditSaving(false);
   }
 
@@ -130,7 +126,7 @@ export default function DiscussionThread({
     }
 
     setDeleteId(null);
-    fetchComments();
+    refreshComments();
     setDeleteLoading(false);
   }
 

--- a/src/app/dashboard/messages/page.tsx
+++ b/src/app/dashboard/messages/page.tsx
@@ -1,6 +1,6 @@
 'use client'
 
-import { useState, useEffect, useCallback, Suspense } from 'react'
+import { useState, useEffect, Suspense } from 'react'
 import { Eyebrow } from '@/components/ui/Eyebrow'
 import { useSession } from 'next-auth/react'
 import { useRouter, useSearchParams } from 'next/navigation'
@@ -11,8 +11,7 @@ import { Card } from '@/components/ui/card'
 import ConversationList from '@/components/messages/ConversationList'
 import type { Conversation } from '@/components/messages/ConversationList'
 import MessageThread from '@/components/messages/MessageThread'
-import { apiFetch } from '@/lib/api/client'
-import { logger } from '@/lib/logger'
+import { useSwrFetch } from '@/lib/api/swr'
 import { useTranslations } from 'next-intl'
 import Heading from '@/components/ui/Heading'
 import { EmptyState } from '@/components/ui/EmptyState'
@@ -23,44 +22,26 @@ function MessagesContent() {
   const { data: session, status: sessionStatus } = useSession()
   const router = useRouter()
   const searchParams = useSearchParams()
-  const [conversations, setConversations] = useState<Conversation[]>([])
-  const [isLoading, setIsLoading] = useState(true)
+  // The deep-link param seeds the initial selection; the SWR fetch is gated on
+  // an authenticated session (null key = no request).
   const [selectedConvId, setSelectedConvId] = useState<string | null>(
     searchParams.get('conversation')
   )
 
+  const { data, isLoading } = useSwrFetch<{ conversations: Conversation[] }>(
+    session?.user ? '/api/messages' : null,
+  )
+  const conversations = data?.conversations ?? []
+
   // Track the selected conversation's details for the thread
   const selectedConv = conversations.find(c => c.id === selectedConvId)
 
-  const fetchConversations = useCallback(async () => {
-    try {
-      const result = await apiFetch<{ conversations: Conversation[] }>('/api/messages')
-      if (result.success) {
-        setConversations(result.data!.conversations)
-        // If deep-link param but not yet in list, keep it
-        const deepLink = searchParams.get('conversation')
-        if (deepLink && result.data!.conversations.some((c: Conversation) => c.id === deepLink)) {
-          setSelectedConvId(deepLink)
-        }
-      }
-    } catch (err) {
-      logger.error('Failed to load conversations', { error: err })
-    } finally {
-      setIsLoading(false)
-    }
-  }, [searchParams])
-
-  // Auth-gated data load. setState happens inside fetchConversations —
-  // legitimate "subscribe to external system on session change" pattern.
-   
   useEffect(() => {
     if (sessionStatus === 'loading') return
     if (!session?.user) {
       router.push('/auth/login')
-      return
     }
-    fetchConversations()
-  }, [session, sessionStatus, router, fetchConversations])
+  }, [session, sessionStatus, router])
 
   const handleSelectConversation = (id: string) => {
     setSelectedConvId(id)
@@ -77,7 +58,8 @@ function MessagesContent() {
     window.history.replaceState({}, '', url.toString())
   }
 
-  if (sessionStatus === 'loading' || isLoading) {
+  // !session?.user: keep the spinner while the login redirect is in flight
+  if (sessionStatus === 'loading' || isLoading || !session?.user) {
     return (
       <div className="flex items-center justify-center min-h-[400px]">
         <Loader2 className="w-8 h-8 text-action animate-spin" aria-hidden="true" />

--- a/src/components/admin/team/activity/useActivityUpdates.ts
+++ b/src/components/admin/team/activity/useActivityUpdates.ts
@@ -6,8 +6,9 @@
  * Data fetching and mutation hooks for activity updates
  */
 
-import { useState, useEffect, useCallback } from 'react'
+import { useState, useCallback } from 'react'
 import { apiFetch } from '@/lib/api/client'
+import { useSwrFetch } from '@/lib/api/swr'
 import type { ActivityUpdate } from './types'
 
 // ============================================================================
@@ -23,39 +24,24 @@ interface UseActivityUpdatesReturn {
 }
 
 export function useActivityUpdates(userId?: string): UseActivityUpdatesReturn {
-  const [updates, setUpdates] = useState<ActivityUpdate[]>([])
-  const [loading, setLoading] = useState(true)
-  const [error, setError] = useState<string | null>(null)
-  const [total, setTotal] = useState(0)
+  const params = new URLSearchParams()
+  if (userId) params.set('user_id', userId)
 
-  const fetchUpdates = useCallback(async () => {
-    setLoading(true)
-    setError(null)
+  const { data, error, isLoading, mutate } = useSwrFetch<{ items: ActivityUpdate[]; total: number }>(
+    `/api/admin/team/activity/updates?${params.toString()}`,
+  )
 
-    try {
-      const params = new URLSearchParams()
-      if (userId) params.set('user_id', userId)
+  const refetch = useCallback(async () => {
+    await mutate()
+  }, [mutate])
 
-      const result = await apiFetch<{ items: ActivityUpdate[]; total: number }>(`/api/admin/team/activity/updates?${params.toString()}`)
-
-      if (!result.success) {
-        throw new Error(result.error || 'Fehler beim Laden')
-      }
-
-      setUpdates(result.data?.items || [])
-      setTotal(result.data?.total || 0)
-    } catch (err) {
-      setError(err instanceof Error ? err.message : 'Unbekannter Fehler')
-    } finally {
-      setLoading(false)
-    }
-  }, [userId])
-
-  useEffect(() => {
-    fetchUpdates()
-  }, [fetchUpdates])
-
-  return { updates, loading, error, total, refetch: fetchUpdates }
+  return {
+    updates: data?.items ?? [],
+    loading: isLoading,
+    error: error instanceof Error ? error.message : null,
+    total: data?.total ?? 0,
+    refetch,
+  }
 }
 
 // ============================================================================

--- a/src/components/admin/team/activity/useDigest.ts
+++ b/src/components/admin/team/activity/useDigest.ts
@@ -6,8 +6,8 @@
  * Data fetching hook for activity digest/summary
  */
 
-import { useState, useEffect, useCallback } from 'react'
-import { apiFetch } from '@/lib/api/client'
+import { useCallback } from 'react'
+import { useSwrFetch } from '@/lib/api/swr'
 import type { DigestSummary } from './types'
 
 // ============================================================================
@@ -22,37 +22,23 @@ interface UseDigestReturn {
 }
 
 export function useDigest(since?: string, until?: string, department?: string): UseDigestReturn {
-  const [digest, setDigest] = useState<DigestSummary | null>(null)
-  const [loading, setLoading] = useState(true)
-  const [error, setError] = useState<string | null>(null)
+  const params = new URLSearchParams()
+  if (since) params.set('since', since)
+  if (until) params.set('until', until)
+  if (department) params.set('department', department)
 
-  const fetchDigest = useCallback(async () => {
-    setLoading(true)
-    setError(null)
+  const { data, error, isLoading, mutate } = useSwrFetch<DigestSummary>(
+    `/api/admin/team/digest?${params.toString()}`,
+  )
 
-    try {
-      const params = new URLSearchParams()
-      if (since) params.set('since', since)
-      if (until) params.set('until', until)
-      if (department) params.set('department', department)
+  const refetch = useCallback(async () => {
+    await mutate()
+  }, [mutate])
 
-      const result = await apiFetch<DigestSummary>(`/api/admin/team/digest?${params.toString()}`)
-
-      if (!result.success) {
-        throw new Error(result.error || 'Fehler beim Laden')
-      }
-
-      setDigest(result.data ?? null)
-    } catch (err) {
-      setError(err instanceof Error ? err.message : 'Unbekannter Fehler')
-    } finally {
-      setLoading(false)
-    }
-  }, [since, until, department])
-
-  useEffect(() => {
-    fetchDigest()
-  }, [fetchDigest])
-
-  return { digest, loading, error, refetch: fetchDigest }
+  return {
+    digest: data ?? null,
+    loading: isLoading,
+    error: error instanceof Error ? error.message : null,
+    refetch,
+  }
 }

--- a/src/components/admin/team/useTeamProfiles.ts
+++ b/src/components/admin/team/useTeamProfiles.ts
@@ -6,6 +6,7 @@
 
 import { useState, useEffect, useCallback } from 'react'
 import { apiFetch } from '@/lib/api/client'
+import { useSwrFetch } from '@/lib/api/swr'
 import type { TeamProfileWithUser } from '@/lib/schemas/team'
 import type { TeamFilterState } from './types'
 
@@ -86,44 +87,19 @@ export function useTeamProfiles(options: UseTeamProfilesOptions = {}): UseTeamPr
  * Hook for fetching a single team profile
  */
 export function useTeamProfile(profileId: string | null) {
-  const [profile, setProfile] = useState<TeamProfileWithUser | null>(null)
-  const [loading, setLoading] = useState(false)
-  const [error, setError] = useState<string | null>(null)
+  const { data, error, isLoading, mutate } = useSwrFetch<TeamProfileWithUser>(
+    profileId ? `/api/admin/team/profiles/${profileId}` : null,
+  )
 
-  const fetchProfile = useCallback(async () => {
-    if (!profileId) {
-      setProfile(null)
-      return
-    }
-
-    try {
-      setLoading(true)
-      setError(null)
-
-      const result = await apiFetch<TeamProfileWithUser>(`/api/admin/team/profiles/${profileId}`)
-
-      if (!result.success) {
-        throw new Error(result.error || 'Profil nicht gefunden')
-      }
-
-      setProfile(result.data ?? null)
-    } catch (err) {
-      setError(err instanceof Error ? err.message : 'Unbekannter Fehler')
-      setProfile(null)
-    } finally {
-      setLoading(false)
-    }
-  }, [profileId])
-
-  useEffect(() => {
-    fetchProfile()
-  }, [fetchProfile])
+  const refetch = useCallback(async () => {
+    await mutate()
+  }, [mutate])
 
   return {
-    profile,
-    loading,
-    error,
-    refetch: fetchProfile,
+    profile: data ?? null,
+    loading: isLoading,
+    error: error instanceof Error ? error.message : null,
+    refetch,
   }
 }
 

--- a/src/components/marketplace/ListingQuestions.tsx
+++ b/src/components/marketplace/ListingQuestions.tsx
@@ -1,6 +1,6 @@
 'use client'
 
-import { useCallback, useEffect, useState } from 'react'
+import { useState } from 'react'
 import { useSession } from 'next-auth/react'
 import { useRouter } from 'next/navigation'
 import { HelpCircle, Loader2, MessageCircleQuestion, Send } from 'lucide-react'
@@ -9,6 +9,7 @@ import Heading from '@/components/ui/Heading'
 import { Button } from '@/components/ui/button'
 import { Textarea } from '@/components/ui/textarea'
 import { apiFetch } from '@/lib/api/client'
+import { useSwrFetch } from '@/lib/api/swr'
 import { formatDateShort } from '@/lib/date-formats'
 import { LISTING_QUESTION_STATUS } from '@/config/marketplace'
 
@@ -34,9 +35,6 @@ export default function ListingQuestions({ listingId, sellerId }: ListingQuestio
   const router = useRouter()
   const t = useTranslations('marketplace.questions')
 
-  const [questions, setQuestions] = useState<ListingQuestion[]>([])
-  const [canAsk, setCanAsk] = useState(false)
-  const [loading, setLoading] = useState(true)
   const [newQuestion, setNewQuestion] = useState('')
   const [submitting, setSubmitting] = useState(false)
   const [error, setError] = useState<string | null>(null)
@@ -46,28 +44,14 @@ export default function ListingQuestions({ listingId, sellerId }: ListingQuestio
 
   const isOwner = session?.user?.id === sellerId
 
-  const loadQuestions = useCallback(async () => {
-    setLoading(true)
-    try {
-      const result = await apiFetch<{
-        questions: ListingQuestion[]
-        can_ask: boolean
-      }>(`/api/listings/${listingId}/questions`)
-
-      if (result.success && result.data) {
-        setQuestions(result.data.questions)
-        setCanAsk(result.data.can_ask)
-      }
-    } catch {
-      // Non-critical — section stays empty
-    } finally {
-      setLoading(false)
-    }
-  }, [listingId])
-
-  useEffect(() => {
-    void loadQuestions()
-  }, [loadQuestions])
+  // Load errors intentionally render as an empty section — questions are
+  // non-critical to the listing page.
+  const { data, isLoading: loading, mutate: loadQuestions } = useSwrFetch<{
+    questions: ListingQuestion[]
+    can_ask: boolean
+  }>(`/api/listings/${listingId}/questions`)
+  const questions = data?.questions ?? []
+  const canAsk = data?.can_ask ?? false
 
   const handleAsk = async () => {
     if (!newQuestion.trim() || submitting) return

--- a/src/components/marketplace/ListingReviews.tsx
+++ b/src/components/marketplace/ListingReviews.tsx
@@ -1,6 +1,6 @@
 'use client'
 
-import { useState, useEffect, useCallback } from 'react'
+import { useState } from 'react'
 import { useSession } from 'next-auth/react'
 import { useTranslations } from 'next-intl'
 import { Star, MessageSquare } from 'lucide-react'
@@ -10,7 +10,7 @@ import { ROUTES } from '@/config/routes'
 import { Button } from '@/components/ui/button'
 import Heading from '@/components/ui/Heading'
 import { formatDateShort } from '@/lib/date-formats'
-import { apiFetch } from '@/lib/api/client'
+import { useSwrFetch } from '@/lib/api/swr'
 import { REVIEW_TARGET_TYPES } from '@/config/database'
 
 interface Review {
@@ -36,37 +36,23 @@ interface ListingReviewsProps {
 export default function ListingReviews({ listingId, sellerId }: ListingReviewsProps) {
   const t = useTranslations('components.listingReviews')
   const { data: session } = useSession()
-  const [reviews, setReviews] = useState<Review[]>([])
-  const [stats, setStats] = useState<ReviewStats>({ average_rating: null, review_count: 0 })
-  const [isLoading, setIsLoading] = useState(true)
   const [showForm, setShowForm] = useState(false)
 
-  const fetchReviews = useCallback(async () => {
-    try {
-      const result = await apiFetch<{ reviews: Review[]; stats?: ReviewStats }>(`/api/reviews?targetType=${REVIEW_TARGET_TYPES.LISTING}&targetId=${listingId}`)
-      if (result.success && result.data) {
-        // The API returns aggregate stats over ALL reviews (not just this page),
-        // so consume them directly instead of averaging the current page.
-        setReviews(result.data.reviews || [])
-        setStats(result.data.stats ?? { average_rating: null, review_count: 0 })
-      }
-    } catch {
-      // Silently fail — reviews are non-critical
-    } finally {
-      setIsLoading(false)
-    }
-  }, [listingId])
-
-  useEffect(() => {
-    fetchReviews()
-  }, [fetchReviews])
+  // Load errors intentionally render as an empty section — reviews are
+  // non-critical. The API returns aggregate stats over ALL reviews (not just
+  // this page), so consume them directly instead of averaging the current page.
+  const { data, isLoading, mutate } = useSwrFetch<{ reviews: Review[]; stats?: ReviewStats }>(
+    `/api/reviews?targetType=${REVIEW_TARGET_TYPES.LISTING}&targetId=${listingId}`,
+  )
+  const reviews = data?.reviews ?? []
+  const stats = data?.stats ?? { average_rating: null, review_count: 0 }
 
   const canReview = session?.user?.id && session.user.id !== sellerId
   const hasReviewed = reviews.some(r => r.reviewerId === session?.user?.id)
 
   const handleReviewSubmitted = () => {
     setShowForm(false)
-    fetchReviews()
+    mutate()
   }
 
   if (isLoading) {


### PR DESCRIPTION
## What

Migrates the 7 cleanly-migratable `react-hooks/set-state-in-effect` sites to the existing `useSwrFetch` wrapper (`src/lib/api/swr.ts`) — the SSOT built for exactly this migration.

- `useDigest`, `useActivityUpdates`, `useTeamProfile` (admin/team)
- `DiscussionThread` (admin decisions)
- `ListingReviews`, `ListingQuestions` (marketplace)
- `dashboard/messages` page (auth-gated via null SWR key; login-redirect spinner preserved)

Each hook keeps its exact return shape (`{ data, loading, error, refetch }`); post-mutation refreshes now go through SWR `mutate()`. Net −104 lines; free upside: cache + revalidation, no reload-flash on revalidate.

## Verification

- lint: set-state-in-effect 46 → 38, no new warnings
- typecheck clean, 7797 unit tests green, production build green

Remaining 38 warnings are bucket-B hooks (pagination/filter/mutation state — follow-up batches) and legitimate external-sync effects (localStorage hydration etc.).

🤖 Generated with [Claude Code](https://claude.com/claude-code)