### PR TITLE
refactor(hooks): migrate 7 admin fetch hooks to useSwrFetch (38→30 set-state-in-effect warnings)

### DIFF
--- a/src/components/admin/blog/submissions/useSubmissions.ts
+++ b/src/components/admin/blog/submissions/useSubmissions.ts
@@ -1,42 +1,38 @@
 'use client'
 
-import { useState, useEffect, useCallback } from 'react'
+import { useState, useCallback } from 'react'
 import { apiFetch } from '@/lib/api/client'
+import { useSwrFetch } from '@/lib/api/swr'
 import { ERROR_MESSAGES } from '@/config/error-messages'
 import { APPROVAL_STATUS } from '@/config/approval-status'
 import type { Submission, FilterStatus, SubmissionAction, StatusCounts } from './types'
 
 export function useSubmissions() {
-  const [submissions, setSubmissions] = useState<Submission[]>([])
   const [filter, setFilter] = useState<FilterStatus>(APPROVAL_STATUS.PENDING)
   const [selectedSubmission, setSelectedSubmission] = useState<Submission | null>(null)
-  const [isLoading, setIsLoading] = useState(true)
   const [actionLoading, setActionLoading] = useState<string | null>(null)
   const [showRejectModal, setShowRejectModal] = useState(false)
   const [showChangesModal, setShowChangesModal] = useState(false)
   const [showEditModal, setShowEditModal] = useState(false)
   const [rejectionReason, setRejectionReason] = useState('')
   const [reviewNotes, setReviewNotes] = useState('')
-  const [error, setError] = useState('')
+  const [actionError, setActionError] = useState('')
   const [success, setSuccess] = useState('')
 
-  const fetchSubmissions = useCallback(async () => {
-    try {
-      setIsLoading(true)
-      const result = await apiFetch<{ submissions: Submission[] }>('/api/blog/submit')
-      if (result.success) {
-        setSubmissions(result.data?.submissions || [])
-      }
-    } catch {
-      setError('Fehler beim Laden der Einreichungen')
-    } finally {
-      setIsLoading(false)
-    }
-  }, [])
+  const {
+    data,
+    error: loadError,
+    isLoading,
+    mutate,
+  } = useSwrFetch<{ submissions: Submission[] }>('/api/blog/submit')
+  const submissions = data?.submissions ?? []
+  // One error surface: action errors win (they're the fresher user feedback).
+  const error = actionError || (loadError ? 'Fehler beim Laden der Einreichungen' : '')
+  const setError = setActionError
 
-  useEffect(() => {
-    fetchSubmissions()
-  }, [fetchSubmissions])
+  const fetchSubmissions = useCallback(async () => {
+    await mutate()
+  }, [mutate])
 
   const handleAction = async (
     action: SubmissionAction,

--- a/src/components/admin/donations/useDonations.ts
+++ b/src/components/admin/donations/useDonations.ts
@@ -1,7 +1,9 @@
-import { useState, useEffect, useCallback } from 'react'
+import { useState, useCallback, useMemo } from 'react'
 import { useSession } from 'next-auth/react'
 import { toast } from 'sonner'
 import { apiFetch } from '@/lib/api/client'
+import { useSwrFetch } from '@/lib/api/swr'
+import { useDebounce } from '@/hooks/useDebounce'
 import { logger } from '@/lib/logger'
 import { API_DEFAULTS } from '@/config/api-defaults'
 import { ERROR_MESSAGES } from '@/config/error-messages'
@@ -11,11 +13,6 @@ import { DEFAULT_FORM_DATA } from './types'
 
 export function useDonations() {
   const { status: sessionStatus } = useSession()
-
-  const [donations, setDonations] = useState<Donation[]>([])
-  const [stats, setStats] = useState<DonationStats | null>(null)
-  const [loading, setLoading] = useState(true)
-  const [error, setError] = useState('')
 
   const [filters, setFilters] = useState<DonationFiltersState>({
     donation_type: 'all',
@@ -28,94 +25,70 @@ export function useDonations() {
 
   // User search state
   const [userSearch, setUserSearch] = useState('')
-  const [userResults, setUserResults] = useState<UserResult[]>([])
-  const [searchingUsers, setSearchingUsers] = useState(false)
   const [selectedUser, setSelectedUser] = useState<UserResult | null>(null)
 
   // Form state
   const [formData, setFormData] = useState<DonationFormData>(DEFAULT_FORM_DATA)
 
+  // Filters are encoded in the SWR key (fetch gated on an authenticated session).
+  const params = new URLSearchParams({ limit: String(API_DEFAULTS.PAGINATION_LIMIT) })
+  if (filters.donation_type !== 'all') {
+    params.set('donation_type', filters.donation_type)
+  }
+  if (filters.status !== 'all') {
+    params.set('status', filters.status)
+  }
+
+  const {
+    data: donationsData,
+    error: loadError,
+    isLoading: loading,
+    mutate,
+  } = useSwrFetch<{ items: Donation[] }>(
+    sessionStatus === 'authenticated' ? `/api/admin/donations?${params}` : null,
+  )
+  const donations = useMemo(() => donationsData?.items ?? [], [donationsData])
+  const error = loadError instanceof Error ? loadError.message || ERROR_MESSAGES.NETWORK_ERROR : ''
+
+  // Stats derive from the loaded page — pure computation, no second state copy.
+  const stats: DonationStats | null = useMemo(() => {
+    if (!donationsData) return null
+    const items = donations
+    const totalValue = items.reduce((sum: number, d: Donation) => {
+      if (d.donation_type === DONATION_TYPES.MONETARY && d.amount_cents) return sum + d.amount_cents
+      if (d.donation_type === DONATION_TYPES.DEVICE && d.estimated_value_cents) return sum + d.estimated_value_cents
+      return sum
+    }, 0)
+    return {
+      total: items.length,
+      monetary: items.filter((d: Donation) => d.donation_type === DONATION_TYPES.MONETARY).length,
+      device: items.filter((d: Donation) => d.donation_type === DONATION_TYPES.DEVICE).length,
+      pendingThanks: items.filter((d: Donation) => !d.thank_you_sent).length,
+      pendingReceipts: items.filter((d: Donation) => d.receipt_requested && !d.receipt_sent).length,
+      totalValueCents: totalValue,
+    }
+  }, [donationsData, donations])
+
   const loadDonations = useCallback(async () => {
-    try {
-      setLoading(true)
-      const params = new URLSearchParams({ limit: String(API_DEFAULTS.PAGINATION_LIMIT) })
+    await mutate()
+  }, [mutate])
 
-      if (filters.donation_type !== 'all') {
-        params.set('donation_type', filters.donation_type)
-      }
-      if (filters.status !== 'all') {
-        params.set('status', filters.status)
-      }
-
-      const result = await apiFetch<{ items: Donation[] }>(`/api/admin/donations?${params}`)
-
-      if (result.success && result.data) {
-        const items = result.data.items || []
-        setDonations(items)
-
-        const monetary = items.filter((d: Donation) => d.donation_type === DONATION_TYPES.MONETARY)
-        const device = items.filter((d: Donation) => d.donation_type === DONATION_TYPES.DEVICE)
-        const pendingThanks = items.filter((d: Donation) => !d.thank_you_sent)
-        const pendingReceipts = items.filter((d: Donation) => d.receipt_requested && !d.receipt_sent)
-        const totalValue = items.reduce((sum: number, d: Donation) => {
-          if (d.donation_type === DONATION_TYPES.MONETARY && d.amount_cents) return sum + d.amount_cents
-          if (d.donation_type === DONATION_TYPES.DEVICE && d.estimated_value_cents) return sum + d.estimated_value_cents
-          return sum
-        }, 0)
-
-        setStats({
-          total: items.length,
-          monetary: monetary.length,
-          device: device.length,
-          pendingThanks: pendingThanks.length,
-          pendingReceipts: pendingReceipts.length,
-          totalValueCents: totalValue,
-        })
-      } else {
-        setError(result.error || ERROR_MESSAGES.INTERNAL_SERVER_ERROR)
-      }
-    } catch {
-      setError(ERROR_MESSAGES.NETWORK_ERROR)
-    } finally {
-      setLoading(false)
-    }
-  }, [filters.donation_type, filters.status])
-
-  useEffect(() => {
-    if (sessionStatus === 'authenticated') {
-      loadDonations()
-    }
-  }, [sessionStatus, loadDonations])
-
-  // User search with debounce
-  useEffect(() => {
-    if (userSearch.length < 2) {
-      setUserResults([])
-      return
-    }
-
-    const timeoutId = setTimeout(async () => {
-      setSearchingUsers(true)
-      try {
-        const result = await apiFetch<{ users: UserResult[] }>(`/api/admin/donations/users?search=${encodeURIComponent(userSearch)}`)
-        if (result.success && result.data) {
-          setUserResults(result.data.users || [])
-        }
-      } catch {
-        // Ignore search errors
-      } finally {
-        setSearchingUsers(false)
-      }
-    }, 300)
-
-    return () => clearTimeout(timeoutId)
-  }, [userSearch])
+  // User search: debounced term becomes the SWR key (null under 2 chars = no
+  // request, empty results). Search errors stay silent, as before.
+  const debouncedUserSearch = useDebounce(userSearch, 300)
+  const userSearchKey =
+    debouncedUserSearch.length >= 2
+      ? `/api/admin/donations/users?search=${encodeURIComponent(debouncedUserSearch)}`
+      : null
+  const { data: userSearchData, isLoading: searchingUsers } = useSwrFetch<{ users: UserResult[] }>(
+    userSearchKey,
+  )
+  const userResults = userSearchKey ? userSearchData?.users ?? [] : []
 
   const handleSelectUser = (user: UserResult) => {
     setSelectedUser(user)
     setFormData(prev => ({ ...prev, donor_name: user.name || '', donor_email: user.email }))
     setUserSearch('')
-    setUserResults([])
   }
 
   const handleClearUser = () => {
@@ -171,7 +144,6 @@ export function useDonations() {
         setShowForm(false)
         setSelectedUser(null)
         setUserSearch('')
-        setUserResults([])
         setFormData(DEFAULT_FORM_DATA)
         loadDonations()
       } else {

--- a/src/components/admin/hr/useHrVacancies.ts
+++ b/src/components/admin/hr/useHrVacancies.ts
@@ -1,7 +1,8 @@
 'use client'
 
-import { useCallback, useEffect, useState } from 'react'
+import { useCallback, useState } from 'react'
 import { apiFetch } from '@/lib/api/client'
+import { useSwrFetch } from '@/lib/api/swr'
 import { UI_FEEDBACK_MS } from '@/config/limits'
 import { VACANCY_STATUS, type VacancyStatus } from '@/config/hr-vacancies'
 import { publicVacancyUrl } from '@/lib/hr/public-urls'
@@ -10,9 +11,7 @@ import type { VacancyFormData, VacancyListItem } from './types'
 import { logger } from '@/lib/logger'
 
 export function useHrVacancies() {
-  const [postings, setPostings] = useState<VacancyListItem[]>([])
-  const [loading, setLoading] = useState(true)
-  const [error, setError] = useState<string | null>(null)
+  const [actionError, setError] = useState<string | null>(null)
   const [statusFilter, setStatusFilter] = useState<string>('')
   const [searchQuery, setSearchQuery] = useState('')
   const [actionLoading, setActionLoading] = useState<string | null>(null)
@@ -23,29 +22,27 @@ export function useHrVacancies() {
     setTimeout(() => setSuccessMessage(null), UI_FEEDBACK_MS.SUCCESS)
   }
 
-  const fetchPostings = useCallback(async () => {
-    try {
-      setLoading(true)
-      setError(null)
-      const params = new URLSearchParams()
-      if (statusFilter) params.set('status', statusFilter)
-      if (searchQuery) params.set('search', searchQuery)
-      const qs = params.toString()
-      const result = await apiFetch<{ postings: VacancyListItem[] }>(
-        `/api/admin/hr/vacancies${qs ? `?${qs}` : ''}`,
-      )
-      if (!result.success) throw new Error(result.error || 'Laden fehlgeschlagen')
-      setPostings(result.data?.postings ?? [])
-    } catch (err) {
-      setError(err instanceof Error ? err.message : 'Unbekannter Fehler')
-    } finally {
-      setLoading(false)
-    }
-  }, [statusFilter, searchQuery])
+  // Filters are encoded in the SWR key — changing them refetches.
+  const params = new URLSearchParams()
+  if (statusFilter) params.set('status', statusFilter)
+  if (searchQuery) params.set('search', searchQuery)
+  const qs = params.toString()
 
-  useEffect(() => {
-    fetchPostings()
-  }, [fetchPostings])
+  const {
+    data,
+    error: loadError,
+    isLoading: loading,
+    mutate,
+  } = useSwrFetch<{ postings: VacancyListItem[] }>(
+    `/api/admin/hr/vacancies${qs ? `?${qs}` : ''}`,
+  )
+  const postings = data?.postings ?? []
+  // One error surface: action errors win (they're the fresher user feedback).
+  const error = actionError ?? (loadError instanceof Error ? loadError.message : null)
+
+  const fetchPostings = useCallback(async () => {
+    await mutate()
+  }, [mutate])
 
   const transitionStatus = async (id: string, status: VacancyStatus) => {
     setActionLoading(id)

--- a/src/components/admin/team/activity/useActivityStream.ts
+++ b/src/components/admin/team/activity/useActivityStream.ts
@@ -6,9 +6,9 @@
  * Unified activity stream with filters. Sub-hooks are in dedicated files.
  */
 
-import { useState, useEffect, useCallback } from 'react'
+import { useState, useCallback } from 'react'
 import { API_DEFAULTS } from '@/config/api-defaults'
-import { apiFetch } from '@/lib/api/client'
+import { useSwrFetch } from '@/lib/api/swr'
 import type { UnifiedActivity, ActivityStreamFilter } from './types'
 
 // Re-export sub-hooks for backward compatibility with barrel index
@@ -34,52 +34,41 @@ interface UseActivityStreamReturn {
 export function useActivityStream(
   initialFilters?: Partial<ActivityStreamFilter>
 ): UseActivityStreamReturn {
-  const [activities, setActivities] = useState<UnifiedActivity[]>([])
-  const [loading, setLoading] = useState(true)
-  const [error, setError] = useState<string | null>(null)
-  const [total, setTotal] = useState(0)
   const [filters, setFiltersState] = useState<ActivityStreamFilter>({
     limit: API_DEFAULTS.PAGINATION_LIMIT,
     offset: 0,
     ...initialFilters,
   })
 
-  const fetchActivities = useCallback(async () => {
-    setLoading(true)
-    setError(null)
+  // Filters (incl. pagination) are encoded in the SWR key — changing them refetches.
+  const params = new URLSearchParams()
+  if (filters.user_id) params.set('user_id', filters.user_id)
+  if (filters.source_type) params.set('source_type', filters.source_type)
+  if (filters.category) params.set('category', filters.category)
+  if (filters.since) params.set('since', filters.since)
+  if (filters.until) params.set('until', filters.until)
+  params.set('limit', String(filters.limit))
+  params.set('offset', String(filters.offset))
 
-    try {
-      const params = new URLSearchParams()
-      if (filters.user_id) params.set('user_id', filters.user_id)
-      if (filters.source_type) params.set('source_type', filters.source_type)
-      if (filters.category) params.set('category', filters.category)
-      if (filters.since) params.set('since', filters.since)
-      if (filters.until) params.set('until', filters.until)
-      params.set('limit', String(filters.limit))
-      params.set('offset', String(filters.offset))
-
-      const result = await apiFetch<{ items: UnifiedActivity[]; total: number }>(`/api/admin/team/activity?${params.toString()}`)
-
-      if (!result.success) {
-        throw new Error(result.error || 'Fehler beim Laden der Aktivitäten')
-      }
-
-      setActivities(result.data?.items || [])
-      setTotal(result.data?.total || 0)
-    } catch (err) {
-      setError(err instanceof Error ? err.message : 'Unbekannter Fehler')
-    } finally {
-      setLoading(false)
-    }
-  }, [filters])
-
-  useEffect(() => {
-    fetchActivities()
-  }, [fetchActivities])
+  const { data, error, isLoading, mutate } = useSwrFetch<{ items: UnifiedActivity[]; total: number }>(
+    `/api/admin/team/activity?${params.toString()}`,
+  )
 
   const setFilters = useCallback((newFilters: Partial<ActivityStreamFilter>) => {
     setFiltersState((prev) => ({ ...prev, ...newFilters }))
   }, [])
 
-  return { activities, loading, error, total, filters, setFilters, refetch: fetchActivities }
+  const refetch = useCallback(async () => {
+    await mutate()
+  }, [mutate])
+
+  return {
+    activities: data?.items ?? [],
+    loading: isLoading,
+    error: error instanceof Error ? error.message : null,
+    total: data?.total ?? 0,
+    filters,
+    setFilters,
+    refetch,
+  }
 }

--- a/src/components/admin/team/activity/useHelpRequests.ts
+++ b/src/components/admin/team/activity/useHelpRequests.ts
@@ -6,8 +6,9 @@
  * Data fetching and mutation hooks for help requests
  */
 
-import { useState, useEffect, useCallback } from 'react'
+import { useState, useCallback } from 'react'
 import { apiFetch } from '@/lib/api/client'
+import { useSwrFetch } from '@/lib/api/swr'
 import { API_DEFAULTS } from '@/config/api-defaults'
 import type { HelpRequest, HelpRequestFilter } from './types'
 
@@ -28,55 +29,44 @@ interface UseHelpRequestsReturn {
 export function useHelpRequests(
   initialFilters?: Partial<HelpRequestFilter>
 ): UseHelpRequestsReturn {
-  const [requests, setRequests] = useState<HelpRequest[]>([])
-  const [loading, setLoading] = useState(true)
-  const [error, setError] = useState<string | null>(null)
-  const [total, setTotal] = useState(0)
   const [filters, setFiltersState] = useState<HelpRequestFilter>({
     limit: API_DEFAULTS.PAGINATION_LIMIT,
     offset: 0,
     ...initialFilters,
   })
 
-  const fetchRequests = useCallback(async () => {
-    setLoading(true)
-    setError(null)
+  // Filters (incl. pagination) are encoded in the SWR key — changing them refetches.
+  const params = new URLSearchParams()
+  if (filters.status) params.set('status', filters.status)
+  if (filters.urgency) params.set('urgency', filters.urgency)
+  if (filters.category) params.set('category', filters.category)
+  if (filters.requester_id) params.set('requester_id', filters.requester_id)
+  if (filters.requested_user_id) params.set('requested_user_id', filters.requested_user_id)
+  if (filters.is_broadcast !== undefined) params.set('is_broadcast', String(filters.is_broadcast))
+  params.set('limit', String(filters.limit))
+  params.set('offset', String(filters.offset))
 
-    try {
-      const params = new URLSearchParams()
-      if (filters.status) params.set('status', filters.status)
-      if (filters.urgency) params.set('urgency', filters.urgency)
-      if (filters.category) params.set('category', filters.category)
-      if (filters.requester_id) params.set('requester_id', filters.requester_id)
-      if (filters.requested_user_id) params.set('requested_user_id', filters.requested_user_id)
-      if (filters.is_broadcast !== undefined) params.set('is_broadcast', String(filters.is_broadcast))
-      params.set('limit', String(filters.limit))
-      params.set('offset', String(filters.offset))
-
-      const result = await apiFetch<{ items: HelpRequest[]; total: number }>(`/api/admin/team/help-requests?${params.toString()}`)
-
-      if (!result.success) {
-        throw new Error(result.error || 'Fehler beim Laden')
-      }
-
-      setRequests(result.data?.items || [])
-      setTotal(result.data?.total || 0)
-    } catch (err) {
-      setError(err instanceof Error ? err.message : 'Unbekannter Fehler')
-    } finally {
-      setLoading(false)
-    }
-  }, [filters])
-
-  useEffect(() => {
-    fetchRequests()
-  }, [fetchRequests])
+  const { data, error, isLoading, mutate } = useSwrFetch<{ items: HelpRequest[]; total: number }>(
+    `/api/admin/team/help-requests?${params.toString()}`,
+  )
 
   const setFilters = useCallback((newFilters: Partial<HelpRequestFilter>) => {
     setFiltersState((prev) => ({ ...prev, ...newFilters }))
   }, [])
 
-  return { requests, loading, error, total, filters, setFilters, refetch: fetchRequests }
+  const refetch = useCallback(async () => {
+    await mutate()
+  }, [mutate])
+
+  return {
+    requests: data?.items ?? [],
+    loading: isLoading,
+    error: error instanceof Error ? error.message : null,
+    total: data?.total ?? 0,
+    filters,
+    setFilters,
+    refetch,
+  }
 }
 
 // ============================================================================

--- a/src/components/admin/team/useTeamProfiles.ts
+++ b/src/components/admin/team/useTeamProfiles.ts
@@ -4,7 +4,7 @@
  * Hook for fetching and managing team profiles
  */
 
-import { useState, useEffect, useCallback } from 'react'
+import { useState, useCallback } from 'react'
 import { apiFetch } from '@/lib/api/client'
 import { useSwrFetch } from '@/lib/api/swr'
 import type { TeamProfileWithUser } from '@/lib/schemas/team'
@@ -31,55 +31,37 @@ const defaultFilters: TeamFilterState = {
 }
 
 export function useTeamProfiles(options: UseTeamProfilesOptions = {}): UseTeamProfilesReturn {
-  const [profiles, setProfiles] = useState<TeamProfileWithUser[]>([])
-  const [loading, setLoading] = useState(true)
-  const [error, setError] = useState<string | null>(null)
   const [filters, setFiltersState] = useState<TeamFilterState>({
     ...defaultFilters,
     ...options.initialFilters,
   })
 
-  const fetchProfiles = useCallback(async () => {
-    try {
-      setLoading(true)
-      setError(null)
+  // Filters are encoded in the SWR key, so changing them refetches automatically.
+  const params = new URLSearchParams()
+  if (filters.department) params.set('department', filters.department)
+  if (filters.employmentType) params.set('employment_type', filters.employmentType)
+  if (filters.isActive !== 'all') params.set('is_active', filters.isActive)
+  if (filters.search) params.set('search', filters.search)
 
-      const params = new URLSearchParams()
-      if (filters.department) params.set('department', filters.department)
-      if (filters.employmentType) params.set('employment_type', filters.employmentType)
-      if (filters.isActive !== 'all') params.set('is_active', filters.isActive)
-      if (filters.search) params.set('search', filters.search)
-
-      const result = await apiFetch<TeamProfileWithUser[]>(`/api/admin/team/profiles?${params.toString()}`)
-
-      if (!result.success) {
-        throw new Error(result.error || 'Fehler beim Laden der Profile')
-      }
-
-      setProfiles(result.data || [])
-    } catch (err) {
-      setError(err instanceof Error ? err.message : 'Unbekannter Fehler')
-      setProfiles([])
-    } finally {
-      setLoading(false)
-    }
-  }, [filters])
-
-  useEffect(() => {
-    fetchProfiles()
-  }, [fetchProfiles])
+  const { data, error, isLoading, mutate } = useSwrFetch<TeamProfileWithUser[]>(
+    `/api/admin/team/profiles?${params.toString()}`,
+  )
 
   const setFilters = useCallback((newFilters: Partial<TeamFilterState>) => {
     setFiltersState(prev => ({ ...prev, ...newFilters }))
   }, [])
 
+  const refetch = useCallback(async () => {
+    await mutate()
+  }, [mutate])
+
   return {
-    profiles,
-    loading,
-    error,
+    profiles: data ?? [],
+    loading: isLoading,
+    error: error instanceof Error ? error.message : null,
     filters,
     setFilters,
-    refetch: fetchProfiles,
+    refetch,
   }
 }
 

--- a/src/components/admin/workshops/instances/useWorkshopInstances.ts
+++ b/src/components/admin/workshops/instances/useWorkshopInstances.ts
@@ -1,10 +1,11 @@
 'use client'
 
-import { useState, useEffect, useCallback } from 'react'
+import { useState, useCallback } from 'react'
 import { useSession } from 'next-auth/react'
 import { toast } from 'sonner'
 import { logger } from '@/lib/logger'
 import { apiFetch } from '@/lib/api/client'
+import { useSwrFetch } from '@/lib/api/swr'
 import { ERROR_MESSAGES } from '@/config/error-messages'
 import type { Workshop, WorkshopInstanceWithDetails, InstanceFormData, InstanceFiltersState } from './types'
 import { initialFormData } from './types'
@@ -13,10 +14,7 @@ import { WORKSHOP_INSTANCE_STATUS, WORKSHOP_INSTANCE_STATUS_LABELS, WORKSHOP_INS
 export function useWorkshopInstances() {
   const { data: session, status: sessionStatus } = useSession()
 
-  const [instances, setInstances] = useState<WorkshopInstanceWithDetails[]>([])
-  const [workshops, setWorkshops] = useState<Workshop[]>([])
-  const [loading, setLoading] = useState(true)
-  const [error, setError] = useState('')
+  const [actionError, setError] = useState('')
 
   const [filters, setFilters] = useState<InstanceFiltersState>({
     workshopId: '',
@@ -30,44 +28,41 @@ export function useWorkshopInstances() {
   const [submitting, setSubmitting] = useState(false)
   const [pendingDeleteId, setPendingDeleteId] = useState<string | null>(null)
 
-  const loadWorkshops = useCallback(async () => {
-    try {
-      const result = await apiFetch<{ workshops: Workshop[] }>('/api/admin/workshops/list')
-      if (result.success && result.data) {
-        setWorkshops(result.data.workshops)
-      }
-    } catch (err) {
-      logger.error('Error loading workshops', { error: err })
-    }
-  }, [])
+  // Both fetches are gated on an authenticated session via null SWR keys;
+  // filters are encoded in the instances key, so changing them refetches.
+  const authed = sessionStatus === 'authenticated'
+
+  // Workshops list is auxiliary (dropdown options) — load errors are non-fatal
+  // and intentionally not surfaced, matching the previous log-only behavior.
+  const { data: workshopsData } = useSwrFetch<{ workshops: Workshop[] }>(
+    authed ? '/api/admin/workshops/list' : null,
+  )
+  const workshops = workshopsData?.workshops ?? []
+
+  const params = new URLSearchParams()
+  if (filters.workshopId) params.set('workshopId', filters.workshopId)
+  if (filters.status !== 'all') params.set('status', filters.status)
+  if (filters.upcoming) params.set('upcoming', 'true')
+
+  const {
+    data: instancesData,
+    error: loadError,
+    isLoading: loading,
+    mutate,
+  } = useSwrFetch<{ instances: WorkshopInstanceWithDetails[] }>(
+    authed ? `/api/admin/workshops/instances?${params}` : null,
+  )
+  const instances = instancesData?.instances ?? []
+  // One error surface: action errors win (they're the fresher user feedback).
+  const error =
+    actionError ||
+    (loadError instanceof Error
+      ? loadError.message || 'Fehler beim Laden der Workshop-Termine'
+      : '')
 
   const loadInstances = useCallback(async () => {
-    try {
-      setLoading(true)
-      const params = new URLSearchParams()
-      if (filters.workshopId) params.set('workshopId', filters.workshopId)
-      if (filters.status !== 'all') params.set('status', filters.status)
-      if (filters.upcoming) params.set('upcoming', 'true')
-
-      const result = await apiFetch<{ instances: WorkshopInstanceWithDetails[] }>(`/api/admin/workshops/instances?${params}`)
-      if (result.success && result.data) {
-        setInstances(result.data.instances)
-      } else {
-        setError(result.error || 'Fehler beim Laden der Workshop-Termine')
-      }
-    } catch {
-      setError(ERROR_MESSAGES.NETWORK_ERROR)
-    } finally {
-      setLoading(false)
-    }
-  }, [filters])
-
-  useEffect(() => {
-    if (sessionStatus === 'authenticated') {
-      loadWorkshops()
-      loadInstances()
-    }
-  }, [sessionStatus, loadWorkshops, loadInstances])
+    await mutate()
+  }, [mutate])
 
   const handleCreateOrUpdate = async () => {
     setSubmitting(true)


### PR DESCRIPTION
## What

Batch 2 of the set-state-in-effect cleanup (after #341): the admin bucket-B hooks — `useTeamProfiles`, `useHelpRequests`, `useActivityStream`, `useSubmissions`, `useHrVacancies`, `useWorkshopInstances`, `useDonations` (2 sites).

- Filters + pagination are encoded in the SWR key → changing them refetches automatically (the filter-driven refetch effects disappear).
- `useDonations` stats derive via `useMemo` from the loaded items (SSOT — no second state copy); the debounced donor search keys SWR on the `useDebounce`d term (null key under 2 chars).
- Post-mutation refreshes go through `mutate()`; each hook keeps its exact return shape. Action errors keep local state and win over load errors on the single exposed error surface.

## Verification

- lint: set-state-in-effect 38 → 30, no new warnings
- typecheck clean, 7797 unit tests green, production build green

🤖 Generated with [Claude Code](https://claude.com/claude-code)