### PR TITLE
refactor(hooks): migrate marketplace/users/it-hilfe/intake browse hooks to SWR (30→24 set-state-in-effect warnings)

### DIFF
--- a/src/app/[locale]/marketplace/MarketplacePageClient.tsx
+++ b/src/app/[locale]/marketplace/MarketplacePageClient.tsx
@@ -48,7 +48,6 @@ export default function MarketplacePage() {
     filters,
     handleSearch,
     clearFilters,
-    validatePrices,
     fetchListings,
     resetOffset,
     goToPage,
@@ -92,7 +91,6 @@ export default function MarketplacePage() {
 
   const sharedSidebarProps = {
     filters,
-    validatePrices,
     resetOffset,
     clearFilters,
     hasActiveFilters,

--- a/src/app/admin/intake/useIntakePipeline.ts
+++ b/src/app/admin/intake/useIntakePipeline.ts
@@ -1,7 +1,7 @@
 'use client'
 
-import { useState, useEffect, useCallback } from 'react'
-import { apiFetch } from '@/lib/api/client'
+import { useState, useCallback } from 'react'
+import { useSwrFetch } from '@/lib/api/swr'
 import type { PipelineItem } from './types'
 
 interface PaginationState {
@@ -19,59 +19,56 @@ interface StatusCounts {
   total: number
 }
 
+const EMPTY_PAGINATION: PaginationState = { total: 0, limit: 48, offset: 0, hasMore: false }
+const EMPTY_COUNTS: StatusCounts = { inProgress: 0, failed: 0, ready: 0, published: 0, total: 0 }
+
 export function useIntakePipeline(active: boolean) {
-  const [items, setItems] = useState<PipelineItem[]>([])
-  const [loading, setLoading] = useState(true)
-  const [pagination, setPagination] = useState<PaginationState>({
-    total: 0, limit: 48, offset: 0, hasMore: false,
-  })
-  const [statusCounts, setStatusCounts] = useState<StatusCounts>({
-    inProgress: 0, failed: 0, ready: 0, published: 0, total: 0,
-  })
+  const [offset, setOffset] = useState(0)
 
-  // Filters
-  const [tierFilter, setTierFilter] = useState('')
-  const [statusFilter, setStatusFilter] = useState('')
-  const [categoryFilter, setCategoryFilter] = useState('')
-  const [searchFilter, setSearchFilter] = useState('')
+  // Filters. Changing one resets to the first page (matching the previous
+  // auto-fetch-at-offset-0 behavior).
+  const [tierFilter, setTierFilterState] = useState('')
+  const [statusFilter, setStatusFilterState] = useState('')
+  const [categoryFilter, setCategoryFilterState] = useState('')
+  const [searchFilter, setSearchFilterState] = useState('')
 
-  const fetchItems = useCallback(async (offset = 0) => {
-    setLoading(true)
-    try {
-      const params = new URLSearchParams({ limit: '48', offset: String(offset) })
-      if (tierFilter) params.set('tier', tierFilter)
-      if (statusFilter) params.set('status', statusFilter)
-      if (categoryFilter) params.set('category', categoryFilter)
-      if (searchFilter) params.set('search', searchFilter)
+  const setTierFilter = useCallback((v: string) => { setTierFilterState(v); setOffset(0) }, [])
+  const setStatusFilter = useCallback((v: string) => { setStatusFilterState(v); setOffset(0) }, [])
+  const setCategoryFilter = useCallback((v: string) => { setCategoryFilterState(v); setOffset(0) }, [])
+  const setSearchFilter = useCallback((v: string) => { setSearchFilterState(v); setOffset(0) }, [])
 
-      const result = await apiFetch<{
-        items: PipelineItem[]
-        pagination: PaginationState
-        statusCounts?: StatusCounts
-      }>(`/api/admin/intake?${params}`)
-      if (result.success && result.data) {
-        setItems(result.data.items)
-        setPagination(result.data.pagination)
-        if (result.data.statusCounts) setStatusCounts(result.data.statusCounts)
+  // Filters + offset are encoded in the SWR key (null while the tab is
+  // inactive) — any change refetches automatically.
+  const params = new URLSearchParams({ limit: '48', offset: String(offset) })
+  if (tierFilter) params.set('tier', tierFilter)
+  if (statusFilter) params.set('status', statusFilter)
+  if (categoryFilter) params.set('category', categoryFilter)
+  if (searchFilter) params.set('search', searchFilter)
+
+  const { data, isLoading: loading, mutate } = useSwrFetch<{
+    items: PipelineItem[]
+    pagination: PaginationState
+    statusCounts?: StatusCounts
+  }>(active ? `/api/admin/intake?${params}` : null)
+
+  // fetchItems(offset) keeps its old signature: same offset = revalidate,
+  // new offset = page change (which refetches via the key).
+  const fetchItems = useCallback(
+    async (newOffset = 0) => {
+      if (newOffset === offset) {
+        await mutate()
+      } else {
+        setOffset(newOffset)
       }
-    } finally {
-      setLoading(false)
-    }
-  }, [tierFilter, statusFilter, categoryFilter, searchFilter])
-
-  // Auto-fetch when active or filters change. Delegates to fetchItems — the
-  // previous hand-copied fetch body drifted (it dropped statusCounts, so the
-  // hero KPIs stayed 0 on every initial load until the user paginated).
-  useEffect(() => {
-    if (!active) return
-    void fetchItems(0)
-  }, [active, fetchItems])
+    },
+    [offset, mutate],
+  )
 
   return {
-    items,
+    items: data?.items ?? [],
     loading,
-    pagination,
-    statusCounts,
+    pagination: data?.pagination ?? EMPTY_PAGINATION,
+    statusCounts: data?.statusCounts ?? EMPTY_COUNTS,
     tierFilter, setTierFilter,
     statusFilter, setStatusFilter,
     categoryFilter, setCategoryFilter,

--- a/src/components/marketplace/ActiveFilterChips.tsx
+++ b/src/components/marketplace/ActiveFilterChips.tsx
@@ -76,7 +76,6 @@ function buildChips(
       onRemove: () => {
         filters.setPriceMin('')
         filters.setPriceMax('')
-        filters.setPriceError(null)
         resetOffset()
       },
     })
@@ -84,13 +83,13 @@ function buildChips(
     chips.push({
       key: 'priceMin',
       label: t('chips.priceFrom', { min: filters.priceMin }),
-      onRemove: () => { filters.setPriceMin(''); filters.setPriceError(null); resetOffset() },
+      onRemove: () => { filters.setPriceMin(''); resetOffset() },
     })
   } else if (filters.priceMax) {
     chips.push({
       key: 'priceMax',
       label: t('chips.priceTo', { max: filters.priceMax }),
-      onRemove: () => { filters.setPriceMax(''); filters.setPriceError(null); resetOffset() },
+      onRemove: () => { filters.setPriceMax(''); resetOffset() },
     })
   }
 

--- a/src/components/marketplace/MarketplaceFilterSidebar.tsx
+++ b/src/components/marketplace/MarketplaceFilterSidebar.tsx
@@ -20,7 +20,6 @@ export type FiltersObj = ReturnType<typeof useMarketplaceListings>['filters']
 
 interface FilterSidebarProps {
   filters: FiltersObj
-  validatePrices: () => boolean
   resetOffset: () => void
   clearFilters: () => void
   hasActiveFilters: boolean
@@ -82,7 +81,6 @@ function PillGroup({
 
 export function MarketplaceFilterSidebar({
   filters,
-  validatePrices,
   resetOffset,
   clearFilters,
   hasActiveFilters,
@@ -169,8 +167,8 @@ export function MarketplaceFilterSidebar({
               step="1"
               placeholder={t('filters.priceMin')}
               value={filters.priceMin}
-              onChange={(e) => { filters.setPriceMin(e.target.value); filters.setPriceError(null) }}
-              onBlur={() => { validatePrices(); resetOffset() }}
+              onChange={(e) => { filters.setPriceMin(e.target.value) }}
+              onBlur={resetOffset}
               aria-label={t('filters.priceMinAriaLabel')}
               aria-invalid={!!filters.priceError}
               className={`w-full ${filters.priceError ? 'border-error-400' : ''}`}
@@ -183,8 +181,8 @@ export function MarketplaceFilterSidebar({
               step="1"
               placeholder={t('filters.priceMax')}
               value={filters.priceMax}
-              onChange={(e) => { filters.setPriceMax(e.target.value); filters.setPriceError(null) }}
-              onBlur={() => { validatePrices(); resetOffset() }}
+              onChange={(e) => { filters.setPriceMax(e.target.value) }}
+              onBlur={resetOffset}
               aria-label={t('filters.priceMaxAriaLabel')}
               aria-invalid={!!filters.priceError}
               className={`w-full ${filters.priceError ? 'border-error-400' : ''}`}

--- a/src/hooks/__tests__/useMarketplaceListings.test.tsx
+++ b/src/hooks/__tests__/useMarketplaceListings.test.tsx
@@ -5,18 +5,24 @@
  * through this. A regression here either breaks the buyer-discovery
  * funnel or sends bogus filters to the listings API.
  *
+ * The hook fetches via useSwrFetch (SWR), so each test renders inside an
+ * SWRConfig with a FRESH cache and dedupe disabled — otherwise SWR's
+ * module-level cache leaks data between tests and fetch-count assertions lie.
+ *
  * Behaviors locked:
- *   - validatePrices: negative, min>max, max-50000 boundaries
- *   - fetchListings URL construction (only-truthy filters, booleans →
- *     "true", limit/offset always set)
- *   - 300ms debounced search auto-fires + resets pagination offset to 0
- *   - handleSearch preventDefault + immediate apply
+ *   - priceError derives from priceMin/priceMax: negative, min>max,
+ *     max-50000 boundaries; clears itself when the range becomes valid
+ *   - invalid price bounds are NOT sent to the API
+ *   - fetch URL construction (only-truthy filters, booleans → "true",
+ *     limit/offset always set)
+ *   - 300ms debounced search fires + typing resets pagination offset to 0
+ *   - handleSearch preventDefault + reset offset (term applies via debounce)
  *   - clearFilters resets EVERY filter dimension
  *   - hasActiveFilters is true iff any filter dimension is set
  *   - Pagination math: totalPages = ceil(total/limit),
  *     currentPage = floor(offset/limit) + 1
  *   - goToPage maps page-1-indexed → offset
- *   - Failure: error state populated, listings cleared to []
+ *   - Failure: error state populated, listings empty
  */
 
 const mockApiFetch = jest.fn()
@@ -29,8 +35,20 @@ jest.mock('@/config/marketplace', () => ({
   MARKETPLACE_LIMITS: { DEFAULT_PAGE_SIZE: 20 },
 }))
 
+import type { ReactNode } from 'react'
 import { renderHook, act, waitFor } from '@testing-library/react'
+import { SWRConfig } from 'swr'
 import { useMarketplaceListings } from '../useMarketplaceListings'
+
+// Fresh SWR cache per render — no cross-test cache leaks, no dedupe window.
+const wrapper = ({ children }: { children: ReactNode }) => (
+  <SWRConfig value={{ provider: () => new Map(), dedupingInterval: 0, revalidateOnFocus: false }}>
+    {children}
+  </SWRConfig>
+)
+
+const renderListings = (initial?: Parameters<typeof useMarketplaceListings>[0]) =>
+  renderHook(() => useMarketplaceListings(initial), { wrapper })
 
 const okResponse = (overrides?: { items?: unknown[]; pagination?: unknown }) => ({
   success: true,
@@ -39,6 +57,8 @@ const okResponse = (overrides?: { items?: unknown[]; pagination?: unknown }) => 
     pagination: overrides?.pagination ?? { total: 0, limit: 20, offset: 0 },
   },
 })
+
+const lastUrl = () => mockApiFetch.mock.calls[mockApiFetch.mock.calls.length - 1][0] as string
 
 beforeEach(() => {
   mockApiFetch.mockReset()
@@ -51,7 +71,7 @@ beforeEach(() => {
 describe('useMarketplaceListings — initial state', () => {
   it('starts with empty filters and DEFAULT_PAGE_SIZE pagination', async () => {
     mockApiFetch.mockResolvedValue(okResponse())
-    const { result } = renderHook(() => useMarketplaceListings())
+    const { result } = renderListings()
 
     expect(result.current.pagination).toEqual({ total: 0, limit: 20, offset: 0 })
     expect(result.current.filters.category).toBe('')
@@ -61,7 +81,7 @@ describe('useMarketplaceListings — initial state', () => {
 
   it('triggers initial fetch on mount', async () => {
     mockApiFetch.mockResolvedValue(okResponse())
-    renderHook(() => useMarketplaceListings())
+    renderListings()
 
     await waitFor(() => expect(mockApiFetch).toHaveBeenCalled())
     const url = mockApiFetch.mock.calls[0][0] as string
@@ -73,16 +93,16 @@ describe('useMarketplaceListings — initial state', () => {
 })
 
 // ============================================================================
-// validatePrices
+// priceError — derived validation
 // ============================================================================
 
-describe('validatePrices', () => {
+describe('priceError (derived)', () => {
   beforeEach(() => {
     mockApiFetch.mockResolvedValue(okResponse())
   })
 
-  it('valid range returns true with no error', async () => {
-    const { result } = renderHook(() => useMarketplaceListings())
+  it('valid range → no error, prices sent to the API', async () => {
+    const { result } = renderListings()
     await waitFor(() => expect(mockApiFetch).toHaveBeenCalled())
 
     act(() => {
@@ -90,32 +110,26 @@ describe('validatePrices', () => {
       result.current.filters.setPriceMax('500')
     })
 
-    let valid = false
-    act(() => {
-      valid = result.current.validatePrices()
-    })
-    expect(valid).toBe(true)
     expect(result.current.filters.priceError).toBeNull()
+    await waitFor(() => {
+      expect(lastUrl()).toContain('price_min=100')
+      expect(lastUrl()).toContain('price_max=500')
+    })
   })
 
   it('negative min → error "Preis kann nicht negativ sein"', async () => {
-    const { result } = renderHook(() => useMarketplaceListings())
+    const { result } = renderListings()
     await waitFor(() => expect(mockApiFetch).toHaveBeenCalled())
 
     act(() => {
       result.current.filters.setPriceMin('-50')
     })
 
-    let valid = true
-    act(() => {
-      valid = result.current.validatePrices()
-    })
-    expect(valid).toBe(false)
     expect(result.current.filters.priceError).toBe('Preis kann nicht negativ sein')
   })
 
   it('min > max → "Mindestpreis darf nicht höher als Höchstpreis sein" (proper umlaut)', async () => {
-    const { result } = renderHook(() => useMarketplaceListings())
+    const { result } = renderListings()
     await waitFor(() => expect(mockApiFetch).toHaveBeenCalled())
 
     act(() => {
@@ -123,57 +137,60 @@ describe('validatePrices', () => {
       result.current.filters.setPriceMax('100')
     })
 
-    let valid = true
-    act(() => {
-      valid = result.current.validatePrices()
-    })
-    expect(valid).toBe(false)
     expect(result.current.filters.priceError).toContain('höher')
     expect(result.current.filters.priceError).not.toContain('hoeher')
   })
 
   it('min > 50000 → "Preis darf maximal CHF 50\'000 sein"', async () => {
-    const { result } = renderHook(() => useMarketplaceListings())
+    const { result } = renderListings()
     await waitFor(() => expect(mockApiFetch).toHaveBeenCalled())
 
     act(() => {
       result.current.filters.setPriceMin('60000')
     })
 
-    let valid = true
-    act(() => {
-      valid = result.current.validatePrices()
-    })
-    expect(valid).toBe(false)
     expect(result.current.filters.priceError).toContain('50')
   })
 
+  it('invalid bounds are NOT sent to the API', async () => {
+    const { result } = renderListings()
+    await waitFor(() => expect(mockApiFetch).toHaveBeenCalled())
+
+    act(() => {
+      result.current.filters.setPriceMin('500')
+      result.current.filters.setPriceMax('100')
+    })
+
+    await waitFor(() => {
+      expect(lastUrl()).not.toContain('price_min')
+      expect(lastUrl()).not.toContain('price_max')
+    })
+  })
+
   it('clears previous error when range becomes valid', async () => {
-    const { result } = renderHook(() => useMarketplaceListings())
+    const { result } = renderListings()
     await waitFor(() => expect(mockApiFetch).toHaveBeenCalled())
 
     act(() => {
       result.current.filters.setPriceMin('-50')
     })
-    act(() => { result.current.validatePrices() })
     expect(result.current.filters.priceError).not.toBeNull()
 
     act(() => {
       result.current.filters.setPriceMin('100')
     })
-    act(() => { result.current.validatePrices() })
     expect(result.current.filters.priceError).toBeNull()
   })
 })
 
 // ============================================================================
-// URL construction in fetchListings
+// URL construction
 // ============================================================================
 
-describe('fetchListings — URL construction', () => {
+describe('fetch — URL construction', () => {
   it('always sets limit and offset', async () => {
     mockApiFetch.mockResolvedValue(okResponse())
-    renderHook(() => useMarketplaceListings())
+    renderListings()
 
     await waitFor(() => expect(mockApiFetch).toHaveBeenCalled())
     const url = mockApiFetch.mock.calls[0][0] as string
@@ -183,7 +200,7 @@ describe('fetchListings — URL construction', () => {
 
   it('only-truthy string filters become query params', async () => {
     mockApiFetch.mockResolvedValue(okResponse())
-    const { result } = renderHook(() => useMarketplaceListings())
+    const { result } = renderListings()
     await waitFor(() => expect(mockApiFetch).toHaveBeenCalled())
 
     act(() => {
@@ -193,16 +210,15 @@ describe('fetchListings — URL construction', () => {
     })
 
     await waitFor(() => {
-      const lastUrl = mockApiFetch.mock.calls[mockApiFetch.mock.calls.length - 1][0] as string
-      expect(lastUrl).toContain('category=laptop')
-      expect(lastUrl).toContain('condition=good')
-      expect(lastUrl).toContain('price_min=100')
+      expect(lastUrl()).toContain('category=laptop')
+      expect(lastUrl()).toContain('condition=good')
+      expect(lastUrl()).toContain('price_min=100')
     })
   })
 
   it('booleans → "true" string when set', async () => {
     mockApiFetch.mockResolvedValue(okResponse())
-    const { result } = renderHook(() => useMarketplaceListings())
+    const { result } = renderListings()
     await waitFor(() => expect(mockApiFetch).toHaveBeenCalled())
 
     act(() => {
@@ -211,15 +227,14 @@ describe('fetchListings — URL construction', () => {
     })
 
     await waitFor(() => {
-      const lastUrl = mockApiFetch.mock.calls[mockApiFetch.mock.calls.length - 1][0] as string
-      expect(lastUrl).toContain('gratis_only=true')
-      expect(lastUrl).toContain('verified_only=true')
+      expect(lastUrl()).toContain('gratis_only=true')
+      expect(lastUrl()).toContain('verified_only=true')
     })
   })
 
   it('false booleans omit the param entirely', async () => {
     mockApiFetch.mockResolvedValue(okResponse())
-    renderHook(() => useMarketplaceListings())
+    renderListings()
 
     await waitFor(() => expect(mockApiFetch).toHaveBeenCalled())
     const url = mockApiFetch.mock.calls[0][0] as string
@@ -229,7 +244,7 @@ describe('fetchListings — URL construction', () => {
 
   it('spec filters use snake_case API param names', async () => {
     mockApiFetch.mockResolvedValue(okResponse())
-    const { result } = renderHook(() => useMarketplaceListings())
+    const { result } = renderListings()
     await waitFor(() => expect(mockApiFetch).toHaveBeenCalled())
 
     act(() => {
@@ -239,45 +254,43 @@ describe('fetchListings — URL construction', () => {
     })
 
     await waitFor(() => {
-      const lastUrl = mockApiFetch.mock.calls[mockApiFetch.mock.calls.length - 1][0] as string
-      expect(lastUrl).toContain('spec_ram_min=16')
-      expect(lastUrl).toContain('spec_storage_min=512')
-      expect(lastUrl).toContain('spec_display_min=14')
+      expect(lastUrl()).toContain('spec_ram_min=16')
+      expect(lastUrl()).toContain('spec_storage_min=512')
+      expect(lastUrl()).toContain('spec_display_min=14')
     })
   })
 })
 
 // ============================================================================
-// fetchListings — failure paths
+// Failure paths
 // ============================================================================
 
-describe('fetchListings — failure', () => {
-  it('failure populates error and clears listings to []', async () => {
+describe('fetch — failure', () => {
+  it('failure populates error and leaves listings empty', async () => {
     mockApiFetch.mockResolvedValue({ success: false, error: 'Server down' })
 
-    const { result } = renderHook(() => useMarketplaceListings())
+    const { result } = renderListings()
 
-    await waitFor(() => expect(result.current.isLoading).toBe(false))
-    expect(result.current.error).toBe('Server down')
+    await waitFor(() => expect(result.current.error).toBe('Server down'))
     expect(result.current.listings).toEqual([])
   })
 
-  it('thrown error caught with German fallback "Ein unerwarteter Fehler ist aufgetreten"', async () => {
+  it('thrown non-Error caught with German fallback "Ein unerwarteter Fehler ist aufgetreten"', async () => {
     mockApiFetch.mockRejectedValue('weird non-Error throw')
 
-    const { result } = renderHook(() => useMarketplaceListings())
+    const { result } = renderListings()
 
-    await waitFor(() => expect(result.current.isLoading).toBe(false))
-    expect(result.current.error).toBe('Ein unerwarteter Fehler ist aufgetreten')
+    await waitFor(() =>
+      expect(result.current.error).toBe('Ein unerwarteter Fehler ist aufgetreten'),
+    )
   })
 
-  it('Swiss-German fallback "Fehler beim Laden der Inserate" when result.error missing', async () => {
+  it('German fallback "Anfrage fehlgeschlagen" when result.error missing', async () => {
     mockApiFetch.mockResolvedValue({ success: false })
 
-    const { result } = renderHook(() => useMarketplaceListings())
+    const { result } = renderListings()
 
-    await waitFor(() => expect(result.current.isLoading).toBe(false))
-    expect(result.current.error).toBe('Fehler beim Laden der Inserate')
+    await waitFor(() => expect(result.current.error).toBe('Anfrage fehlgeschlagen'))
   })
 })
 
@@ -290,7 +303,7 @@ describe('debounced search', () => {
     jest.useFakeTimers()
     mockApiFetch.mockResolvedValue(okResponse())
 
-    const { result } = renderHook(() => useMarketplaceListings())
+    const { result } = renderListings()
 
     // Wait for the initial mount-fetch to settle (only the first call)
     await act(async () => {
@@ -303,8 +316,10 @@ describe('debounced search', () => {
       result.current.filters.setSearchInput('macbook')
     })
 
-    // Right after typing — no new fetch yet (debounce)
-    expect(mockApiFetch.mock.calls.length).toBe(initialCalls)
+    // Right after typing — the search term itself is not applied yet (debounce)
+    expect(
+      mockApiFetch.mock.calls.some(call => (call[0] as string).includes('search=macbook')),
+    ).toBe(false)
 
     // After 300ms debounce — search applied, new fetch fires
     await act(async () => {
@@ -312,26 +327,26 @@ describe('debounced search', () => {
     })
 
     await waitFor(() => {
-      const calls = mockApiFetch.mock.calls.length
-      expect(calls).toBeGreaterThan(initialCalls)
+      expect(mockApiFetch.mock.calls.length).toBeGreaterThan(initialCalls)
+      expect(lastUrl()).toContain('search=macbook')
     })
-
-    const lastUrl = mockApiFetch.mock.calls[mockApiFetch.mock.calls.length - 1][0] as string
-    expect(lastUrl).toContain('search=macbook')
 
     jest.useRealTimers()
   })
 })
 
 // ============================================================================
-// handleSearch — immediate apply
+// handleSearch — submit resets paging, term applies via debounce
 // ============================================================================
 
 describe('handleSearch', () => {
-  it('preventDefault on submit + immediate apply (no debounce wait)', async () => {
+  it('preventDefault on submit; term applies via the 300ms debounce', async () => {
+    jest.useFakeTimers()
     mockApiFetch.mockResolvedValue(okResponse())
-    const { result } = renderHook(() => useMarketplaceListings())
-    await waitFor(() => expect(mockApiFetch).toHaveBeenCalled())
+    const { result } = renderListings()
+    await act(async () => {
+      jest.advanceTimersByTime(0)
+    })
 
     act(() => {
       result.current.filters.setSearchInput('quick search')
@@ -346,18 +361,22 @@ describe('handleSearch', () => {
 
     expect(preventDefault).toHaveBeenCalled()
 
-    // Search applied immediately (no 300ms wait)
-    await waitFor(() => {
-      const lastUrl = mockApiFetch.mock.calls[mockApiFetch.mock.calls.length - 1][0] as string
-      expect(lastUrl).toContain('search=quick')
+    await act(async () => {
+      jest.advanceTimersByTime(300)
     })
+
+    await waitFor(() => {
+      expect(lastUrl()).toContain('search=quick')
+    })
+
+    jest.useRealTimers()
   })
 
-  it('search reset offset to 0', async () => {
+  it('typing a search resets offset to 0', async () => {
     mockApiFetch.mockResolvedValue(okResponse({
       pagination: { total: 100, limit: 20, offset: 60 },
     }))
-    const { result } = renderHook(() => useMarketplaceListings())
+    const { result } = renderListings()
     await waitFor(() => expect(mockApiFetch).toHaveBeenCalled())
 
     // Move to page 4 first
@@ -374,10 +393,9 @@ describe('handleSearch', () => {
       result.current.handleSearch({ preventDefault } as unknown as React.FormEvent)
     })
 
-    // After search, offset is reset to 0 (next fetch will use offset=0)
+    // After search, offset is reset to 0 (next fetch uses offset=0)
     await waitFor(() => {
-      const lastUrl = mockApiFetch.mock.calls[mockApiFetch.mock.calls.length - 1][0] as string
-      expect(lastUrl).toContain('offset=0')
+      expect(lastUrl()).toContain('offset=0')
     })
   })
 })
@@ -389,7 +407,7 @@ describe('handleSearch', () => {
 describe('clearFilters', () => {
   it('resets every filter dimension and offset', async () => {
     mockApiFetch.mockResolvedValue(okResponse())
-    const { result } = renderHook(() => useMarketplaceListings())
+    const { result } = renderListings()
     await waitFor(() => expect(mockApiFetch).toHaveBeenCalled())
 
     act(() => {
@@ -439,13 +457,13 @@ describe('hasActiveFilters', () => {
   })
 
   it('false on initial mount', async () => {
-    const { result } = renderHook(() => useMarketplaceListings())
+    const { result } = renderListings()
     await waitFor(() => expect(mockApiFetch).toHaveBeenCalled())
     expect(result.current.hasActiveFilters).toBe(false)
   })
 
   it('does NOT count default sort=newest as active', async () => {
-    const { result } = renderHook(() => useMarketplaceListings())
+    const { result } = renderListings()
     await waitFor(() => expect(mockApiFetch).toHaveBeenCalled())
 
     // Sort defaults to "newest" but hasActiveFilters explicitly excludes sort
@@ -454,7 +472,7 @@ describe('hasActiveFilters', () => {
   })
 
   it('true when only gratisOnly is set', async () => {
-    const { result } = renderHook(() => useMarketplaceListings())
+    const { result } = renderListings()
     await waitFor(() => expect(mockApiFetch).toHaveBeenCalled())
 
     act(() => {
@@ -465,7 +483,7 @@ describe('hasActiveFilters', () => {
   })
 
   it('true when only a spec filter is set', async () => {
-    const { result } = renderHook(() => useMarketplaceListings())
+    const { result } = renderListings()
     await waitFor(() => expect(mockApiFetch).toHaveBeenCalled())
 
     act(() => {
@@ -486,7 +504,7 @@ describe('pagination math', () => {
       pagination: { total: 47, limit: 20, offset: 0 },
     }))
 
-    const { result } = renderHook(() => useMarketplaceListings())
+    const { result } = renderListings()
     await waitFor(() => expect(result.current.pagination.total).toBe(47))
 
     expect(result.current.totalPages).toBe(3) // ceil(47/20)
@@ -497,8 +515,8 @@ describe('pagination math', () => {
       pagination: { total: 0, limit: 20, offset: 0 },
     }))
 
-    const { result } = renderHook(() => useMarketplaceListings())
-    await waitFor(() => expect(result.current.pagination.total).toBe(0))
+    const { result } = renderListings()
+    await waitFor(() => expect(mockApiFetch).toHaveBeenCalled())
 
     expect(result.current.totalPages).toBe(0)
   })
@@ -508,7 +526,7 @@ describe('pagination math', () => {
       pagination: { total: 100, limit: 20, offset: 40 },
     }))
 
-    const { result } = renderHook(() => useMarketplaceListings())
+    const { result } = renderListings()
     await waitFor(() => expect(result.current.pagination.offset).toBe(40))
 
     expect(result.current.currentPage).toBe(3) // floor(40/20) + 1
@@ -519,7 +537,7 @@ describe('pagination math', () => {
       pagination: { total: 50, limit: 20, offset: 0 },
     }))
 
-    const { result } = renderHook(() => useMarketplaceListings())
+    const { result } = renderListings()
     await waitFor(() => expect(result.current.pagination.offset).toBe(0))
 
     expect(result.current.currentPage).toBe(1)
@@ -530,7 +548,7 @@ describe('pagination math', () => {
       pagination: { total: 100, limit: 20, offset: 0 },
     }))
 
-    const { result } = renderHook(() => useMarketplaceListings())
+    const { result } = renderListings()
     await waitFor(() => expect(mockApiFetch).toHaveBeenCalled())
 
     act(() => {
@@ -539,8 +557,7 @@ describe('pagination math', () => {
 
     // After goToPage(5): offset = (5-1) * 20 = 80
     await waitFor(() => {
-      const lastUrl = mockApiFetch.mock.calls[mockApiFetch.mock.calls.length - 1][0] as string
-      expect(lastUrl).toContain('offset=80')
+      expect(lastUrl()).toContain('offset=80')
     })
   })
 
@@ -549,16 +566,22 @@ describe('pagination math', () => {
       pagination: { total: 100, limit: 20, offset: 60 },
     }))
 
-    const { result } = renderHook(() => useMarketplaceListings())
+    const { result } = renderListings()
     await waitFor(() => expect(mockApiFetch).toHaveBeenCalled())
+
+    act(() => {
+      result.current.goToPage(5)
+    })
+    await waitFor(() => {
+      expect(lastUrl()).toContain('offset=80')
+    })
 
     act(() => {
       result.current.goToPage(1)
     })
 
     await waitFor(() => {
-      const lastUrl = mockApiFetch.mock.calls[mockApiFetch.mock.calls.length - 1][0] as string
-      expect(lastUrl).toContain('offset=0')
+      expect(lastUrl()).toContain('offset=0')
     })
   })
 })

--- a/src/hooks/useITHilfeRequests.ts
+++ b/src/hooks/useITHilfeRequests.ts
@@ -1,8 +1,7 @@
 'use client'
 
-import { useState, useEffect, useCallback } from 'react'
-import { apiFetch } from '@/lib/api/client'
-import { logger } from '@/lib/logger'
+import { useState, useCallback } from 'react'
+import { useSwrFetch } from '@/lib/api/swr'
 import type { ITHilfeRequest } from '@/components/it-hilfe/detail/types'
 import { PAGINATION } from '@/config/pagination'
 
@@ -27,54 +26,41 @@ const EMPTY_FILTERS: ITHilfeFilters = {
 }
 
 export function useITHilfeRequests() {
-  const [requests, setRequests] = useState<ITHilfeRequest[]>([])
-  const [loading, setLoading] = useState(true)
-  const [total, setTotal] = useState(0)
-  const [error, setError] = useState<string | null>(null)
-
   const [searchInput, setSearchInput] = useState('')
   const [search, setSearch] = useState('')
   const [sort, setSort] = useState('newest')
   const [offset, setOffset] = useState(0)
   const [filters, setFilters] = useState<ITHilfeFilters>(EMPTY_FILTERS)
 
-  const fetchRequests = useCallback(async () => {
-    setLoading(true)
-    setError(null)
-    try {
-      const params = new URLSearchParams()
-      if (filters.category) params.set('category', filters.category)
-      if (filters.canton) params.set('canton', filters.canton)
-      if (filters.urgency) params.set('urgency', filters.urgency)
-      if (filters.budgetType) params.set('budgetType', filters.budgetType)
-      if (filters.skill) params.set('skill', filters.skill)
-      if (filters.serviceType) params.set('serviceType', filters.serviceType)
-      if (filters.matchMySkills) params.set('matchMySkills', 'true')
-      if (search) params.set('search', search)
-      if (sort) params.set('sort', sort)
-      params.set('limit', String(PAGINATION.PUBLIC))
-      params.set('offset', String(offset))
+  // Filters, search, sort and pagination are encoded in the SWR key — any
+  // change refetches automatically.
+  const params = new URLSearchParams()
+  if (filters.category) params.set('category', filters.category)
+  if (filters.canton) params.set('canton', filters.canton)
+  if (filters.urgency) params.set('urgency', filters.urgency)
+  if (filters.budgetType) params.set('budgetType', filters.budgetType)
+  if (filters.skill) params.set('skill', filters.skill)
+  if (filters.serviceType) params.set('serviceType', filters.serviceType)
+  if (filters.matchMySkills) params.set('matchMySkills', 'true')
+  if (search) params.set('search', search)
+  if (sort) params.set('sort', sort)
+  params.set('limit', String(PAGINATION.PUBLIC))
+  params.set('offset', String(offset))
 
-      const result = await apiFetch<{ requests: ITHilfeRequest[]; total: number }>(
-        `/api/it-hilfe/requests?${params}`,
-      )
+  const { data, error: loadError, isLoading: loading, mutate } = useSwrFetch<{
+    requests: ITHilfeRequest[]
+    total: number
+  }>(`/api/it-hilfe/requests?${params}`)
 
-      if (result.success && result.data) {
-        setRequests(result.data.requests)
-        setTotal(result.data.total)
-      } else {
-        logger.warn('Error fetching IT-Hilfe requests', { error: result.error })
-        setError(result.error ?? 'Fehler beim Laden der Anfragen')
-        setRequests([])
-      }
-    } finally {
-      setLoading(false)
-    }
-  }, [filters, search, sort, offset])
+  const requests = data?.requests ?? []
+  const total = data?.total ?? 0
+  const error = loadError instanceof Error
+    ? loadError.message || 'Fehler beim Laden der Anfragen'
+    : null
 
-  useEffect(() => {
-    fetchRequests()
-  }, [fetchRequests])
+  const retry = useCallback(async () => {
+    await mutate()
+  }, [mutate])
 
   const handleSearch = (e: React.FormEvent) => {
     e.preventDefault()
@@ -127,7 +113,7 @@ export function useITHilfeRequests() {
     totalPages,
     currentPage,
     goToPage,
-    retry: fetchRequests,
+    retry,
     limit: PAGINATION.PUBLIC,
   }
 }

--- a/src/hooks/useMarketplaceListings.ts
+++ b/src/hooks/useMarketplaceListings.ts
@@ -1,8 +1,8 @@
 'use client'
 
-import { useState, useEffect, useCallback } from 'react'
+import { useState, useMemo, useCallback } from 'react'
 import { useDebounce } from '@/hooks/useDebounce'
-import { apiFetch } from '@/lib/api/client'
+import { useSwrFetch } from '@/lib/api/swr'
 import { MARKETPLACE_LIMITS } from '@/config/marketplace'
 
 export interface ListingItem {
@@ -60,14 +60,7 @@ interface InitialMarketplaceFilters {
 }
 
 export function useMarketplaceListings(initialFilters: InitialMarketplaceFilters = {}) {
-  const [listings, setListings] = useState<ListingItem[]>([])
-  const [pagination, setPagination] = useState<Pagination>({
-    total: 0,
-    limit: MARKETPLACE_LIMITS.DEFAULT_PAGE_SIZE,
-    offset: 0,
-  })
-  const [isLoading, setIsLoading] = useState(true)
-  const [error, setError] = useState<string | null>(null)
+  const [offset, setOffset] = useState(0)
 
   // Filters
   const [category, setCategory] = useState(initialFilters.category ?? '')
@@ -75,11 +68,9 @@ export function useMarketplaceListings(initialFilters: InitialMarketplaceFilters
   const [delivery, setDelivery] = useState('')
   const [payment, setPayment] = useState('')
   const [sort, setSort] = useState('newest')
-  const [search, setSearch] = useState(initialFilters.search ?? '')
-  const [searchInput, setSearchInput] = useState(initialFilters.search ?? '')
+  const [searchInput, setSearchInputState] = useState(initialFilters.search ?? '')
   const [priceMin, setPriceMin] = useState('')
   const [priceMax, setPriceMax] = useState('')
-  const [priceError, setPriceError] = useState<string | null>(null)
   // Phase 1 additions
   const [sellerType, setSellerType] = useState(initialFilters.sellerType ?? '')
   const [gratisOnly, setGratisOnly] = useState(false)
@@ -88,94 +79,72 @@ export function useMarketplaceListings(initialFilters: InitialMarketplaceFilters
   const [specStorageMin, setSpecStorageMin] = useState('')
   const [specDisplayMin, setSpecDisplayMin] = useState('')
 
+  // The debounced input IS the applied search term (no second `search` copy).
   const debouncedSearch = useDebounce(searchInput, 300)
 
-  const validatePrices = useCallback(() => {
+  // Derived, not state: recomputes as the user types, clears itself when the
+  // inputs become valid again.
+  const priceError = useMemo((): string | null => {
     const min = Number(priceMin)
     const max = Number(priceMax)
-
-    if (priceMin && min < 0) {
-      setPriceError('Preis kann nicht negativ sein')
-      return false
-    }
-    if (priceMax && max < 0) {
-      setPriceError('Preis kann nicht negativ sein')
-      return false
-    }
-    if (priceMin && priceMax && min > max) {
-      setPriceError('Mindestpreis darf nicht höher als Höchstpreis sein')
-      return false
-    }
-    if (priceMin && min > 50000) {
-      setPriceError('Preis darf maximal CHF 50\'000 sein')
-      return false
-    }
-    if (priceMax && max > 50000) {
-      setPriceError('Preis darf maximal CHF 50\'000 sein')
-      return false
-    }
-
-    setPriceError(null)
-    return true
+    if ((priceMin && min < 0) || (priceMax && max < 0)) return 'Preis kann nicht negativ sein'
+    if (priceMin && priceMax && min > max) return 'Mindestpreis darf nicht höher als Höchstpreis sein'
+    if ((priceMin && min > 50000) || (priceMax && max > 50000)) return 'Preis darf maximal CHF 50\'000 sein'
+    return null
   }, [priceMin, priceMax])
 
+  // All applied filters + pagination live in the SWR key — any change
+  // refetches automatically. Invalid price bounds are simply not applied.
+  const params = new URLSearchParams()
+  if (category) params.set('category', category)
+  if (condition) params.set('condition', condition)
+  if (delivery) params.set('delivery', delivery)
+  if (payment) params.set('payment', payment)
+  if (sort) params.set('sort', sort)
+  if (debouncedSearch) params.set('search', debouncedSearch)
+  if (priceMin && !priceError) params.set('price_min', priceMin)
+  if (priceMax && !priceError) params.set('price_max', priceMax)
+  if (sellerType) params.set('seller_type', sellerType)
+  if (gratisOnly) params.set('gratis_only', 'true')
+  if (verifiedOnly) params.set('verified_only', 'true')
+  if (specRamMin) params.set('spec_ram_min', specRamMin)
+  if (specStorageMin) params.set('spec_storage_min', specStorageMin)
+  if (specDisplayMin) params.set('spec_display_min', specDisplayMin)
+  params.set('limit', String(MARKETPLACE_LIMITS.DEFAULT_PAGE_SIZE))
+  params.set('offset', String(offset))
+
+  const { data, error: loadError, isLoading, mutate } = useSwrFetch<{
+    items: ListingItem[]
+    pagination: Pagination
+  }>(`/api/listings?${params.toString()}`)
+
   const fetchListings = useCallback(async () => {
-    if (!validatePrices()) return
-    setIsLoading(true)
-    setError(null)
+    await mutate()
+  }, [mutate])
 
-    try {
-      const params = new URLSearchParams()
-      if (category) params.set('category', category)
-      if (condition) params.set('condition', condition)
-      if (delivery) params.set('delivery', delivery)
-      if (payment) params.set('payment', payment)
-      if (sort) params.set('sort', sort)
-      if (search) params.set('search', search)
-      if (priceMin) params.set('price_min', priceMin)
-      if (priceMax) params.set('price_max', priceMax)
-      if (sellerType) params.set('seller_type', sellerType)
-      if (gratisOnly) params.set('gratis_only', 'true')
-      if (verifiedOnly) params.set('verified_only', 'true')
-      if (specRamMin) params.set('spec_ram_min', specRamMin)
-      if (specStorageMin) params.set('spec_storage_min', specStorageMin)
-      if (specDisplayMin) params.set('spec_display_min', specDisplayMin)
-      params.set('limit', String(pagination.limit))
-      params.set('offset', String(pagination.offset))
+  const listings = data?.items ?? []
+  const pagination: Pagination = data?.pagination ?? {
+    total: 0,
+    limit: MARKETPLACE_LIMITS.DEFAULT_PAGE_SIZE,
+    offset,
+  }
+  const error = loadError
+    ? loadError instanceof Error && loadError.message
+      ? loadError.message
+      : 'Ein unerwarteter Fehler ist aufgetreten'
+    : null
 
-      const result = await apiFetch<{ items: ListingItem[]; pagination: Pagination }>(`/api/listings?${params.toString()}`)
+  const resetOffset = () => setOffset(0)
 
-      if (result.success && result.data) {
-        setListings(result.data.items)
-        setPagination(result.data.pagination)
-      } else {
-        throw new Error(result.error || 'Fehler beim Laden der Inserate')
-      }
-    } catch (err) {
-      setError(err instanceof Error ? err.message : 'Ein unerwarteter Fehler ist aufgetreten')
-      setListings([])
-    } finally {
-      setIsLoading(false)
-    }
-  }, [category, condition, delivery, payment, sort, search, priceMin, priceMax, sellerType, gratisOnly, verifiedOnly, specRamMin, specStorageMin, specDisplayMin, pagination.limit, pagination.offset, validatePrices])
-
-  useEffect(() => {
-    fetchListings()
-  }, [fetchListings])
-
-  // Auto-search when debounced input changes
-  useEffect(() => {
-    if (debouncedSearch !== search) {
-      setSearch(debouncedSearch)
-      setPagination(prev => ({ ...prev, offset: 0 }))
-    }
-  }, [debouncedSearch, search])
-
-  const resetOffset = () => setPagination(prev => ({ ...prev, offset: 0 }))
+  // Typing starts a new search — back to the first page immediately.
+  const setSearchInput = useCallback((value: string) => {
+    setSearchInputState(value)
+    setOffset(0)
+  }, [])
 
   const handleSearch = (e: React.FormEvent) => {
     e.preventDefault()
-    setSearch(searchInput)
+    // The debounced term applies within 300ms; submit just resets paging.
     resetOffset()
   }
 
@@ -185,8 +154,7 @@ export function useMarketplaceListings(initialFilters: InitialMarketplaceFilters
     setDelivery('')
     setPayment('')
     setSort('newest')
-    setSearch('')
-    setSearchInput('')
+    setSearchInputState('')
     setPriceMin('')
     setPriceMax('')
     setSellerType('')
@@ -198,13 +166,13 @@ export function useMarketplaceListings(initialFilters: InitialMarketplaceFilters
     resetOffset()
   }
 
-  const hasActiveFilters = !!(category || condition || delivery || payment || search || priceMin || priceMax || sellerType || gratisOnly || verifiedOnly || specRamMin || specStorageMin || specDisplayMin)
+  const hasActiveFilters = !!(category || condition || delivery || payment || searchInput || priceMin || priceMax || sellerType || gratisOnly || verifiedOnly || specRamMin || specStorageMin || specDisplayMin)
 
   const totalPages = Math.ceil(pagination.total / pagination.limit)
   const currentPage = Math.floor(pagination.offset / pagination.limit) + 1
 
   const goToPage = (page: number) => {
-    setPagination(prev => ({ ...prev, offset: (page - 1) * prev.limit }))
+    setOffset((page - 1) * MARKETPLACE_LIMITS.DEFAULT_PAGE_SIZE)
   }
 
   return {
@@ -223,7 +191,7 @@ export function useMarketplaceListings(initialFilters: InitialMarketplaceFilters
       searchInput, setSearchInput,
       priceMin, setPriceMin,
       priceMax, setPriceMax,
-      priceError, setPriceError,
+      priceError,
       sellerType, setSellerType,
       gratisOnly, setGratisOnly,
       verifiedOnly, setVerifiedOnly,
@@ -234,7 +202,6 @@ export function useMarketplaceListings(initialFilters: InitialMarketplaceFilters
     // Actions
     handleSearch,
     clearFilters,
-    validatePrices,
     fetchListings,
     resetOffset,
     goToPage,

--- a/src/hooks/useUsersList.ts
+++ b/src/hooks/useUsersList.ts
@@ -1,7 +1,8 @@
 'use client'
 
-import { useState, useEffect, useCallback } from 'react'
-import { apiFetch } from '@/lib/api/client'
+import { useState, useCallback } from 'react'
+import { useSwrFetch } from '@/lib/api/swr'
+import { useDebounce } from '@/hooks/useDebounce'
 import type { UserRow } from '@/components/admin/users'
 
 interface UsersApiData {
@@ -20,65 +21,57 @@ export interface UsersFilterState {
   verified: string
 }
 
-export function useUsersList() {
-  const [users, setUsers] = useState<UserRow[]>([])
-  const [loading, setLoading] = useState(true)
-  const [error, setError] = useState<string | null>(null)
-  const [filters, setFilters] = useState<UsersFilterState>({ search: '', type: 'all', verified: 'all' })
-  const [pagination, setPagination] = useState({ page: 1, limit: 25, total: 0, pages: 0 })
-  const [debouncedSearch, setDebouncedSearch] = useState('')
+const PAGE_LIMIT = 25
 
-  useEffect(() => {
-    const timer = setTimeout(() => setDebouncedSearch(filters.search), 300)
-    return () => clearTimeout(timer)
-  }, [filters.search])
+export function useUsersList() {
+  const [filters, setFilters] = useState<UsersFilterState>({ search: '', type: 'all', verified: 'all' })
+  const [page, setPage] = useState(1)
+  const debouncedSearch = useDebounce(filters.search, 300)
+
+  // Filters (search debounced) + page are encoded in the SWR key — any change
+  // refetches automatically.
+  const params = new URLSearchParams()
+  if (debouncedSearch) params.set('search', debouncedSearch)
+  if (filters.type !== 'all') params.set('type', filters.type)
+  if (filters.verified !== 'all') params.set('verified', filters.verified)
+  params.set('page', page.toString())
+  params.set('limit', PAGE_LIMIT.toString())
+
+  const { data, error: loadError, isLoading: loading, mutate } = useSwrFetch<UsersApiData>(
+    `/api/admin/users?${params.toString()}`,
+  )
+
+  const users = data?.items ?? []
+  const error = loadError instanceof Error
+    ? loadError.message || 'Fehler beim Laden der Benutzer'
+    : null
+  const pagination = {
+    page,
+    limit: PAGE_LIMIT,
+    total: data?.pagination.total ?? 0,
+    pages: data?.pagination.pages ?? 0,
+  }
 
   const fetchUsers = useCallback(async () => {
-    try {
-      setLoading(true)
-      setError(null)
-      const params = new URLSearchParams()
-      if (debouncedSearch) params.set('search', debouncedSearch)
-      if (filters.type !== 'all') params.set('type', filters.type)
-      if (filters.verified !== 'all') params.set('verified', filters.verified)
-      params.set('page', pagination.page.toString())
-      params.set('limit', pagination.limit.toString())
-      const result = await apiFetch<UsersApiData>(`/api/admin/users?${params.toString()}`)
-      if (!result.success || !result.data) {
-        throw new Error(result.error || 'Fehler beim Laden der Benutzer')
-      }
-      setUsers(result.data.items)
-      setPagination(prev => ({
-        ...prev,
-        total: result.data!.pagination.total,
-        pages: result.data!.pagination.pages,
-      }))
-    } catch (err) {
-      setError(err instanceof Error ? err.message : 'Unbekannter Fehler')
-      setUsers([])
-    } finally {
-      setLoading(false)
-    }
-  }, [debouncedSearch, filters.type, filters.verified, pagination.page, pagination.limit])
+    await mutate()
+  }, [mutate])
 
-  useEffect(() => {
-    fetchUsers()
-  }, [fetchUsers])
-
-  useEffect(() => {
-    setPagination(prev => ({ ...prev, page: 1 }))
-  }, [debouncedSearch, filters.type, filters.verified])
-
+  // Filter changes reset to the first page (previously an effect on the
+  // debounced value; doing it in the handler avoids the extra render pass).
   const handleFilterChange = (field: keyof UsersFilterState, value: string) => {
     setFilters(prev => ({ ...prev, [field]: value }))
+    setPage(1)
   }
 
   const handlePageChange = (newPage: number) => {
-    setPagination(prev => ({ ...prev, page: newPage }))
+    setPage(newPage)
     window.scrollTo({ top: 0, behavior: 'smooth' })
   }
 
-  const resetFilters = () => setFilters({ search: '', type: 'all', verified: 'all' })
+  const resetFilters = () => {
+    setFilters({ search: '', type: 'all', verified: 'all' })
+    setPage(1)
+  }
   const hasActiveFilters = filters.search !== '' || filters.type !== 'all' || filters.verified !== 'all'
 
   return {

--- a/src/lib/api/swr.ts
+++ b/src/lib/api/swr.ts
@@ -31,7 +31,8 @@ import { apiFetch } from './client'
 async function apiFetchSwrFetcher<T>(url: string): Promise<T> {
   const result = await apiFetch<T>(url)
   if (!result.success) {
-    throw new Error(result.error || 'Request failed')
+    // German fallback: hooks surface error.message directly in the UI.
+    throw new Error(result.error || 'Anfrage fehlgeschlagen')
   }
   // result.data may legitimately be undefined when the endpoint returns
   // a success envelope without a body — cast through unknown to satisfy


### PR DESCRIPTION
## What

Batch 3 (after #341, #342): the pagination/search-heavy browse hooks.

- `useMarketplaceListings` — filters + debounced search + offset in the SWR key; `priceError` becomes **derived** (self-clearing, invalid bounds simply not sent to the API), so `validatePrices`/`setPriceError` disappear from the hook API and its 3 consumers (sidebar, chips, page client).
- `useUsersList` — debounced search via the shared `useDebounce`; filter changes reset the page in the handler instead of an effect.
- `useITHilfeRequests`, `useIntakePipeline` — same key-encoding pattern; `fetchItems(offset)` keeps its signature (same offset = revalidate, new offset = page change).
- `src/lib/api/swr.ts` fetcher fallback message is now German (`Anfrage fehlgeschlagen`) since hooks surface `error.message` directly.
- The 565-line marketplace hook test suite is rewritten for SWR semantics (fresh cache per render, dedupe off) — 30 tests, all green. Deliberate behavior change locked in: form-submit search applies via the 300ms debounce instead of instantly.

## Verification

- lint: set-state-in-effect 30 → 24, no new warnings
- typecheck clean, 7798 unit tests green (30 rewritten), production build green

🤖 Generated with [Claude Code](https://claude.com/claude-code)