### PR TITLE
ci(lint): lock set-state-in-effect at zero (warn → error)

### DIFF
--- a/eslint.config.mjs
+++ b/eslint.config.mjs
@@ -124,7 +124,11 @@ const eslintConfig = [
       "@next/next/no-img-element": "off",
       "react/no-unescaped-entities": "off",
       "react-hooks/immutability": "off",
-      "react-hooks/set-state-in-effect": "warn",
+      // Driven to zero 2026-08 (PRs #341–#345: fetch hooks → useSwrFetch,
+      // derivable state derived). Error keeps the class closed; a genuinely
+      // legitimate external-store sync (localStorage hydration, one-shot form
+      // prefill) gets a targeted eslint-disable line stating why.
+      "react-hooks/set-state-in-effect": "error",
     },
   },
   {


### PR DESCRIPTION
The `react-hooks/set-state-in-effect` class was driven 46 → 0 in #341–#345. This flips the rule to `error` so the class stays closed — a new offender fails `npm run lint` (and therefore `verify`/CI) instead of adding a warning nobody reads.

**Gate proven by mutation**: a planted `useEffect(() => setX(1), [])` component makes lint exit 1; removing it returns to green (0 errors, 4 pre-existing unrelated warnings).

Legitimate external-store syncs (localStorage hydration, one-shot form prefill, close-on-navigate) carry targeted per-line disables stating why — the same path any future legitimate case takes.

🤖 Generated with [Claude Code](https://claude.com/claude-code)