### PR TITLE
refactor(hooks): migrate review/favorites/orders/abos/it-hilfe-detail to SWR (24→18 set-state-in-effect warnings)

### DIFF
--- a/src/app/[locale]/abos/AbosPageClient.tsx
+++ b/src/app/[locale]/abos/AbosPageClient.tsx
@@ -14,9 +14,8 @@ export default function AbosPageClient() {
   const {
     session,
     pools,
-    setPools,
     myPoolIds,
-    setMyPoolIds,
+    addPool,
     loading,
     showCreate,
     setShowCreate,
@@ -125,10 +124,7 @@ export default function AbosPageClient() {
       {showCreate && (
         <CreatePoolModal
           onClose={() => setShowCreate(false)}
-          onCreate={pool => {
-            setPools(prev => [pool, ...prev])
-            setMyPoolIds(prev => new Set([...prev, pool.id]))
-          }}
+          onCreate={addPool}
         />
       )}
     </>

--- a/src/app/[locale]/abos/useAbosPage.ts
+++ b/src/app/[locale]/abos/useAbosPage.ts
@@ -1,61 +1,63 @@
 'use client'
 
-import { useState, useEffect, useCallback } from 'react'
+import { useState } from 'react'
 import { useSession } from 'next-auth/react'
 import { apiFetch } from '@/lib/api/client'
-import { logger } from '@/lib/logger'
+import { useSwrFetch } from '@/lib/api/swr'
 import type { Pool } from './types'
 
 export function useAbosPage() {
   const { data: session } = useSession()
-  const [pools, setPools] = useState<Pool[]>([])
-  const [myPoolIds, setMyPoolIds] = useState<Set<string>>(new Set())
-  const [loading, setLoading] = useState(true)
   const [showCreate, setShowCreate] = useState(false)
   const [activeCategory, setActiveCategory] = useState<string | null>(null)
 
-  const loadPools = useCallback(async () => {
-    try {
-      const result = await apiFetch<Pool[]>('/api/pools')
-      if (result.success && result.data) {
-        setPools(result.data)
-      } else {
-        logger.error('Failed to load pools', { error: result.error })
-      }
-    } finally {
-      setLoading(false)
-    }
-  }, [])
+  const {
+    data: poolsData,
+    isLoading: loading,
+    mutate: mutatePools,
+  } = useSwrFetch<Pool[]>('/api/pools')
+  const pools = poolsData ?? []
 
-  const loadMyMemberships = useCallback(async () => {
-    if (!session?.user) return
-    const result = await apiFetch<{ poolId: string }[]>('/api/pools/my')
-    if (result.success && result.data) {
-      setMyPoolIds(new Set(result.data.map(m => m.poolId)))
-    }
-  }, [session?.user])
+  // Memberships are gated on an authenticated session via the null SWR key.
+  const { data: myData, mutate: mutateMy } = useSwrFetch<{ poolId: string }[]>(
+    session?.user ? '/api/pools/my' : null,
+  )
+  const myPoolIds = new Set((myData ?? []).map(m => m.poolId))
 
-  useEffect(() => {
-    loadPools()
-    loadMyMemberships()
-  }, [loadPools, loadMyMemberships])
+  // Join/leave patch both caches locally — the server already recorded the change.
+  const applyMembership = (id: string, delta: 1 | -1) => {
+    mutateMy(
+      current => delta === 1
+        ? [...(current ?? []), { poolId: id }]
+        : (current ?? []).filter(m => m.poolId !== id),
+      { revalidate: false },
+    )
+    mutatePools(
+      current => current?.map(p =>
+        p.id === id
+          ? { ...p, memberCount: p.memberCount + delta, spotsLeft: p.spotsLeft - delta }
+          : p
+      ),
+      { revalidate: false },
+    )
+  }
 
   const handleJoin = async (id: string) => {
     const result = await apiFetch<unknown>(`/api/pools/${id}/join`, { method: 'POST' })
     if (!result.success) throw new Error(result.error)
-    setMyPoolIds(prev => new Set([...prev, id]))
-    setPools(prev => prev.map(p =>
-      p.id === id ? { ...p, memberCount: p.memberCount + 1, spotsLeft: p.spotsLeft - 1 } : p
-    ))
+    applyMembership(id, 1)
   }
 
   const handleLeave = async (id: string) => {
     const result = await apiFetch<unknown>(`/api/pools/${id}/leave`, { method: 'POST' })
     if (!result.success) throw new Error(result.error)
-    setMyPoolIds(prev => { const s = new Set(prev); s.delete(id); return s })
-    setPools(prev => prev.map(p =>
-      p.id === id ? { ...p, memberCount: p.memberCount - 1, spotsLeft: p.spotsLeft + 1 } : p
-    ))
+    applyMembership(id, -1)
+  }
+
+  // A newly created pool goes straight into both caches (creator auto-joins).
+  const addPool = (pool: Pool) => {
+    mutatePools(current => [pool, ...(current ?? [])], { revalidate: false })
+    mutateMy(current => [...(current ?? []), { poolId: pool.id }], { revalidate: false })
   }
 
   const filtered = activeCategory ? pools.filter(p => p.serviceCategory === activeCategory) : pools
@@ -64,9 +66,8 @@ export function useAbosPage() {
   return {
     session,
     pools,
-    setPools,
     myPoolIds,
-    setMyPoolIds,
+    addPool,
     loading,
     showCreate,
     setShowCreate,

--- a/src/app/dashboard/favorites/page.tsx
+++ b/src/app/dashboard/favorites/page.tsx
@@ -1,6 +1,7 @@
 'use client'
 
 import { useState, useEffect, useCallback } from 'react'
+import { useSwrFetch } from '@/lib/api/swr'
 import { Eyebrow } from '@/components/ui/Eyebrow'
 import { useSession } from 'next-auth/react'
 import { useRouter } from 'next/navigation'
@@ -45,41 +46,40 @@ export default function FavoritesPage() {
   const t = useTranslations('dashboard.favorites')
   const { data: session, status: sessionStatus } = useSession()
   const router = useRouter()
-  const [favorites, setFavorites] = useState<FavoriteListing[]>([])
-  const [isLoading, setIsLoading] = useState(true)
-  const [error, setError] = useState<string | null>(null)
   const [removingId, setRemovingId] = useState<string | null>(null)
 
-  const fetchFavorites = useCallback(async () => {
-    setIsLoading(true)
-    setError(null)
-    const result = await apiFetch<{ items: FavoriteListing[] }>('/api/listings/favorites')
-    if (result.success && result.data) {
-      setFavorites(result.data.items)
-    } else {
-      setError(result.error || t('loadError'))
-    }
-    setIsLoading(false)
-  }, [t])
+  // Fetch is gated on an authenticated session via the null SWR key.
+  const { data, error: loadError, isLoading, mutate } = useSwrFetch<{
+    items: FavoriteListing[]
+  }>(session?.user ? '/api/listings/favorites' : null)
+  const favorites = data?.items ?? []
+  const error = loadError
+    ? loadError instanceof Error && loadError.message
+      ? loadError.message
+      : t('loadError')
+    : null
 
-  // Auth-gated data load. setState happens inside fetchFavorites — this is
-  // the legitimate "subscribe to external system on session change" pattern.
-   
+  const fetchFavorites = useCallback(async () => {
+    await mutate()
+  }, [mutate])
+
   useEffect(() => {
     if (sessionStatus === 'loading') return
     if (!session?.user) {
       router.push('/auth/login')
-      return
     }
-    fetchFavorites()
-  }, [session, sessionStatus, router, fetchFavorites])
+  }, [session, sessionStatus, router])
 
   const removeFavorite = async (listingId: string) => {
     setRemovingId(listingId)
     try {
       const result = await apiFetch<unknown>(`/api/listings/${listingId}/favorite`, { method: 'POST' })
       if (result.success) {
-        setFavorites(prev => prev.filter(f => f.id !== listingId))
+        // The server already removed it — drop it from the cached list locally.
+        mutate(
+          current => current && { items: current.items.filter(f => f.id !== listingId) },
+          { revalidate: false },
+        )
       }
     } finally {
       setRemovingId(null)

--- a/src/app/dashboard/orders/page.tsx
+++ b/src/app/dashboard/orders/page.tsx
@@ -1,6 +1,7 @@
 'use client'
 
-import { useState, useEffect, useCallback } from 'react'
+import { useState, useEffect } from 'react'
+import { useSwrFetch } from '@/lib/api/swr'
 import { Eyebrow } from '@/components/ui/Eyebrow'
 import { useSession } from 'next-auth/react'
 import { useRouter } from 'next/navigation'
@@ -17,7 +18,6 @@ import {
 import { ORDER_STATUS_CONFIG, ORDER_STATUS, MARKETPLACE_LIMITS, formatCHF } from '@/config/marketplace'
 import type { OrderStatus } from '@/config/marketplace'
 import { formatDateShort } from '@/lib/date-formats'
-import { apiFetch } from '@/lib/api/client'
 import { useTranslations } from 'next-intl'
 import Heading from '@/components/ui/Heading'
 import { EmptyState } from '@/components/ui/EmptyState'
@@ -43,7 +43,6 @@ export default function DashboardOrdersPage() {
   const t = useTranslations('dashboard.orders')
   const { data: session, status: sessionStatus } = useSession()
   const router = useRouter()
-  const [orders, setOrders] = useState<OrderItem[]>([])
   const TABS = [
     { key: '', label: t('tabAll') },
     { key: ORDER_STATUS.PENDING_PAYMENT, label: t('tabPending') },
@@ -51,43 +50,29 @@ export default function DashboardOrdersPage() {
     { key: ORDER_STATUS.SHIPPED, label: t('tabShipped') },
     { key: ORDER_STATUS.COMPLETED, label: t('tabCompleted') },
   ]
-  const [total, setTotal] = useState(0)
-  const [isLoading, setIsLoading] = useState(true)
   const [activeTab, setActiveTab] = useState('')
   const [role, setRole] = useState<'buyer' | 'seller'>('buyer')
   const [offset, setOffset] = useState(0)
-  const [limit, setLimit] = useState<number>(PAGE_SIZE)
 
-  const fetchOrders = useCallback(async () => {
-    setIsLoading(true)
-    try {
-      const params = new URLSearchParams({ role, limit: String(PAGE_SIZE), offset: String(offset) })
-      if (activeTab) params.set('status', activeTab)
+  // Role/tab/offset are encoded in the SWR key (fetch gated on an
+  // authenticated session) — any change refetches automatically.
+  const params = new URLSearchParams({ role, limit: String(PAGE_SIZE), offset: String(offset) })
+  if (activeTab) params.set('status', activeTab)
 
-      const result = await apiFetch<{
-        items: OrderItem[]
-        pagination: { total: number; limit: number; offset: number }
-      }>(`/api/marketplace/orders?${params}`)
+  const { data, isLoading } = useSwrFetch<{
+    items: OrderItem[]
+    pagination: { total: number; limit: number; offset: number }
+  }>(sessionStatus === 'authenticated' ? `/api/marketplace/orders?${params}` : null)
 
-      if (result.success && result.data) {
-        setOrders(result.data.items)
-        setTotal(result.data.pagination.total)
-        setLimit(result.data.pagination.limit)
-      }
-    } finally {
-      setIsLoading(false)
-    }
-  }, [activeTab, role, offset])
+  const orders = data?.items ?? []
+  const total = data?.pagination.total ?? 0
+  const limit = data?.pagination.limit ?? PAGE_SIZE
 
   useEffect(() => {
     if (sessionStatus === 'unauthenticated') {
       router.push('/auth/login')
-      return
     }
-    if (sessionStatus === 'authenticated') {
-      fetchOrders()
-    }
-  }, [sessionStatus, fetchOrders, router])
+  }, [sessionStatus, router])
 
   if (sessionStatus === 'loading') {
     return (

--- a/src/components/it-hilfe/detail/useITHilfeDetail.ts
+++ b/src/components/it-hilfe/detail/useITHilfeDetail.ts
@@ -5,6 +5,7 @@ import { useSession } from 'next-auth/react'
 import { useTranslations } from 'next-intl'
 import { toast } from 'sonner'
 import { apiFetch } from '@/lib/api/client'
+import { useSwrFetch } from '@/lib/api/swr'
 import { logger } from '@/lib/logger'
 import { REQUEST_STATUS } from '@/config/it-hilfe'
 import { REVIEW_TARGET_TYPES } from '@/config/database'
@@ -14,10 +15,7 @@ export function useITHilfeDetail(id: string) {
   const t = useTranslations('itHelp.detail')
   const { data: session } = useSession()
 
-  const [request, setRequest] = useState<ITHilfeRequest | null>(null)
-  const [offers, setOffers] = useState<Offer[]>([])
-  const [loading, setLoading] = useState(true)
-  const [error, setError] = useState('')
+  const [actionError, setError] = useState('')
 
   // Offer form state
   const [showOfferForm, setShowOfferForm] = useState(false)
@@ -62,49 +60,36 @@ export function useITHilfeDetail(id: string) {
   const [pendingConfirm, setPendingConfirm] = useState<PendingConfirm | null>(null)
   const cancelPendingConfirm = () => setPendingConfirm(null)
 
+  const {
+    data: requestData,
+    error: requestError,
+    isLoading: loading,
+    mutate: mutateRequest,
+  } = useSwrFetch<{ request: ITHilfeRequest }>(`/api/it-hilfe/requests/${id}`)
+  const request = requestData?.request ?? null
+  // One error surface: action errors win (they're the fresher user feedback).
+  const error =
+    actionError ||
+    (requestError
+      ? requestError instanceof Error && requestError.message
+        ? requestError.message
+        : t('errorLoading')
+      : '')
+
+  // Offers are owner-only — the null SWR key skips the fetch for everyone else.
+  // Load errors stay silent (log-only), matching the previous behavior.
+  const { data: offersData, mutate: mutateOffers } = useSwrFetch<{ offers: Offer[] }>(
+    request?.isOwner ? `/api/it-hilfe/requests/${id}/offers` : null,
+  )
+  const offers = offersData?.offers ?? []
+
   const fetchRequest = useCallback(async () => {
-    try {
-      setLoading(true)
-      const result = await apiFetch<{ request: ITHilfeRequest }>(`/api/it-hilfe/requests/${id}`)
-
-      if (!result.success || !result.data) {
-        setError(result.error || t('errorLoading'))
-        return
-      }
-
-      setRequest(result.data.request)
-    } catch (err) {
-      const message = err instanceof Error ? err.message : t('unexpectedError')
-      setError(message)
-      logger.error('Error fetching peer repair request', { error: err })
-    } finally {
-      setLoading(false)
-    }
-  }, [id, t])
+    await mutateRequest()
+  }, [mutateRequest])
 
   const fetchOffers = useCallback(async () => {
-    if (!request?.isOwner) return
-
-    try {
-      const result = await apiFetch<{ offers: Offer[] }>(`/api/it-hilfe/requests/${id}/offers`)
-
-      if (result.success && result.data) {
-        setOffers(result.data.offers)
-      }
-    } catch (err) {
-      logger.error('Error fetching offers', { error: err })
-    }
-  }, [id, request?.isOwner])
-
-  useEffect(() => {
-    fetchRequest()
-  }, [fetchRequest])
-
-  useEffect(() => {
-    if (request?.isOwner) {
-      fetchOffers()
-    }
-  }, [request?.isOwner, fetchOffers])
+    await mutateOffers()
+  }, [mutateOffers])
 
   // Fetch current user's own offer on this request (non-owners only)
   useEffect(() => {

--- a/src/hooks/__tests__/useReviewManagement.test.tsx
+++ b/src/hooks/__tests__/useReviewManagement.test.tsx
@@ -53,8 +53,20 @@ jest.mock('@/lib/logger', () => ({
   },
 }))
 
+import type { ReactNode } from 'react'
 import { renderHook, act, waitFor } from '@testing-library/react'
+import { SWRConfig } from 'swr'
 import { useReviewManagement, type Review } from '../useReviewManagement'
+
+// Fresh SWR cache per render — no cross-test cache leaks, no dedupe window.
+const wrapper = ({ children }: { children: ReactNode }) => (
+  <SWRConfig value={{ provider: () => new Map(), dedupingInterval: 0, revalidateOnFocus: false }}>
+    {children}
+  </SWRConfig>
+)
+
+const renderReviews = (authStatus: string) =>
+  renderHook(() => useReviewManagement(authStatus), { wrapper })
 
 const baseReview: Review = {
   id: 'rev-1',
@@ -94,13 +106,13 @@ beforeEach(() => {
 
 describe('useReviewManagement — auth gate', () => {
   it('redirects to /auth/login when unauthenticated', () => {
-    renderHook(() => useReviewManagement('unauthenticated'))
+    renderReviews('unauthenticated')
     expect(mockRedirect).toHaveBeenCalledWith('/auth/login')
     expect(mockApiFetch).not.toHaveBeenCalled()
   })
 
   it('does NOT fetch or redirect while auth status is "loading"', () => {
-    renderHook(() => useReviewManagement('loading'))
+    renderReviews('loading')
     expect(mockRedirect).not.toHaveBeenCalled()
     expect(mockApiFetch).not.toHaveBeenCalled()
   })
@@ -108,7 +120,7 @@ describe('useReviewManagement — auth gate', () => {
   it('fetches reviews when authenticated', async () => {
     mockApiFetch.mockResolvedValueOnce({ success: true, data: { reviews: [baseReview] } })
 
-    renderHook(() => useReviewManagement('authenticated'))
+    renderReviews('authenticated')
 
     await waitFor(() => expect(mockApiFetch).toHaveBeenCalledWith('/api/user/reviews'))
   })
@@ -125,7 +137,7 @@ describe('useReviewManagement — fetchUserReviews', () => {
       data: { reviews: [baseReview, { ...baseReview, id: 'rev-2' }] },
     })
 
-    const { result } = renderHook(() => useReviewManagement('authenticated'))
+    const { result } = renderReviews('authenticated')
 
     await waitFor(() => expect(result.current.loading).toBe(false))
     expect(result.current.reviews).toHaveLength(2)
@@ -135,7 +147,7 @@ describe('useReviewManagement — fetchUserReviews', () => {
   it('defaults reviews to [] when data.reviews is missing', async () => {
     mockApiFetch.mockResolvedValueOnce({ success: true, data: {} })
 
-    const { result } = renderHook(() => useReviewManagement('authenticated'))
+    const { result } = renderReviews('authenticated')
 
     await waitFor(() => expect(result.current.loading).toBe(false))
     expect(result.current.reviews).toEqual([])
@@ -144,16 +156,16 @@ describe('useReviewManagement — fetchUserReviews', () => {
   it('sets error from result on failure with fallback message', async () => {
     mockApiFetch.mockResolvedValueOnce({ success: false })
 
-    const { result } = renderHook(() => useReviewManagement('authenticated'))
+    const { result } = renderReviews('authenticated')
 
     await waitFor(() => expect(result.current.loading).toBe(false))
-    expect(result.current.error).toBe('Failed to fetch reviews')
+    expect(result.current.error).toBe('Anfrage fehlgeschlagen')
   })
 
   it('catches thrown errors with the message', async () => {
     mockApiFetch.mockRejectedValueOnce(new Error('Network down'))
 
-    const { result } = renderHook(() => useReviewManagement('authenticated'))
+    const { result } = renderReviews('authenticated')
 
     await waitFor(() => expect(result.current.loading).toBe(false))
     expect(result.current.error).toBe('Network down')
@@ -168,7 +180,7 @@ describe('handleEditReview', () => {
   it('sets editingReview to the review id and populates editForm from review', async () => {
     mockApiFetch.mockResolvedValue({ success: true, data: { reviews: [baseReview] } })
 
-    const { result } = renderHook(() => useReviewManagement('authenticated'))
+    const { result } = renderReviews('authenticated')
     await waitFor(() => expect(result.current.loading).toBe(false))
 
     act(() => {
@@ -195,7 +207,7 @@ describe('handleEditReview', () => {
       ratings: { communication: 3 }, // only one rating present
     }
 
-    const { result } = renderHook(() => useReviewManagement('authenticated'))
+    const { result } = renderReviews('authenticated')
     await waitFor(() => expect(result.current.loading).toBe(false))
 
     act(() => {
@@ -213,7 +225,7 @@ describe('handleEditReview', () => {
     mockApiFetch.mockResolvedValue({ success: true, data: { reviews: [baseReview] } })
     const noTitle: Review = { ...baseReview, title: undefined }
 
-    const { result } = renderHook(() => useReviewManagement('authenticated'))
+    const { result } = renderReviews('authenticated')
     await waitFor(() => expect(result.current.loading).toBe(false))
 
     act(() => {
@@ -232,7 +244,7 @@ describe('cancelEdit', () => {
   it('clears editingReview state', async () => {
     mockApiFetch.mockResolvedValue({ success: true, data: { reviews: [baseReview] } })
 
-    const { result } = renderHook(() => useReviewManagement('authenticated'))
+    const { result } = renderReviews('authenticated')
     await waitFor(() => expect(result.current.loading).toBe(false))
 
     act(() => {
@@ -258,7 +270,7 @@ describe('handleSaveEdit', () => {
       .mockResolvedValueOnce({ success: true })                                    // PUT
       .mockResolvedValueOnce({ success: true, data: { reviews: [baseReview] } })   // re-fetch
 
-    const { result } = renderHook(() => useReviewManagement('authenticated'))
+    const { result } = renderReviews('authenticated')
     await waitFor(() => expect(result.current.loading).toBe(false))
 
     act(() => {
@@ -281,7 +293,7 @@ describe('handleSaveEdit', () => {
   it('no-op when editingReview is null', async () => {
     mockApiFetch.mockResolvedValueOnce({ success: true, data: { reviews: [baseReview] } })
 
-    const { result } = renderHook(() => useReviewManagement('authenticated'))
+    const { result } = renderReviews('authenticated')
     await waitFor(() => expect(result.current.loading).toBe(false))
 
     // No handleEditReview call → editingReview is null
@@ -299,7 +311,7 @@ describe('handleSaveEdit', () => {
       .mockResolvedValueOnce({ success: true, data: { reviews: [baseReview] } })
       .mockResolvedValueOnce({ success: false, error: 'forbidden' })
 
-    const { result } = renderHook(() => useReviewManagement('authenticated'))
+    const { result } = renderReviews('authenticated')
     await waitFor(() => expect(result.current.loading).toBe(false))
 
     act(() => {
@@ -324,7 +336,7 @@ describe('handleDeleteReview', () => {
     mockApiFetch.mockResolvedValueOnce({ success: true, data: { reviews: [baseReview] } })
     const confirmSpy = jest.spyOn(window, 'confirm').mockReturnValue(false)
 
-    const { result } = renderHook(() => useReviewManagement('authenticated'))
+    const { result } = renderReviews('authenticated')
     await waitFor(() => expect(result.current.loading).toBe(false))
 
     await act(async () => {
@@ -344,7 +356,7 @@ describe('handleDeleteReview', () => {
       .mockResolvedValueOnce({ success: true, data: { reviews: [] } })
     const confirmSpy = jest.spyOn(window, 'confirm').mockReturnValue(true)
 
-    const { result } = renderHook(() => useReviewManagement('authenticated'))
+    const { result } = renderReviews('authenticated')
     await waitFor(() => expect(result.current.loading).toBe(false))
 
     await act(async () => {
@@ -365,7 +377,7 @@ describe('handleDeleteReview', () => {
       .mockResolvedValueOnce({ success: false, error: 'cannot delete' })
     const confirmSpy = jest.spyOn(window, 'confirm').mockReturnValue(true)
 
-    const { result } = renderHook(() => useReviewManagement('authenticated'))
+    const { result } = renderReviews('authenticated')
     await waitFor(() => expect(result.current.loading).toBe(false))
 
     await act(async () => {
@@ -388,7 +400,7 @@ describe('handleVote', () => {
       .mockResolvedValueOnce({ success: true, data: { reviews: [baseReview] } })
       .mockResolvedValueOnce({ success: true, data: { action: 'added' } })
 
-    const { result } = renderHook(() => useReviewManagement('authenticated'))
+    const { result } = renderReviews('authenticated')
     await waitFor(() => expect(result.current.loading).toBe(false))
 
     await act(async () => {
@@ -405,7 +417,7 @@ describe('handleVote', () => {
       .mockResolvedValueOnce({ success: true, data: { reviews: [baseReview] } })
       .mockResolvedValueOnce({ success: true, data: { action: 'added' } })
 
-    const { result } = renderHook(() => useReviewManagement('authenticated'))
+    const { result } = renderReviews('authenticated')
     await waitFor(() => expect(result.current.loading).toBe(false))
 
     await act(async () => {
@@ -421,7 +433,7 @@ describe('handleVote', () => {
       .mockResolvedValueOnce({ success: true, data: { reviews: [baseReview] } })
       .mockResolvedValueOnce({ success: true, data: { action: 'removed' } })
 
-    const { result } = renderHook(() => useReviewManagement('authenticated'))
+    const { result } = renderReviews('authenticated')
     await waitFor(() => expect(result.current.loading).toBe(false))
 
     await act(async () => {
@@ -438,7 +450,7 @@ describe('handleVote', () => {
       .mockResolvedValueOnce({ success: true, data: { reviews: [baseReview, reviewB] } })
       .mockResolvedValueOnce({ success: true, data: { action: 'added' } })
 
-    const { result } = renderHook(() => useReviewManagement('authenticated'))
+    const { result } = renderReviews('authenticated')
     await waitFor(() => expect(result.current.loading).toBe(false))
 
     await act(async () => {
@@ -454,7 +466,7 @@ describe('handleVote', () => {
       .mockResolvedValueOnce({ success: true, data: { reviews: [baseReview] } })
       .mockResolvedValueOnce({ success: false, error: 'rate limit' })
 
-    const { result } = renderHook(() => useReviewManagement('authenticated'))
+    const { result } = renderReviews('authenticated')
     await waitFor(() => expect(result.current.loading).toBe(false))
 
     await act(async () => {
@@ -484,30 +496,30 @@ describe('canEditReview', () => {
   })
 
   it('returns true for a review created today', () => {
-    const { result } = renderHook(() => useReviewManagement('loading'))
+    const { result } = renderReviews('loading')
     expect(result.current.canEditReview('2026-01-15T10:00:00Z')).toBe(true)
   })
 
   it('returns true for a review created 29 days ago', () => {
-    const { result } = renderHook(() => useReviewManagement('loading'))
+    const { result } = renderReviews('loading')
     // 29 days before 2026-01-15 = 2025-12-17
     expect(result.current.canEditReview('2025-12-17T12:00:00Z')).toBe(true)
   })
 
   it('returns true at exactly 30 days (boundary inclusive)', () => {
-    const { result } = renderHook(() => useReviewManagement('loading'))
+    const { result } = renderReviews('loading')
     // 30 days before 2026-01-15 = 2025-12-16
     expect(result.current.canEditReview('2025-12-16T12:00:00Z')).toBe(true)
   })
 
   it('returns false for a review created 31 days ago', () => {
-    const { result } = renderHook(() => useReviewManagement('loading'))
+    const { result } = renderReviews('loading')
     // 31 days before = 2025-12-15
     expect(result.current.canEditReview('2025-12-15T11:00:00Z')).toBe(false)
   })
 
   it('returns false for an ancient review', () => {
-    const { result } = renderHook(() => useReviewManagement('loading'))
+    const { result } = renderReviews('loading')
     expect(result.current.canEditReview('2024-01-01T00:00:00Z')).toBe(false)
   })
 })
@@ -522,7 +534,7 @@ describe('getUserVoteForReview', () => {
       .mockResolvedValueOnce({ success: true, data: { reviews: [baseReview] } })
       .mockResolvedValueOnce({ success: true, data: { action: 'added' } })
 
-    const { result } = renderHook(() => useReviewManagement('authenticated'))
+    const { result } = renderReviews('authenticated')
     await waitFor(() => expect(result.current.loading).toBe(false))
 
     await act(async () => {
@@ -539,7 +551,7 @@ describe('getUserVoteForReview', () => {
       .mockResolvedValueOnce({ success: true, data: { action: 'added' } })
       .mockResolvedValueOnce({ success: true, data: { action: 'removed' } })
 
-    const { result } = renderHook(() => useReviewManagement('authenticated'))
+    const { result } = renderReviews('authenticated')
     await waitFor(() => expect(result.current.loading).toBe(false))
 
     await act(async () => {

--- a/src/hooks/useReviewManagement.ts
+++ b/src/hooks/useReviewManagement.ts
@@ -3,6 +3,7 @@
 import { useState, useEffect } from 'react'
 import { toast } from 'sonner'
 import { apiFetch } from '@/lib/api/client'
+import { useSwrFetch } from '@/lib/api/swr'
 import { logger } from '@/lib/logger'
 import { redirect } from 'next/navigation'
 
@@ -62,34 +63,28 @@ const DEFAULT_EDIT_FORM: EditForm = {
 }
 
 export function useReviewManagement(authStatus: string) {
-  const [reviews, setReviews] = useState<Review[]>([])
   const [userVotes, setUserVotes] = useState<UserVote[]>([])
-  const [loading, setLoading] = useState(true)
-  const [error, setError] = useState<string | null>(null)
   const [editingReview, setEditingReview] = useState<string | null>(null)
   const [editForm, setEditForm] = useState<EditForm>(DEFAULT_EDIT_FORM)
 
+  // Fetch is gated on an authenticated session via the null SWR key.
+  const { data, error: loadError, isLoading: loading, mutate } = useSwrFetch<{
+    reviews: Review[]
+  }>(authStatus === 'authenticated' ? '/api/user/reviews' : null)
+  const reviews = data?.reviews ?? []
+  const error = loadError
+    ? loadError instanceof Error && loadError.message
+      ? loadError.message
+      : 'Unknown error'
+    : null
+
   const fetchUserReviews = async () => {
-    try {
-      setLoading(true)
-      const result = await apiFetch<{ reviews: Review[] }>('/api/user/reviews')
-      if (result.success) {
-        setReviews(result.data?.reviews || [])
-      } else {
-        setError(result.error || 'Failed to fetch reviews')
-      }
-    } catch (err) {
-      setError(err instanceof Error ? err.message : 'Unknown error')
-    } finally {
-      setLoading(false)
-    }
+    await mutate()
   }
 
   useEffect(() => {
     if (authStatus === 'unauthenticated') {
       redirect('/auth/login')
-    } else if (authStatus === 'authenticated') {
-      fetchUserReviews()
     }
   }, [authStatus])
 
@@ -164,19 +159,25 @@ export function useReviewManagement(authStatus: string) {
 
       const action = result.data!.action
 
-      setReviews(reviews.map(review =>
-        review.id === reviewId
-          ? {
-              ...review,
-              helpfulVotes: voteType === 'helpful'
-                ? (action === 'added' ? review.helpfulVotes + 1 : review.helpfulVotes - 1)
-                : review.helpfulVotes,
-              totalVotes: action === 'added'
-                ? review.totalVotes + 1
-                : review.totalVotes - 1
-            }
-          : review
-      ))
+      // Patch the cached payload locally — the server already recorded the vote.
+      mutate(
+        current => current && {
+          reviews: current.reviews.map(review =>
+            review.id === reviewId
+              ? {
+                  ...review,
+                  helpfulVotes: voteType === 'helpful'
+                    ? (action === 'added' ? review.helpfulVotes + 1 : review.helpfulVotes - 1)
+                    : review.helpfulVotes,
+                  totalVotes: action === 'added'
+                    ? review.totalVotes + 1
+                    : review.totalVotes - 1
+                }
+              : review
+          ),
+        },
+        { revalidate: false },
+      )
 
       if (action === 'added') {
         setUserVotes([...userVotes.filter(v => v.reviewId !== reviewId), { reviewId, voteType }])


### PR DESCRIPTION
## What

Batch 4 (after #341–#343): the optimistic-update bucket.

- `useReviewManagement` — vote counts patch the SWR cache locally (`revalidate: false`); auth-gated via null key.
- `dashboard/favorites` — optimistic remove becomes a cache patch.
- `dashboard/orders` — role/tab/offset in the SWR key; server-echoed limit derived from data.
- `useAbosPage` — pools + memberships as two SWR fetches; join/leave/create patch both caches; exposes `addPool()` instead of raw `setPools`/`setMyPoolIds` (consumer updated).
- `useITHilfeDetail` — request + owner-gated offers on SWR keys; the 8 action-refetch call sites keep `fetchRequest`/`fetchOffers` as `mutate` wrappers.
- Review-management test suite gets the fresh-SWR-cache-per-render wrapper (29 green).

## Verification

- lint: set-state-in-effect 24 → 18, no new warnings
- typecheck clean, 7798 unit tests green, production build green

Remaining 18 warnings are bucket C (localStorage/session prefill, derived-state sync) — final batch assesses each individually.

🤖 Generated with [Claude Code](https://claude.com/claude-code)